### PR TITLE
Fix/stop at crossing entity behavior

### DIFF
--- a/.github/workflows/ScenarioTest.yaml
+++ b/.github/workflows/ScenarioTest.yaml
@@ -148,6 +148,13 @@ jobs:
           ros2 launch cpp_mock_scenarios mock_test.launch.py scenario:=traveled_distance timeout:=15 > log.txt
           cat log.txt | grep "Scenario Succeed"
 
+      - name: Run stop_at_crosswalk scenario
+        if: matrix.test_flags == 'cpp_mock_test'
+        run: |
+          source ~/ros2_ws/install/setup.bash
+          ros2 launch cpp_mock_scenarios mock_test.launch.py scenario:=stop_at_crosswalk timeout:=15 > log.txt
+          cat log.txt | grep "Scenario Succeed"
+
       - name: Collect coverage for openscenario_interpreter
         if: matrix.test_flags == 'openscenario_interpreter'
         run: |

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,7 +3,7 @@
 ## Difference between the latest release and master
 - Add a new metrics module which detects vel, acc and jerk out of range. (Contribution by [kyabe2718](https://github.com/kyabe2718)).
 - Fix phase control feature in traffic light manager class. [Link](https://github.com/tier4/scenario_simulator_v2/pull/450)
-- Fix problems in crossing entity on crosswalk. [link]()
+- Fix problems in crossing entity on crosswalk. [link](https://github.com/tier4/scenario_simulator_v2/pull/452)
 
 ## Version 0.4.3
 - [Release Page](https://github.com/tier4/scenario_simulator_v2/releases/0.4.3) on Github :fa-github:

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Difference between the latest release and master
 - Add a new metrics module which detects vel, acc and jerk out of range. (Contribution by [kyabe2718](https://github.com/kyabe2718)).
 - Fix phase control feature in traffic light manager class. [Link](https://github.com/tier4/scenario_simulator_v2/pull/450)
+- Fix problems in crossing entity on crosswalk. [link]()
 
 ## Version 0.4.3
 - [Release Page](https://github.com/tier4/scenario_simulator_v2/releases/0.4.3) on Github :fa-github:

--- a/mock/cpp_mock_scenarios/CMakeLists.txt
+++ b/mock/cpp_mock_scenarios/CMakeLists.txt
@@ -43,6 +43,7 @@ add_subdirectory(src/lane_change)
 add_subdirectory(src/merge)
 add_subdirectory(src/metrics)
 add_subdirectory(src/traffic_light)
+add_subdirectory(src/crosswalk)
 
 install(
   DIRECTORY launch rviz

--- a/mock/cpp_mock_scenarios/src/crosswalk/CMakeLists.txt
+++ b/mock/cpp_mock_scenarios/src/crosswalk/CMakeLists.txt
@@ -1,0 +1,9 @@
+ament_auto_add_executable(stop_at_crosswalk
+  stop_at_crosswalk.cpp
+)
+target_link_libraries(stop_at_crosswalk cpp_scenario_node)
+
+install(TARGETS
+  stop_at_crosswalk
+  DESTINATION lib/cpp_mock_scenarios
+)

--- a/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
+++ b/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
@@ -1,0 +1,85 @@
+// Copyright 2015-2020 Tier IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <quaternion_operation/quaternion_operation.h>
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <cpp_mock_scenarios/catalogs.hpp>
+#include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <openscenario_msgs/msg/driver_model.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <traffic_simulator/api/api.hpp>
+
+// headers in STL
+#include <memory>
+#include <string>
+#include <vector>
+
+class TrafficSimulationDemoScenario : public cpp_mock_scenarios::CppScenarioNode
+{
+public:
+  explicit TrafficSimulationDemoScenario(const rclcpp::NodeOptions & option)
+  : cpp_mock_scenarios::CppScenarioNode(
+      "idiot_npc", ament_index_cpp::get_package_share_directory("kashiwanoha_map") + "/map",
+      "lanelet2_map.osm", __FILE__, false, option)
+  {
+    start();
+  }
+
+private:
+  void onUpdate() override
+  {
+    const auto t = api_.getCurrentTime();
+    if (t >= 10) {
+      stop(cpp_mock_scenarios::Result::SUCCESS);
+    }
+    if (t >= 6.3 && 6.8 >= t) {
+      const auto vel = api_.getEntityStatus("ego").action_status.twist.linear.x;
+      if (std::fabs(0.01) <= vel) {
+        stop(cpp_mock_scenarios::Result::FAILURE);
+      }
+    }
+  }
+
+  void onInitialize() override
+  {
+    api_.spawn(false, "ego", getVehicleParameters());
+    api_.setEntityStatus(
+      "ego", traffic_simulator::helper::constructLaneletPose(120545, 0),
+      traffic_simulator::helper::constructActionStatus(10));
+    api_.setTargetSpeed("ego", 8, true);
+    api_.spawn(
+      false, "bob", getPedestrianParameters(),
+      traffic_simulator::helper::constructLaneletPose(34378, 0.0),
+      traffic_simulator::helper::constructActionStatus(1));
+    api_.setTargetSpeed("bob", 1, true);
+    api_.requestAssignRoute(
+      "ego", std::vector<openscenario_msgs::msg::LaneletPose>{
+               traffic_simulator::helper::constructLaneletPose(34675, 0.0),
+               traffic_simulator::helper::constructLaneletPose(34690, 0.0)});
+  }
+
+private:
+  bool lanechange_executed_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  auto component = std::make_shared<TrafficSimulationDemoScenario>(options);
+  rclcpp::spin(component);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
+++ b/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
@@ -41,6 +41,9 @@ private:
   void onUpdate() override
   {
     const auto t = api_.getCurrentTime();
+    if (api_.entityExists("bob") && api_.checkCollision("ego", "bob")) {
+      stop(cpp_mock_scenarios::Result::FAILURE);
+    }
     if (t >= 10) {
       stop(cpp_mock_scenarios::Result::SUCCESS);
     }

--- a/simulation/traffic_simulator/src/behavior/action_node.cpp
+++ b/simulation/traffic_simulator/src/behavior/action_node.cpp
@@ -231,11 +231,8 @@ boost::optional<double> ActionNode::getDistanceToTargetEntityOnCrosswalk(
   const openscenario_msgs::msg::EntityStatus & status)
 {
   if (status.lanelet_pose_valid) {
-    std::cout << __FILE__ << "," << __LINE__ << std::endl;
     auto polygon = hdmap_utils->getLaneletPolygon(status.lanelet_pose.lanelet_id);
-    const auto s = spline.getCollisionPointIn2D(polygon, false, true);
-    std::cout << __FILE__ << "," << __LINE__ << std::endl;
-    return s;
+    return spline.getCollisionPointIn2D(polygon, false, true);
   }
   return boost::none;
 }

--- a/simulation/traffic_simulator/src/behavior/action_node.cpp
+++ b/simulation/traffic_simulator/src/behavior/action_node.cpp
@@ -231,8 +231,11 @@ boost::optional<double> ActionNode::getDistanceToTargetEntityOnCrosswalk(
   const openscenario_msgs::msg::EntityStatus & status)
 {
   if (status.lanelet_pose_valid) {
+    std::cout << __FILE__ << "," << __LINE__ << std::endl;
     auto polygon = hdmap_utils->getLaneletPolygon(status.lanelet_pose.lanelet_id);
-    return spline.getCollisionPointIn2D(polygon, false, true);
+    const auto s = spline.getCollisionPointIn2D(polygon, false, true);
+    std::cout << __FILE__ << "," << __LINE__ << std::endl;
+    return s;
   }
   return boost::none;
 }
@@ -263,7 +266,7 @@ boost::optional<double> ActionNode::getDistanceToTargetEntityPolygon(
   if (status.lanelet_pose_valid) {
     const auto polygon = traffic_simulator::math::transformPoints(
       status.pose, traffic_simulator::math::getPointsFromBbox(status.bounding_box));
-    return spline.getCollisionPointIn2D(polygon);
+    return spline.getCollisionPointIn2D(polygon, false, true);
   }
   return boost::none;
 }

--- a/simulation/traffic_simulator/src/behavior/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
+++ b/simulation/traffic_simulator/src/behavior/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
@@ -111,19 +111,21 @@ BT::NodeStatus StopAtCrossingEntityAction::tick()
   auto distance_to_stopline =
     hdmap_utils->getDistanceToStopLine(route_lanelets, waypoints.waypoints);
   const auto distance_to_front_entity = getDistanceToFrontEntity(spline);
-  if ((distance_to_front_entity || distance_to_stopline) && distance_to_stop_target_) {
+  if (!distance_to_stop_target_) {
+    in_stop_sequence_ = false;
+    return BT::NodeStatus::FAILURE;
+  }
+  if (distance_to_front_entity) {
     if (distance_to_front_entity.get() <= distance_to_stop_target_.get()) {
       in_stop_sequence_ = false;
       return BT::NodeStatus::FAILURE;
     }
+  }
+  if (distance_to_stopline) {
     if (distance_to_stopline.get() <= distance_to_stop_target_.get()) {
       in_stop_sequence_ = false;
       return BT::NodeStatus::FAILURE;
     }
-  }
-  if ((distance_to_front_entity || distance_to_stopline) && !distance_to_stop_target_) {
-    in_stop_sequence_ = false;
-    return BT::NodeStatus::FAILURE;
   }
   boost::optional<double> target_linear_speed;
   if (distance_to_stop_target_) {

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -529,7 +529,6 @@ void EntityManager::update(const double current_time, const double step_time)
   start = std::chrono::system_clock::now();
   step_time_ = step_time;
   current_time_ = current_time;
-  configuration.verbose = true;
   if (configuration.verbose) {
     std::cout << "-------------------------- UPDATE --------------------------" << std::endl;
     std::cout << "current_time : " << current_time_ << std::endl;

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -529,6 +529,7 @@ void EntityManager::update(const double current_time, const double step_time)
   start = std::chrono::system_clock::now();
   step_time_ = step_time;
   current_time_ = current_time;
+  configuration.verbose = true;
   if (configuration.verbose) {
     std::cout << "-------------------------- UPDATE --------------------------" << std::endl;
     std::cout << "current_time : " << current_time_ << std::endl;

--- a/simulation/traffic_simulator/src/math/hermite_curve.cpp
+++ b/simulation/traffic_simulator/src/math/hermite_curve.cpp
@@ -177,19 +177,25 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
     double tx = (x - point0.x) / (point1.x - point0.x);
     double y = solver_.cubicFunction(ay_, by_, cy_, dy_, solution);
     double ty = (y - point0.y) / (point1.y - point0.y);
-    double poly_x = (1 - tx) * point1.x + tx * point0.x;
-    double poly_y = (1 - ty) * point1.y + ty * point0.y;
+    // double poly_x = (1 - tx) * point1.x + tx * point0.x;
+    // double poly_y = (1 - ty) * point1.y + ty * point0.y;
     if (0 > tx || tx > 1) {
       continue;
     }
     if (0 > ty || ty > 1) {
       continue;
     }
+    if (0 > solution || solution > 1) {
+      continue;
+    }
+    s_values.emplace_back(solution);
+    /*
     double error = std::hypot(poly_x - x, poly_y - y);
     /// @note Hard coded parameter, torelance of the collision point.
-    if (error < 3) {
+    if (error < 0.1) {
       s_values.emplace_back(solution);
     }
+    */
   }
   if (s_values.empty()) {
     return boost::none;

--- a/simulation/traffic_simulator/src/math/hermite_curve.cpp
+++ b/simulation/traffic_simulator/src/math/hermite_curve.cpp
@@ -162,7 +162,6 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
   bool search_backward) const
 {
   std::vector<double> s_values;
-  // double l = std::hypot(point0.x - point1.x, point0.y - point1.y);
   double fx = point0.x;
   double ex = (point1.x - point0.x);
   double fy = point0.y;

--- a/simulation/traffic_simulator/src/math/hermite_curve.cpp
+++ b/simulation/traffic_simulator/src/math/hermite_curve.cpp
@@ -177,8 +177,6 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
     double tx = (x - point0.x) / (point1.x - point0.x);
     double y = solver_.cubicFunction(ay_, by_, cy_, dy_, solution);
     double ty = (y - point0.y) / (point1.y - point0.y);
-    // double poly_x = (1 - tx) * point1.x + tx * point0.x;
-    // double poly_y = (1 - ty) * point1.y + ty * point0.y;
     if (0 > tx || tx > 1) {
       continue;
     }
@@ -189,13 +187,6 @@ boost::optional<double> HermiteCurve::getCollisionPointIn2D(
       continue;
     }
     s_values.emplace_back(solution);
-    /*
-    double error = std::hypot(poly_x - x, poly_y - y);
-    /// @note Hard coded parameter, torelance of the collision point.
-    if (error < 0.1) {
-      s_values.emplace_back(solution);
-    }
-    */
   }
   if (s_values.empty()) {
     return boost::none;


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
Flow of the stop_at_crossing_entity action was wrong, NPC does not stops in front of the pedestrian on lane.

## How to review this PR.
Please check passing all test cases.
Regression test to this bug already included. (stop_at_crosswalk scenario in cpp_mock_test)

## Others
