### PR TITLE
Fix flags of SpellCheck action and add SpellCheckAll for manual checking

### DIFF
--- a/.github/workflows/SpellCheckAll.yaml
+++ b/.github/workflows/SpellCheckAll.yaml
@@ -1,9 +1,7 @@
-name: SpellCheck
+name: SpellCheckAll
 
 on:
-  pull_request:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   spellcheck:
@@ -21,5 +19,8 @@ jobs:
       - uses: streetsidesoftware/cspell-action@v1.2.5
         with:
           config: ".github/workflows/.cspell.json"
-          incremental_files_only: true
+          incremental_files_only: false
           strict: false
+          files: |
+            **
+            .*/**


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [X] Bugfix

## Link to the issue

## Description

SpellCheck action seems to skip all files, that is, it checks nothing. This PR fixes the flags of the action and adds SpellCheckAll action to check all files, which can be triggered by hand.

## How to review this PR.

Please check whether the action works well or not.

## Others
