### PR TITLE
suppress warnings

### DIFF
--- a/external/concealer/include/concealer/miscellaneous_api.hpp
+++ b/external/concealer/include/concealer/miscellaneous_api.hpp
@@ -395,8 +395,8 @@ public:
     INIT_PUBLISHER(CurrentVelocity, "/vehicle/status/velocity"),
     INIT_PUBLISHER(GoalPose, "/planning/mission_planning/goal"),
     INIT_PUBLISHER(InitialPose, "/initialpose"),
-    INIT_PUBLISHER(LocalizationPose, "/localization/pose_with_covariance"),
     INIT_PUBLISHER(LocalizationTwist, "/localization/twist"),
+    INIT_PUBLISHER(LocalizationPose, "/localization/pose_with_covariance"),
     INIT_SUBSCRIPTION(Trajectory, "/planning/scenario_planning/trajectory", []() {}),
     INIT_SUBSCRIPTION(TurnSignalCommand, "/control/turn_signal_cmd", []() {}),
     INIT_SUBSCRIPTION(VehicleCommand, "/control/vehicle_cmd", []() {})

--- a/openscenario/openscenario_visualization/CMakeLists.txt
+++ b/openscenario/openscenario_visualization/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 # find dependencies

--- a/openscenario/openscenario_visualization/src/openscenario_visualization_component.cpp
+++ b/openscenario/openscenario_visualization/src/openscenario_visualization_component.cpp
@@ -146,7 +146,7 @@ const visualization_msgs::msg::MarkerArray OpenscenarioVisualizationComponent::g
   bbox.pose.orientation.z = 0.0;
   bbox.pose.orientation.w = 1.0;
   bbox.type = bbox.LINE_LIST;
-  bbox.lifetime = rclcpp::Duration(0.1);
+  bbox.lifetime = rclcpp::Duration::from_seconds(0.1);
   geometry_msgs::msg::Point p0, p1, p2, p3, p4, p5, p6, p7;
 
   p0.x = status.bounding_box.center.x + status.bounding_box.dimensions.x * 0.5;
@@ -253,7 +253,7 @@ const visualization_msgs::msg::MarkerArray OpenscenarioVisualizationComponent::g
   text.scale.x = 0.0;
   text.scale.y = 0.0;
   text.scale.z = 0.6;
-  text.lifetime = rclcpp::Duration(0.1);
+  text.lifetime = rclcpp::Duration::from_seconds(0.1);
   text.text = status.name;
   text.color = color_utils::makeColorMsg("white", 0.99);
   ret.markers.emplace_back(text);
@@ -292,7 +292,7 @@ const visualization_msgs::msg::MarkerArray OpenscenarioVisualizationComponent::g
   arrow.scale.x = 1.0;
   arrow.scale.y = 1.0;
   arrow.scale.z = 1.0;
-  arrow.lifetime = rclcpp::Duration(0.1);
+  arrow.lifetime = rclcpp::Duration::from_seconds(0.1);
   arrow.color = color_utils::makeColorMsg("red", 0.99);
   ret.markers.emplace_back(arrow);
 
@@ -315,7 +315,7 @@ const visualization_msgs::msg::MarkerArray OpenscenarioVisualizationComponent::g
   text_action.scale.x = 0.0;
   text_action.scale.y = 0.0;
   text_action.scale.z = 0.4;
-  text_action.lifetime = rclcpp::Duration(0.1);
+  text_action.lifetime = rclcpp::Duration::from_seconds(0.1);
   text_action.text = status.action_status.current_action;
   text_action.color = color_utils::makeColorMsg("white", 0.99);
   ret.markers.emplace_back(text_action);

--- a/simulation/traffic_simulator/CMakeLists.txt
+++ b/simulation/traffic_simulator/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
 find_package(ament_cmake_auto REQUIRED)

--- a/simulation/traffic_simulator/src/behavior/action_node.cpp
+++ b/simulation/traffic_simulator/src/behavior/action_node.cpp
@@ -204,31 +204,26 @@ boost::optional<double> ActionNode::getDistanceToFrontEntity(
 boost::optional<std::string> ActionNode::getFrontEntityName(
   const traffic_simulator::math::CatmullRomSpline & spline)
 {
-  boost::optional<double> front_entity_distance;
-  std::string front_entity_name = "";
+  std::vector<double> distances;
+  std::vector<std::string> entities;
   for (const auto & each : other_entity_status) {
     const auto distance = getDistanceToTargetEntityPolygon(spline, each.first);
     if (distance) {
       if (distance.get() < 40) {
-        if (!front_entity_distance) {
-          front_entity_distance = distance.get();
-          front_entity_name = each.first;
-        } else {
-          if (front_entity_distance.get() > distance.get()) {
-            front_entity_distance = distance.get();
-            front_entity_name = each.first;
-          }
-        }
+        entities.emplace_back(each.first);
+        distances.emplace_back(distance.get());
       }
     }
   }
-  if (!front_entity_distance) {
+  if (entities.size() != distances.size()) {
+    THROW_SIMULATION_ERROR("size of entities and distances vector does not match.");
+  }
+  if (distances.empty()) {
     return boost::none;
   }
-  if (front_entity_name == "") {
-    THROW_SIMULATION_ERROR("name of front entity is empty.");
-  }
-  return front_entity_name;
+  std::vector<double>::iterator iter = std::min_element(distances.begin(), distances.end());
+  size_t index = std::distance(distances.begin(), iter);
+  return entities[index];
 }
 
 boost::optional<double> ActionNode::getDistanceToTargetEntityOnCrosswalk(

--- a/simulation/traffic_simulator/src/behavior/action_node.cpp
+++ b/simulation/traffic_simulator/src/behavior/action_node.cpp
@@ -200,7 +200,7 @@ boost::optional<double> ActionNode::getDistanceToFrontEntity()
 
 boost::optional<openscenario_msgs::msg::EntityStatus> ActionNode::getFrontEntityStatus()
 {
-  boost::optional<double> front_entity_distance, front_entity_speed;
+  boost::optional<double> front_entity_distance{0.0}, front_entity_speed{0.0};
   std::string front_entity_name = "";
   for (const auto & each : other_entity_status) {
     if (!entity_status.lanelet_pose_valid || !each.second.lanelet_pose_valid) {

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -51,6 +51,8 @@ namespace hdmap_utils
 HdMapUtils::HdMapUtils(
   const boost::filesystem::path & lanelet2_map_path, const geographic_msgs::msg::GeoPoint & origin)
 {
+  (void)origin;
+
   lanelet::projection::MGRSProjector projector;
 
   lanelet::ErrorMessages errors;

--- a/simulation/traffic_simulator/src/simulation_clock/simulation_clock.cpp
+++ b/simulation/traffic_simulator/src/simulation_clock/simulation_clock.cpp
@@ -20,7 +20,7 @@ namespace traffic_simulator
 SimulationClock::SimulationClock(rcl_clock_type_t clock_type, bool use_raw_clock)
 : rclcpp::Clock(clock_type),
   use_raw_clock(use_raw_clock),
-  step_time_duration_(0),
+  step_time_duration_(rclcpp::Duration::from_seconds(0)),
   initialized_(false)
 {
 }

--- a/simulation/traffic_simulator/src/traffic_lights/traffic_light_state.cpp
+++ b/simulation/traffic_simulator/src/traffic_lights/traffic_light_state.cpp
@@ -55,6 +55,7 @@ std::ostream & operator<<(std::ostream & os, const TrafficLightColor & datum)
     case TrafficLightColor::RED:    return os << "red";
     case TrafficLightColor::GREEN:  return os << "green";
     case TrafficLightColor::YELLOW: return os << "yellow";
+    default:                        return os << "error";
   }
   // clang-format on
 }
@@ -123,6 +124,7 @@ std::ostream & operator<<(std::ostream & os, const TrafficLightArrow & datum)
     case TrafficLightArrow::STRAIGHT: return os << "straight";
     case TrafficLightArrow::LEFT:     return os << "left";
     case TrafficLightArrow::RIGHT:    return os << "right";
+    default:                          return os << "error";
   }
   // clang-format on
 }


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description

- adding Werror option
- fix reorder warnings
- remove deprecated function in rclcpp::Duration class
- adding void for unused arguments.
- adding default to the swich syntax.
- fix parameter initialization problem.

## How to review this PR.

## Others
