### PR TITLE
Fix/add include crosswalk option

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Difference between the latest release and master
 - Fix problems in coordinate conversion from world to lane in pedestrian entity.
+- Adding include_crosswalk option to the HdMapUtils::getClosetLaneletId() and HdMapUtils::toLaneletPose()
 
 ## Version 0.4.1
 - [Release Page](https://github.com/tier4/scenario_simulator_v2/releases/0.4.1) on Github :fa-github:

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Difference between the latest release and master
+- Fix problems in coordinate conversion from world to lane in pedestrian entity.
 
 ## Version 0.4.1
 - [Release Page](https://github.com/tier4/scenario_simulator_v2/releases/0.4.1) on Github :fa-github:

--- a/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
@@ -62,7 +62,8 @@ public:
     const visualization_msgs::msg::MarkerArray & a2) const;
   std::vector<geometry_msgs::msg::Point> toMapPoints(
     std::int64_t lanelet_id, std::vector<double> s);
-  boost::optional<openscenario_msgs::msg::LaneletPose> toLaneletPose(geometry_msgs::msg::Pose pose);
+  boost::optional<openscenario_msgs::msg::LaneletPose> toLaneletPose(
+    geometry_msgs::msg::Pose pose, bool include_crosswalk = false);
 
   geometry_msgs::msg::PoseStamped toMapPose(
     std::int64_t lanelet_id, double s, double offset, geometry_msgs::msg::Quaternion quat);
@@ -120,7 +121,7 @@ public:
   const std::unordered_map<std::int64_t, std::vector<std::int64_t>> getRightOfWayLaneletIds(
     std::vector<std::int64_t> lanelet_ids) const;
   boost::optional<std::int64_t> getClosetLaneletId(
-    geometry_msgs::msg::Pose pose, double distance_thresh = 30.0);
+    geometry_msgs::msg::Pose pose, double distance_thresh = 30.0, bool include_crosswalk = false);
   const std::vector<geometry_msgs::msg::Point> getLaneletPolygon(std::int64_t lanelet_id);
   const std::vector<geometry_msgs::msg::Point> getStopLinePolygon(std::int64_t lanelet_id);
   const std::vector<std::int64_t> getTrafficLightIds() const;

--- a/simulation/traffic_simulator/src/behavior/pedestrian/follow_lane_action.cpp
+++ b/simulation/traffic_simulator/src/behavior/pedestrian/follow_lane_action.cpp
@@ -42,6 +42,8 @@ BT::NodeStatus FollowLaneAction::tick()
     setOutput("updated_status", stopAtEndOfRoad());
     return BT::NodeStatus::RUNNING;
   }
+  RCLCPP_ERROR_STREAM(rclcpp::get_logger("test"), __FILE__ << "," << __LINE__);
+  RCLCPP_ERROR_STREAM(rclcpp::get_logger("test"), entity_status.lanelet_pose.lanelet_id);
   auto following_lanelets =
     hdmap_utils->getFollowingLanelets(entity_status.lanelet_pose.lanelet_id);
   if (!target_speed) {

--- a/simulation/traffic_simulator/src/behavior/pedestrian/follow_lane_action.cpp
+++ b/simulation/traffic_simulator/src/behavior/pedestrian/follow_lane_action.cpp
@@ -47,46 +47,7 @@ BT::NodeStatus FollowLaneAction::tick()
   if (!target_speed) {
     target_speed = hdmap_utils->getSpeedLimit(following_lanelets);
   }
-  geometry_msgs::msg::Accel accel_new;
-  accel_new = entity_status.action_status.accel;
-
-  double target_accel =
-    (target_speed.get() - entity_status.action_status.twist.linear.x) / step_time;
-  if (entity_status.action_status.twist.linear.x > target_speed.get()) {
-    target_accel = boost::algorithm::clamp(target_accel, -5, 0);
-    /*　target_accel = boost::algorithm::clamp(target_accel,
-      -1*vehicle_param_ptr->performance.max_deceleration, vehicle_param_ptr->performance.max_acceleration);
-      */
-  } else {
-    target_accel = boost::algorithm::clamp(target_accel, 0, 3);
-    /* target_accel = boost::algorithm::clamp(target_accel,
-      -1*vehicle_param_ptr->performance.max_deceleration, vehicle_param_ptr->performance.max_acceleration);*/
-  }
-  accel_new.linear.x = target_accel;
-  geometry_msgs::msg::Twist twist_new;
-  twist_new.linear.x = boost::algorithm::clamp(
-    entity_status.action_status.twist.linear.x + accel_new.linear.x * step_time, 0, 5.0);
-  twist_new.linear.y = 0.0;
-  twist_new.linear.z = 0.0;
-  twist_new.angular.x = 0.0;
-  twist_new.angular.y = 0.0;
-  twist_new.angular.z = 0.0;
-
-  double new_s =
-    entity_status.lanelet_pose.s +
-    (twist_new.linear.x + entity_status.action_status.twist.linear.x) / 2.0 * step_time;
-  geometry_msgs::msg::Vector3 rpy = entity_status.lanelet_pose.rpy;
-
-  openscenario_msgs::msg::EntityStatus entity_status_updated;
-  entity_status_updated.time = current_time + step_time;
-  entity_status_updated.lanelet_pose.lanelet_id = entity_status.lanelet_pose.lanelet_id;
-  entity_status_updated.lanelet_pose.s = new_s;
-  entity_status_updated.lanelet_pose.offset = entity_status.lanelet_pose.offset;
-  entity_status_updated.lanelet_pose.rpy = rpy;
-  entity_status_updated.action_status.twist = twist_new;
-  entity_status_updated.action_status.accel = accel_new;
-  entity_status_updated.pose = hdmap_utils->toMapPose(entity_status.lanelet_pose).pose;
-  setOutput("updated_status", entity_status_updated);
+  setOutput("updated_status", calculateEntityStatusUpdated(target_speed.get()));
   return BT::NodeStatus::RUNNING;
 }
 }  // namespace pedestrian

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -235,7 +235,11 @@ auto EntityManager::getLaneletPose(const std::string & name)
   if (status->lanelet_pose_valid) {
     return status->lanelet_pose;
   }
-  return toLaneletPose(status->pose);
+  bool include_crosswalk = true;
+  if (getEntityType(name).type == openscenario_msgs::msg::EntityType::VEHICLE) {
+    include_crosswalk = false;
+  }
+  return toLaneletPose(status->pose, include_crosswalk);
 }
 
 auto EntityManager::getLongitudinalDistance(


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

Fix problems in coordinate conversion from world to lane in pedestrian entity.
Adding include_crosswalk option to the HdMapUtils::getClosetLaneletId() and HdMapUtils::toLaneletPose()

## How to review this PR.

## Others
