### PR TITLE
suppress warnings for lanelet2_extension_psim

### DIFF
--- a/external/lanelet2_extension_psim/CMakeLists.txt
+++ b/external/lanelet2_extension_psim/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/external/lanelet2_extension_psim/lib/autoware_traffic_light.cpp
+++ b/external/lanelet2_extension_psim/lib/autoware_traffic_light.cpp
@@ -78,9 +78,8 @@ LineStringsOrPolygons3d getLsOrPoly(const RuleParameterMap & paramsMap, RoleName
   return result;
 }
 
-
-[[maybe_unused]]
-ConstLineStringsOrPolygons3d getConstLsOrPoly(const RuleParameterMap & params, RoleName role)
+[[maybe_unused]] ConstLineStringsOrPolygons3d getConstLsOrPoly(
+  const RuleParameterMap & params, RoleName role)
 {
   auto cast_func = [](auto & lsOrPoly) {
     return static_cast<ConstLineStringOrPolygon3d>(lsOrPoly);
@@ -88,8 +87,7 @@ ConstLineStringsOrPolygons3d getConstLsOrPoly(const RuleParameterMap & params, R
   return utils::transform(getLsOrPoly(params, role), cast_func);
 }
 
-[[maybe_unused]]
-RegulatoryElementDataPtr constructAutowareTrafficLightData(
+[[maybe_unused]] RegulatoryElementDataPtr constructAutowareTrafficLightData(
   Id id, const AttributeMap & attributes, const LineStringsOrPolygons3d & trafficLights,
   const Optional<LineString3d> & stopLine, const LineStrings3d & lightBulbs)
 {

--- a/external/lanelet2_extension_psim/lib/autoware_traffic_light.cpp
+++ b/external/lanelet2_extension_psim/lib/autoware_traffic_light.cpp
@@ -78,6 +78,8 @@ LineStringsOrPolygons3d getLsOrPoly(const RuleParameterMap & paramsMap, RoleName
   return result;
 }
 
+
+[[maybe_unused]]
 ConstLineStringsOrPolygons3d getConstLsOrPoly(const RuleParameterMap & params, RoleName role)
 {
   auto cast_func = [](auto & lsOrPoly) {
@@ -86,6 +88,7 @@ ConstLineStringsOrPolygons3d getConstLsOrPoly(const RuleParameterMap & params, R
   return utils::transform(getLsOrPoly(params, role), cast_func);
 }
 
+[[maybe_unused]]
 RegulatoryElementDataPtr constructAutowareTrafficLightData(
   Id id, const AttributeMap & attributes, const LineStringsOrPolygons3d & trafficLights,
   const Optional<LineString3d> & stopLine, const LineStrings3d & lightBulbs)

--- a/external/lanelet2_extension_psim/lib/utilities.cpp
+++ b/external/lanelet2_extension_psim/lib/utilities.cpp
@@ -36,8 +36,7 @@ namespace utils
 {
 namespace
 {
-[[maybe_unused]]
-bool exists(const std::vector<int> & array, const int element)
+[[maybe_unused]] bool exists(const std::vector<int> & array, const int element)
 {
   return std::find(array.begin(), array.end(), element) != array.end();
 }
@@ -52,8 +51,7 @@ bool exists(const std::vector<int> & array, const int element)
  * @param  contacting_lanelet_ids [array of lanelet ids that is contacting with
  * search_point]
  */
-[[maybe_unused]]
-void getContactingLanelets(
+[[maybe_unused]] void getContactingLanelets(
   const lanelet::LaneletMapPtr lanelet_map,
   const lanelet::traffic_rules::TrafficRulesPtr traffic_rules,
   const lanelet::BasicPoint2d search_point, std::vector<int> * contacting_lanelet_ids)

--- a/external/lanelet2_extension_psim/lib/utilities.cpp
+++ b/external/lanelet2_extension_psim/lib/utilities.cpp
@@ -36,6 +36,7 @@ namespace utils
 {
 namespace
 {
+[[maybe_unused]]
 bool exists(const std::vector<int> & array, const int element)
 {
   return std::find(array.begin(), array.end(), element) != array.end();
@@ -51,6 +52,7 @@ bool exists(const std::vector<int> & array, const int element)
  * @param  contacting_lanelet_ids [array of lanelet ids that is contacting with
  * search_point]
  */
+[[maybe_unused]]
 void getContactingLanelets(
   const lanelet::LaneletMapPtr lanelet_map,
   const lanelet::traffic_rules::TrafficRulesPtr traffic_rules,

--- a/external/lanelet2_extension_psim/lib/visualization.cpp
+++ b/external/lanelet2_extension_psim/lib/visualization.cpp
@@ -62,6 +62,7 @@ void adjacentPoints(
   }
 }
 
+[[maybe_unused]]
 double hypot(const geometry_msgs::msg::Point32 & p0, const geometry_msgs::msg::Point32 & p1)
 {
   return sqrt(pow((p1.x - p0.x), 2.0) + pow((p1.y - p0.y), 2.0));

--- a/external/lanelet2_extension_psim/lib/visualization.cpp
+++ b/external/lanelet2_extension_psim/lib/visualization.cpp
@@ -62,8 +62,8 @@ void adjacentPoints(
   }
 }
 
-[[maybe_unused]]
-double hypot(const geometry_msgs::msg::Point32 & p0, const geometry_msgs::msg::Point32 & p1)
+[[maybe_unused]] double hypot(
+  const geometry_msgs::msg::Point32 & p0, const geometry_msgs::msg::Point32 & p1)
 {
   return sqrt(pow((p1.x - p0.x), 2.0) + pow((p1.y - p0.y), 2.0));
 }

--- a/external/lanelet2_extension_psim/lib/visualization.cpp
+++ b/external/lanelet2_extension_psim/lib/visualization.cpp
@@ -278,7 +278,7 @@ visualization_msgs::msg::Marker polygonAsMarker(
   marker.id = polygon.id();
   marker.ns = name_space;
   marker.type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
-  marker.lifetime = rclcpp::Duration(0);
+  marker.lifetime = rclcpp::Duration::from_seconds(0);
   marker.pose.position.x = 0.0;
   marker.pose.position.y = 0.0;
   marker.pose.position.z = 0.0;


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ x ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description

- add `Werror` compile option
- fix deprecated `rclcpp::Duration`
- add `[[maybe_unused]]` to functions which are not used now

## How to review this PR.

## Others
