### PR TITLE
Fix/follow front entity behavior

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -2,6 +2,8 @@
 
 ## Difference between the latest release and master
 - Enables vehicle entity yield to merging entity. See also [this video.](https://user-images.githubusercontent.com/10348912/128287863-8a2db025-d1af-4e54-b5a3-08e5d2e168e4.mp4)
+- Checking collision between crosswalk and waypoints in lane coordinate
+- Remove division in checking collision function in order to avoid zero-division.
 
 ## Version 0.4.2
 - [Release Page](https://github.com/tier4/scenario_simulator_v2/releases/0.4.2) on Github :fa-github:

--- a/simulation/traffic_simulator/include/traffic_simulator/math/catmull_rom_spline.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/math/catmull_rom_spline.hpp
@@ -49,10 +49,10 @@ public:
     double tolerance = 0.001);
   double getSquaredDistanceIn2D(geometry_msgs::msg::Point point, double s) const;
   boost::optional<double> getCollisionPointIn2D(
-    geometry_msgs::msg::Point point0, geometry_msgs::msg::Point point1,
+    const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
     bool search_backward = false) const;
   boost::optional<double> getCollisionPointIn2D(
-    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false,
+    const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward = false,
     bool close_start_end = true) const;
   const openscenario_msgs::msg::CatmullRomSpline toRosMsg() const;
   const geometry_msgs::msg::Point getRightBoundsPoint(

--- a/simulation/traffic_simulator/include/traffic_simulator/math/catmull_rom_spline.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/math/catmull_rom_spline.hpp
@@ -52,7 +52,8 @@ public:
     geometry_msgs::msg::Point point0, geometry_msgs::msg::Point point1,
     bool search_backward = false) const;
   boost::optional<double> getCollisionPointIn2D(
-    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false) const;
+    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false,
+    bool close_start_end = true) const;
   const openscenario_msgs::msg::CatmullRomSpline toRosMsg() const;
   const geometry_msgs::msg::Point getRightBoundsPoint(
     double width, double s, double z_offset = 0) const;

--- a/simulation/traffic_simulator/include/traffic_simulator/math/hermite_curve.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/math/hermite_curve.hpp
@@ -66,7 +66,7 @@ public:
     geometry_msgs::msg::Point point0, geometry_msgs::msg::Point point1,
     bool search_backward = false) const;
   boost::optional<double> getCollisionPointIn2D(
-    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false, bool close_start_end=false) const;
+    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false, bool close_start_end=true) const;
   const openscenario_msgs::msg::HermiteCurve toRosMsg() const;
 
 private:

--- a/simulation/traffic_simulator/include/traffic_simulator/math/hermite_curve.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/math/hermite_curve.hpp
@@ -66,7 +66,7 @@ public:
     geometry_msgs::msg::Point point0, geometry_msgs::msg::Point point1,
     bool search_backward = false) const;
   boost::optional<double> getCollisionPointIn2D(
-    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false) const;
+    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false, bool close_start_end=false) const;
   const openscenario_msgs::msg::HermiteCurve toRosMsg() const;
 
 private:

--- a/simulation/traffic_simulator/include/traffic_simulator/math/hermite_curve.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/math/hermite_curve.hpp
@@ -66,7 +66,8 @@ public:
     geometry_msgs::msg::Point point0, geometry_msgs::msg::Point point1,
     bool search_backward = false) const;
   boost::optional<double> getCollisionPointIn2D(
-    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false, bool close_start_end=true) const;
+    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false,
+    bool close_start_end = true) const;
   const openscenario_msgs::msg::HermiteCurve toRosMsg() const;
 
 private:

--- a/simulation/traffic_simulator/include/traffic_simulator/math/hermite_curve.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/math/hermite_curve.hpp
@@ -63,10 +63,10 @@ public:
   double getSquaredDistanceIn2D(
     geometry_msgs::msg::Point point, double s, bool autoscale = false) const;
   boost::optional<double> getCollisionPointIn2D(
-    geometry_msgs::msg::Point point0, geometry_msgs::msg::Point point1,
+    const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
     bool search_backward = false) const;
   boost::optional<double> getCollisionPointIn2D(
-    std::vector<geometry_msgs::msg::Point> polygon, bool search_backward = false,
+    const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward = false,
     bool close_start_end = true) const;
   const openscenario_msgs::msg::HermiteCurve toRosMsg() const;
 

--- a/simulation/traffic_simulator/src/behavior/action_node.cpp
+++ b/simulation/traffic_simulator/src/behavior/action_node.cpp
@@ -237,8 +237,7 @@ boost::optional<double> ActionNode::getDistanceToTargetEntityOnCrosswalk(
 {
   if (status.lanelet_pose_valid) {
     auto polygon = hdmap_utils->getLaneletPolygon(status.lanelet_pose.lanelet_id);
-    const auto s = spline.getCollisionPointIn2D(polygon, false, true);
-    return s;
+    return spline.getCollisionPointIn2D(polygon, false, true);
   }
   return boost::none;
 }

--- a/simulation/traffic_simulator/src/behavior/action_node.cpp
+++ b/simulation/traffic_simulator/src/behavior/action_node.cpp
@@ -237,7 +237,6 @@ boost::optional<double> ActionNode::getDistanceToTargetEntityOnCrosswalk(
 {
   if (status.lanelet_pose_valid) {
     auto polygon = hdmap_utils->getLaneletPolygon(status.lanelet_pose.lanelet_id);
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger("test"), "crosswalk");
     const auto s = spline.getCollisionPointIn2D(polygon, false, true);
     return s;
   }

--- a/simulation/traffic_simulator/src/behavior/action_node.cpp
+++ b/simulation/traffic_simulator/src/behavior/action_node.cpp
@@ -237,7 +237,9 @@ boost::optional<double> ActionNode::getDistanceToTargetEntityOnCrosswalk(
 {
   if (status.lanelet_pose_valid) {
     auto polygon = hdmap_utils->getLaneletPolygon(status.lanelet_pose.lanelet_id);
-    return spline.getCollisionPointIn2D(polygon);
+    RCLCPP_ERROR_STREAM(rclcpp::get_logger("test"), "crosswalk");
+    const auto s = spline.getCollisionPointIn2D(polygon, false, true);
+    return s;
   }
   return boost::none;
 }

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -529,7 +529,6 @@ void EntityManager::update(const double current_time, const double step_time)
   start = std::chrono::system_clock::now();
   step_time_ = step_time;
   current_time_ = current_time;
-  configuration.verbose = true;
   if (configuration.verbose) {
     std::cout << "-------------------------- UPDATE --------------------------" << std::endl;
     std::cout << "current_time : " << current_time_ << std::endl;

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -529,6 +529,7 @@ void EntityManager::update(const double current_time, const double step_time)
   start = std::chrono::system_clock::now();
   step_time_ = step_time;
   current_time_ = current_time;
+  configuration.verbose = true;
   if (configuration.verbose) {
     std::cout << "-------------------------- UPDATE --------------------------" << std::endl;
     std::cout << "current_time : " << current_time_ << std::endl;

--- a/simulation/traffic_simulator/src/math/catmull_rom_spline.cpp
+++ b/simulation/traffic_simulator/src/math/catmull_rom_spline.cpp
@@ -283,7 +283,8 @@ double CatmullRomSpline::getSInSplineCurve(size_t curve_index, double s) const
 }
 
 boost::optional<double> CatmullRomSpline::getCollisionPointIn2D(
-  std::vector<geometry_msgs::msg::Point> polygon, bool search_backward, bool close_start_end) const
+  const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward,
+  bool close_start_end) const
 {
   size_t n = curves_.size();
   if (search_backward) {
@@ -307,7 +308,8 @@ boost::optional<double> CatmullRomSpline::getCollisionPointIn2D(
 }
 
 boost::optional<double> CatmullRomSpline::getCollisionPointIn2D(
-  geometry_msgs::msg::Point point0, geometry_msgs::msg::Point point1, bool search_backward) const
+  const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
+  bool search_backward) const
 {
   size_t n = curves_.size();
   if (search_backward) {

--- a/simulation/traffic_simulator/src/math/catmull_rom_spline.cpp
+++ b/simulation/traffic_simulator/src/math/catmull_rom_spline.cpp
@@ -283,12 +283,12 @@ double CatmullRomSpline::getSInSplineCurve(size_t curve_index, double s) const
 }
 
 boost::optional<double> CatmullRomSpline::getCollisionPointIn2D(
-  std::vector<geometry_msgs::msg::Point> polygon, bool search_backward) const
+  std::vector<geometry_msgs::msg::Point> polygon, bool search_backward, bool close_start_end) const
 {
   size_t n = curves_.size();
   if (search_backward) {
     for (size_t i = 0; i < n; i++) {
-      auto s = curves_[n - 1 - i].getCollisionPointIn2D(polygon, search_backward);
+      auto s = curves_[n - 1 - i].getCollisionPointIn2D(polygon, search_backward, close_start_end);
       if (s) {
         return getSInSplineCurve(n - 1 - i, s.get());
       }
@@ -296,7 +296,7 @@ boost::optional<double> CatmullRomSpline::getCollisionPointIn2D(
     return boost::none;
   } else {
     for (size_t i = 0; i < n; i++) {
-      auto s = curves_[i].getCollisionPointIn2D(polygon, search_backward);
+      auto s = curves_[i].getCollisionPointIn2D(polygon, search_backward, close_start_end);
       if (s) {
         return getSInSplineCurve(i, s.get());
       }

--- a/simulation/traffic_simulator/src/math/hermite_curve.cpp
+++ b/simulation/traffic_simulator/src/math/hermite_curve.cpp
@@ -201,7 +201,7 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
       double poly_x = (1 - tx) * point1.x + tx * point0.x;
       double poly_y = (1 - ty) * point1.y + ty * point0.y;
       double error = std::hypot(poly_x - x, poly_y - y);
-      if (error < 3) {
+      if (error < 0.1) {
         s_values.emplace_back(solution);
       }
     }

--- a/simulation/traffic_simulator/src/math/hermite_curve.cpp
+++ b/simulation/traffic_simulator/src/math/hermite_curve.cpp
@@ -203,6 +203,7 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
       double poly_x = (1 - tx) * point1.x + tx * point0.x;
       double poly_y = (1 - ty) * point1.y + ty * point0.y;
       double error = std::hypot(poly_x - x, poly_y - y);
+      /// @note Hard coded parameter, torelance of the collision point.
       if (error < 0.1) {
         s_values.emplace_back(solution);
       }

--- a/simulation/traffic_simulator/src/math/hermite_curve.cpp
+++ b/simulation/traffic_simulator/src/math/hermite_curve.cpp
@@ -139,9 +139,9 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
       s_values.emplace_back(s.get());
     }
   }
-  if(close_start_end) {
-    const auto p0 = *polygon.end();
-    const auto p1 = *polygon.begin();
+  if (close_start_end) {
+    const auto p0 = polygon[n - 1];
+    const auto p1 = polygon[0];
     auto s = getCollisionPointIn2D(p0, p1, search_backward);
     if (s) {
       s_values.emplace_back(s.get());
@@ -201,7 +201,7 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
       double poly_x = (1 - tx) * point1.x + tx * point0.x;
       double poly_y = (1 - ty) * point1.y + ty * point0.y;
       double error = std::hypot(poly_x - x, poly_y - y);
-      if (error < 3 && 0 < tx && tx < 1 && 0 < ty && ty < 1 && 0 < solution && solution < 1) {
+      if (error < 3) {
         s_values.emplace_back(solution);
       }
     }

--- a/simulation/traffic_simulator/src/math/hermite_curve.cpp
+++ b/simulation/traffic_simulator/src/math/hermite_curve.cpp
@@ -188,8 +188,8 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
       }
     }
   } else {
-    double a = ay_ * ey - ax_ * ey;
-    double b = by_ * ey - bx_ * ey;
+    double a = ay_ * ex - ax_ * ey;
+    double b = by_ * ex - bx_ * ey;
     double c = cy_ * ex - cx_ * ey;
     double d = dy_ * ex - dx_ * ey - ex * fy + ey * fx;
     auto solutions = solver_.solveCubicEquation(a, b, c, d);

--- a/simulation/traffic_simulator/src/math/hermite_curve.cpp
+++ b/simulation/traffic_simulator/src/math/hermite_curve.cpp
@@ -124,7 +124,8 @@ double HermiteCurve::getNewtonMethodStepSize(
 }
 
 boost::optional<double> HermiteCurve::getCollisionPointIn2D(
-  std::vector<geometry_msgs::msg::Point> polygon, bool search_backward, bool close_start_end) const
+  const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward,
+  bool close_start_end) const
 {
   size_t n = polygon.size();
   if (n <= 1) {
@@ -157,7 +158,8 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
 }
 
 boost::optional<double> HermiteCurve::getCollisionPointIn2D(
-  geometry_msgs::msg::Point point0, geometry_msgs::msg::Point point1, bool search_backward) const
+  const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
+  bool search_backward) const
 {
   std::vector<double> s_values;
   // double l = std::hypot(point0.x - point1.x, point0.y - point1.y);

--- a/simulation/traffic_simulator/src/math/hermite_curve.cpp
+++ b/simulation/traffic_simulator/src/math/hermite_curve.cpp
@@ -124,7 +124,7 @@ double HermiteCurve::getNewtonMethodStepSize(
 }
 
 boost::optional<double> HermiteCurve::getCollisionPointIn2D(
-  std::vector<geometry_msgs::msg::Point> polygon, bool search_backward) const
+  std::vector<geometry_msgs::msg::Point> polygon, bool search_backward, bool close_start_end) const
 {
   size_t n = polygon.size();
   if (n <= 1) {
@@ -134,6 +134,14 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
   for (size_t i = 0; i < (n - 1); i++) {
     const auto p0 = polygon[i];
     const auto p1 = polygon[i + 1];
+    auto s = getCollisionPointIn2D(p0, p1, search_backward);
+    if (s) {
+      s_values.emplace_back(s.get());
+    }
+  }
+  if(close_start_end) {
+    const auto p0 = *polygon.end();
+    const auto p1 = *polygon.begin();
     auto s = getCollisionPointIn2D(p0, p1, search_backward);
     if (s) {
       s_values.emplace_back(s.get());


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
- Enables vehicle entity yield to merging entity. See also [this video.](https://user-images.githubusercontent.com/10348912/128287863-8a2db025-d1af-4e54-b5a3-08e5d2e168e4.mp4)
- Checking collision between crosswalk and waypoints in lane coordinate
- Remove division in checking collision function in order to avoid zero-division.
## How to review this PR.
Please check passing all CI tests.
## Others
