### PR TITLE
enable use raw ros timestamp

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/scenario_object.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/scenario_object.hpp
@@ -93,7 +93,7 @@ struct ScenarioObject
         assignController(name, object_controller);
         if (object_controller.isEgo()) {
           attachLidarSensor(traffic_simulator::helper::constructLidarConfiguration(
-            traffic_simulator::helper::LidarType::VLP32, name
+            traffic_simulator::helper::LidarType::VLP16, name
 #ifdef AUTOWARE_ARCHITECTURE_PROPOSAL
             ,
             "/sensing/lidar/no_ground/pointcloud"

--- a/simulation/traffic_simulator/include/traffic_simulator/simulation_clock/simulation_clock.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/simulation_clock/simulation_clock.hpp
@@ -23,17 +23,18 @@ namespace traffic_simulator
 class SimulationClock : rclcpp::Clock
 {
 public:
-  SimulationClock();
+  SimulationClock(rcl_clock_type_t clock_type = RCL_ROS_TIME, bool use_raw_clock = true);
   void initialize(double initial_simulation_time, double step_time);
   void update();
   double getCurrentSimulationTime() const { return current_simulation_time_; }
   double getStepTime() const { return step_time_; }
-  rclcpp::Time getCurrentRosTime() const;
-  rosgraph_msgs::msg::Clock getCurrentRosTimeAsMsg() const;
+  const rclcpp::Time getCurrentRosTime();
+  const rosgraph_msgs::msg::Clock getCurrentRosTimeAsMsg();
+  const bool use_raw_clock;
 
 private:
   rclcpp::Duration step_time_duration_;
-  rclcpp::Time system_time_on_initialize_;
+  rclcpp::Time time_on_initialize_;
   double current_simulation_time_;
   double initial_simulation_time_;
   double step_time_;


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue
adding use_raw_clock option (default = True) to the SimulationClock class.
## Description

## How to review this PR.
Please check passing all test cases.
## Others
