### PR TITLE
Fix/throw errors when set target speed after ego starts

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Difference between the latest release and master
 - Add support for RelativeTargetSpeed, the syntax of OpenSCENARIO
 - Add feature to publish context information during scenario execution to topic `/simulation/context` as a JSON string
+- Enable throw semantic error when you call setEntityStatus or setTargetSpeed function which targets to the ego vehicle after starting scenario.
 
 ## Ver 0.1.0
 - Synchronize ROS time between traffic_simulator and sensor_simulator.

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -103,7 +103,7 @@ public:
 
   virtual auto setStatus(const openscenario_msgs::msg::EntityStatus & status) -> bool;
 
-  virtual void setTargetSpeed(const double target_speed, const bool continuous) = 0;
+  virtual void setTargetSpeed(double target_speed, bool continuous) = 0;
 
   virtual void setTrafficLightManager(
     const std::shared_ptr<traffic_simulator::TrafficLightManager> & ptr)

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
@@ -210,9 +210,10 @@ public:
   FORWARD_TO_ENTITY(requestLaneChange, );
   FORWARD_TO_ENTITY(requestWalkStraight, );
   FORWARD_TO_ENTITY(setDriverModel, );
-  FORWARD_TO_ENTITY(setTargetSpeed, );
 
 #undef FORWARD_TO_SPECIFIED_ENTITY
+
+  void setTargetSpeed(const std::string & name, double target_speed, bool continuous);
 
   openscenario_msgs::msg::EntityStatus updateNpcLogic(
     const std::string & name,

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -69,6 +69,7 @@ auto toString(const VehicleModelType datum) -> std::string
   }
 
 #undef BOILERPLATE
+  THROW_SEMANTIC_ERROR("Invalid vehicle model type.");
 }
 
 auto getVehicleModelType()

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -530,10 +530,21 @@ void EntityManager::requestLaneChange(const std::string & name, const Direction 
   }
 }
 
+void EntityManager::setTargetSpeed(const std::string & name, double target_speed, bool continuous)
+{
+  if(isEgo(name) && getCurrentTime() > 0) {
+    THROW_SEMANTIC_ERROR("You cannot set target speed to the ego vehicle after starting scenario.");
+  }
+  return entities_.at(name)->setTargetSpeed(target_speed, continuous);
+}
+
 bool EntityManager::setEntityStatus(
   const std::string & name, openscenario_msgs::msg::EntityStatus status)
 {
   status.name = name;  // XXX UGLY CODE
+  if(isEgo(name) && getCurrentTime() > 0) {
+    THROW_SEMANTIC_ERROR("You cannot set entity status to the ego vehicle after starting scenario.");
+  }
   return entities_.at(name)->setStatus(status);
 }
 

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -532,7 +532,7 @@ void EntityManager::requestLaneChange(const std::string & name, const Direction 
 
 void EntityManager::setTargetSpeed(const std::string & name, double target_speed, bool continuous)
 {
-  if(isEgo(name) && getCurrentTime() > 0) {
+  if (isEgo(name) && getCurrentTime() > 0) {
     THROW_SEMANTIC_ERROR("You cannot set target speed to the ego vehicle after starting scenario.");
   }
   return entities_.at(name)->setTargetSpeed(target_speed, continuous);
@@ -542,8 +542,9 @@ bool EntityManager::setEntityStatus(
   const std::string & name, openscenario_msgs::msg::EntityStatus status)
 {
   status.name = name;  // XXX UGLY CODE
-  if(isEgo(name) && getCurrentTime() > 0) {
-    THROW_SEMANTIC_ERROR("You cannot set entity status to the ego vehicle after starting scenario.");
+  if (isEgo(name) && getCurrentTime() > 0) {
+    THROW_SEMANTIC_ERROR(
+      "You cannot set entity status to the ego vehicle after starting scenario.");
   }
   return entities_.at(name)->setStatus(status);
 }


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description
throw semantic errors when set target speed / entity status after ego starts

## How to review this PR.
Please check passing all tests

## Others
