### PR TITLE
remove autoware_auto_msgs fron depends

### DIFF
--- a/dependency.repos
+++ b/dependency.repos
@@ -3,7 +3,3 @@ repositories:
     type: git
     url: https://github.com/OUXT-Polaris/quaternion_operation.git
     version: ros2
-  autoware_auto_msgs:
-    type: git
-    url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
-    version: master


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description
remove autoware_auto_msgs from repos and install via apt
## How to review this PR.

## Others
