### PR TITLE
Fix/phase control

### DIFF
--- a/.github/workflows/ScenarioTest.yaml
+++ b/.github/workflows/ScenarioTest.yaml
@@ -134,6 +134,19 @@ jobs:
           ros2 launch cpp_mock_scenarios mock_test.launch.py scenario:=merge_left timeout:=15 > log.txt
           cat log.txt | grep "Scenario Succeed"
 
+      - name: Run phase_control scenario
+        if: matrix.test_flags == 'cpp_mock_test'
+        run: |
+          source ~/ros2_ws/install/setup.bash
+          ros2 launch cpp_mock_scenarios mock_test.launch.py scenario:=phase_control timeout:=15 > log.txt
+          cat log.txt | grep "Scenario Succeed"
+
+      - name: Run traveled_distance scenario
+        if: matrix.test_flags == 'cpp_mock_test'
+        run: |
+          source ~/ros2_ws/install/setup.bash
+          ros2 launch cpp_mock_scenarios mock_test.launch.py scenario:=traveled_distance timeout:=15 > log.txt
+          cat log.txt | grep "Scenario Succeed"
 
       - name: Collect coverage for openscenario_interpreter
         if: matrix.test_flags == 'openscenario_interpreter'

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -2,6 +2,7 @@
 
 ## Difference between the latest release and master
 - Add a new metrics module which detects vel, acc and jerk out of range. (Contribution by [kyabe2718](https://github.com/kyabe2718)).
+- Fix phase control feature in traffic light manager class. [Link](https://github.com/tier4/scenario_simulator_v2/pull/450)
 
 ## Version 0.4.3
 - [Release Page](https://github.com/tier4/scenario_simulator_v2/releases/0.4.3) on Github :fa-github:

--- a/mock/cpp_mock_scenarios/CMakeLists.txt
+++ b/mock/cpp_mock_scenarios/CMakeLists.txt
@@ -42,7 +42,7 @@ add_subdirectory(src/collision)
 add_subdirectory(src/lane_change)
 add_subdirectory(src/merge)
 add_subdirectory(src/metrics)
-# add_subdirectory(src/phase_control)
+add_subdirectory(src/traffic_light)
 
 install(
   DIRECTORY launch rviz

--- a/mock/cpp_mock_scenarios/src/metrics/traveled_distance.cpp
+++ b/mock/cpp_mock_scenarios/src/metrics/traveled_distance.cpp
@@ -45,6 +45,9 @@ private:
         stop(cpp_mock_scenarios::Result::FAILURE);
       }
     }
+    if (api_.getCurrentTime() >= 12) {
+      stop(cpp_mock_scenarios::Result::SUCCESS);
+    }
   }
 
   void onInitialize() override

--- a/mock/cpp_mock_scenarios/src/traffic_light/phase_control.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_light/phase_control.cpp
@@ -1,0 +1,69 @@
+// Copyright 2015-2020 Tier IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <quaternion_operation/quaternion_operation.h>
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <cpp_mock_scenarios/catalogs.hpp>
+#include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <openscenario_msgs/msg/driver_model.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <traffic_simulator/api/api.hpp>
+
+// headers in STL
+#include <memory>
+#include <string>
+#include <vector>
+
+class AccelerateAndFollowScenario : public cpp_mock_scenarios::CppScenarioNode
+{
+public:
+  explicit AccelerateAndFollowScenario(const rclcpp::NodeOptions & option)
+  : cpp_mock_scenarios::CppScenarioNode(
+      "idiot_npc", ament_index_cpp::get_package_share_directory("cargo_delivery") + "/maps/kashiwa",
+      "lanelet2_map_with_private_road_and_walkway_ele_fix.osm", __FILE__, false, option)
+  {
+    start();
+  }
+
+private:
+  void onUpdate() override
+  {
+  }
+
+  void onInitialize() override
+  {
+    api_.spawn(false, "ego", getVehicleParameters());
+    api_.setEntityStatus(
+      "ego", traffic_simulator::helper::constructLaneletPose(34741, 0, 0),
+      traffic_simulator::helper::constructActionStatus(3));
+    api_.setTargetSpeed("ego", 3, true);
+    std::vector<std::pair<double, traffic_simulator::TrafficLightColor>> phase;
+    phase = {
+      {10, traffic_simulator::TrafficLightColor::GREEN},
+      {10, traffic_simulator::TrafficLightColor::YELLOW},
+      {10, traffic_simulator::TrafficLightColor::RED}};
+    api_.setTrafficLightColorPhase(34802, phase);
+  }
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  auto component = std::make_shared<AccelerateAndFollowScenario>(options);
+  rclcpp::spin(component);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/mock/cpp_mock_scenarios/src/traffic_light/phase_control.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_light/phase_control.cpp
@@ -38,7 +38,21 @@ public:
   }
 
 private:
-  void onUpdate() override {}
+  void onUpdate() override
+  {
+    const auto t = api_.getCurrentTime();
+    const auto color = api_.getTrafficLightColor(34802);
+    if (0 < t && t <= 9.9) {
+      if (color != traffic_simulator::TrafficLightColor::GREEN) {
+        stop(cpp_mock_scenarios::Result::FAILURE);
+      }
+    }
+    if (t >= 10.1) {
+      if (color != traffic_simulator::TrafficLightColor::YELLOW) {
+        stop(cpp_mock_scenarios::Result::SUCCESS);
+      }
+    }
+  }
 
   void onInitialize() override
   {

--- a/mock/cpp_mock_scenarios/src/traffic_light/phase_control.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_light/phase_control.cpp
@@ -48,8 +48,10 @@ private:
       }
     }
     if (t >= 10.1) {
-      if (color != traffic_simulator::TrafficLightColor::YELLOW) {
+      if (color == traffic_simulator::TrafficLightColor::YELLOW) {
         stop(cpp_mock_scenarios::Result::SUCCESS);
+      } else {
+        stop(cpp_mock_scenarios::Result::FAILURE);
       }
     }
   }

--- a/mock/cpp_mock_scenarios/src/traffic_light/phase_control.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_light/phase_control.cpp
@@ -38,9 +38,7 @@ public:
   }
 
 private:
-  void onUpdate() override
-  {
-  }
+  void onUpdate() override {}
 
   void onInitialize() override
   {

--- a/mock/cpp_mock_scenarios/src/traffic_simulation_demo.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_simulation_demo.cpp
@@ -125,9 +125,9 @@ private:
       traffic_simulator::helper::constructActionStatus());
     std::vector<std::pair<double, traffic_simulator::TrafficLightColor>> phase;
     phase = {
-      {10, traffic_simulator::TrafficLightColor::GREEN},
-      {10, traffic_simulator::TrafficLightColor::YELLOW},
-      {10, traffic_simulator::TrafficLightColor::RED}};
+      {1, traffic_simulator::TrafficLightColor::GREEN},
+      {1, traffic_simulator::TrafficLightColor::YELLOW},
+      {1, traffic_simulator::TrafficLightColor::RED}};
     api_.setTrafficLightColorPhase(34802, phase);
   }
 

--- a/simulation/traffic_simulator/include/traffic_simulator/traffic_lights/traffic_light_manager.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/traffic_lights/traffic_light_manager.hpp
@@ -42,7 +42,7 @@ public:
     const rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightStateArray>::SharedPtr &,
     const std::shared_ptr<rclcpp::Clock> & clock_ptr, const std::string & map_frame = "map");
 
-  void update(const double current_time);
+  void update(const double step_time);
 
 #define FORWARD_TO_GIVEN_TRAFFIC_LIGHT(IDENTIFIER)                                         \
   template <typename... Ts>                                                                \

--- a/simulation/traffic_simulator/src/traffic_lights/traffic_light.cpp
+++ b/simulation/traffic_simulator/src/traffic_lights/traffic_light.cpp
@@ -43,8 +43,8 @@ void TrafficLight::setArrow(const TrafficLightArrow arrow) { arrow_phase_.setSta
 double TrafficLight::getColorPhaseDuration() const { return color_phase_.getPhaseDuration(); }
 double TrafficLight::getArrowPhaseDuration() const { return arrow_phase_.getPhaseDuration(); }
 
-TrafficLightArrow TrafficLight::getArrow() const { return arrow_phase_.getState(); }
 TrafficLightColor TrafficLight::getColor() const { return color_phase_.getState(); }
+TrafficLightArrow TrafficLight::getArrow() const { return arrow_phase_.getState(); }
 
 void TrafficLight::update(const double step_time)
 {
@@ -54,7 +54,11 @@ void TrafficLight::update(const double step_time)
 
   const auto previous_color = getColor();
   color_phase_.update(step_time);
-  color_changed_ = (previous_color != getColor());
+  if (previous_color != getColor()) {
+    color_changed_ = true;
+  } else {
+    color_changed_ = false;
+  }
 }
 
 const geometry_msgs::msg::Point & TrafficLight::getPosition(const TrafficLightColor & color) const

--- a/simulation/traffic_simulator/src/traffic_lights/traffic_light_manager.cpp
+++ b/simulation/traffic_simulator/src/traffic_lights/traffic_light_manager.cpp
@@ -117,8 +117,8 @@ void TrafficLightManager::update(const double step_time)
 {
   publishTrafficLightStateArray();
 
-  for (const auto & light : traffic_lights_) {
-    std::get<1>(light).update(step_time);
+  for (auto & light : traffic_lights_) {
+    light.second.update(step_time);
   }
 
   if (std::any_of(
@@ -127,7 +127,6 @@ void TrafficLightManager::update(const double step_time)
           return std::get<1>(id_and_traffic_light).colorChanged();
         })) {
     deleteAllMarkers();
-    // RCLCPP_ERROR_STREAM(rclcpp::get_logger("test"), __FILE__ << "," << __LINE__);
   }
 
   drawMarkers();

--- a/simulation/traffic_simulator/src/traffic_lights/traffic_light_manager.cpp
+++ b/simulation/traffic_simulator/src/traffic_lights/traffic_light_manager.cpp
@@ -113,9 +113,13 @@ void TrafficLightManager::drawMarkers() const
   marker_pub_->publish(msg);
 }
 
-void TrafficLightManager::update(const double)
+void TrafficLightManager::update(const double step_time)
 {
   publishTrafficLightStateArray();
+
+  for (const auto & light : traffic_lights_) {
+    std::get<1>(light).update(step_time);
+  }
 
   if (std::any_of(
         std::begin(traffic_lights_), std::end(traffic_lights_),
@@ -123,6 +127,7 @@ void TrafficLightManager::update(const double)
           return std::get<1>(id_and_traffic_light).colorChanged();
         })) {
     deleteAllMarkers();
+    // RCLCPP_ERROR_STREAM(rclcpp::get_logger("test"), __FILE__ << "," << __LINE__);
   }
 
   drawMarkers();


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
Phase control feature was disabled due to update function was not called in traffic light manager.

## How to review this PR.

```
ros2 launch cpp_mock_scenarios mock_test.launch.py scenario:=phase_control timeout:=15 with_rviz:=True
```

Please check output like below appears.
```
masaya@tieriv-masaya-galactic:~/workspace/scenario_simulator_ws$ ros2 launch cpp_mock_scenarios mock_test.launch.py scenario:=phase_control timeout:=15 with_rviz:=True
[INFO] [launch]: All log files can be found below /home/masaya/.ros/log/2021-08-19-15-11-51-104831-tieriv-masaya-galactic-193770
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [phase_control-1]: process started with pid [193773]
[INFO] [simple_sensor_simulator_node-2]: process started with pid [193775]
[INFO] [openscenario_visualization_node-3]: process started with pid [193777]
[INFO] [rviz2-4]: process started with pid [193779]
[phase_control-1] [0.051]: root                      IDLE -> RUNNING
[phase_control-1] [0.051]: lane_change               IDLE -> FAILURE
[phase_control-1] [0.051]: follow_lane_sequence      IDLE -> RUNNING
[phase_control-1] [0.052]: follow_lane               IDLE -> RUNNING
Scenario Succeed
[phase_control-1] cpp_scenario:success
[INFO] [phase_control-1]: process has finished cleanly [pid 193773]
[INFO] [rviz2-4]: sending signal 'SIGINT' to process[rviz2-4]
[INFO] [openscenario_visualization_node-3]: sending signal 'SIGINT' to process[openscenario_visualization_node-3]
[INFO] [simple_sensor_simulator_node-2]: sending signal 'SIGINT' to process[simple_sensor_simulator_node-2]
[openscenario_visualization_node-3] [INFO] [1629353521.528111631] [rclcpp]: signal_handler(signal_value=2)
[simple_sensor_simulator_node-2] [INFO] [1629353521.528600060] [rclcpp]: signal_handler(signal_value=2)
[INFO] [simple_sensor_simulator_node-2]: process has finished cleanly [pid 193775]
[INFO] [openscenario_visualization_node-3]: process has finished cleanly [pid 193777]
[INFO] [rviz2-4]: process has finished cleanly [pid 193779]
```

## Others
