### PR TITLE
explicit show depends in cmakelist.txt

### DIFF
--- a/external/awapi_awauto_adapter/CMakeLists.txt
+++ b/external/awapi_awauto_adapter/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_auto REQUIRED)
+find_package(autoware_api_msgs REQUIRED)
 
 ament_auto_find_build_dependencies()
 


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
explicitly show the depends of autoware_api_msgs in CMakeLists.txt

## How to review this PR.

## Others
