### PR TITLE
rviz visual tools to depends

### DIFF
--- a/dependency.repos
+++ b/dependency.repos
@@ -15,3 +15,7 @@ repositories:
     type: git
     url: https://github.com/ros-visualization/interactive_markers.git
     version: eloquent
+  common_interfaces:
+    type: git
+    url: https://github.com/ros2/common_interfaces.git
+    version: eloquent


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue
None
## Description
add rviz visual tools(eloquent-cleanup branch) to the depends
## How to review this PR.

```
ros2 launch rviz_visual_tools demo_combined.launch.py
```

## Others
