### PR TITLE
Remove dependency for only Autoware.Auto (to fix rosdep error)

### DIFF
--- a/test_runner/scenario_test_runner/package.xml
+++ b/test_runner/scenario_test_runner/package.xml
@@ -18,7 +18,7 @@
   <exec_depend>openscenario_utility</exec_depend>
 
   <!-- AutowareAuto launch -->
-  <exec_depend>scenario_test_runner_launch</exec_depend>
+  <!-- <exec_depend>scenario_test_runner_launch</exec_depend> -->
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

## How to review this PR.

## Others
