### PR TITLE
fix route planner logic

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,6 +4,7 @@
 - Enable spawn MiscObjectEntity by using API class.
 - Integrate with AutowareAuto (Autoware type is chosen at build time using `AUTOWARE_ARCHITECTURE_PROPOSAL` or `AUTOWARE_AUTO` flag)
 - Update WorldPosition to be convertible with 'openscenario_msgs::msg::LaneletPose'.
+- Fix problems when the whole route is empty in route planner class.
 
 ## Ver 0.2.0
 - Enhance `/simulation/context` topic infomation. (adding TriggeringEntitiesRule, TriggeringEntities, CollisionCondition, TimeHeadwayCondition, AccelerationCondition, StandStillCondition, SpeedCondition, ReachPositionCondition, DistanceCondition, RelativeDistanceCondition, ParameterCondition, StoryboardElementStateCondition)

--- a/simulation/traffic_simulator/src/behavior/route_planner.cpp
+++ b/simulation/traffic_simulator/src/behavior/route_planner.cpp
@@ -69,6 +69,10 @@ std::vector<std::int64_t> RoutePlanner::getRouteLanelets(
   if (!whole_route_) {
     return hdmap_utils_ptr_->getFollowingLanelets(entity_lanelet_pose.lanelet_id, horizon, true);
   }
+  if(whole_route_->size() == 0) {
+    whole_route_ = boost::none;
+    return hdmap_utils_ptr_->getFollowingLanelets(entity_lanelet_pose.lanelet_id, horizon, true);
+  }
   return hdmap_utils_ptr_->getFollowingLanelets(
     entity_lanelet_pose.lanelet_id, whole_route_.get(), horizon, true);
 }

--- a/simulation/traffic_simulator/src/behavior/route_planner.cpp
+++ b/simulation/traffic_simulator/src/behavior/route_planner.cpp
@@ -69,7 +69,7 @@ std::vector<std::int64_t> RoutePlanner::getRouteLanelets(
   if (!whole_route_) {
     return hdmap_utils_ptr_->getFollowingLanelets(entity_lanelet_pose.lanelet_id, horizon, true);
   }
-  if(whole_route_->size() == 0) {
+  if (whole_route_->size() == 0) {
     whole_route_ = boost::none;
     return hdmap_utils_ptr_->getFollowingLanelets(entity_lanelet_pose.lanelet_id, horizon, true);
   }


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
When the whole route is empty, route planner pass the empty route to the hdmap utils class.
So, I fixed this problem.
## How to review this PR.
Please check passing all CI test.
## Others
