### PR TITLE
Fix usage of uninitialized ZMQ API

### DIFF
--- a/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
+++ b/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
@@ -34,8 +34,8 @@ void CppScenarioNode::update()
 
 void CppScenarioNode::start()
 {
-  onInitialize();
   api_.initialize(1.0, 0.05);
+  onInitialize();
   using namespace std::chrono_literals;
   update_timer_ = this->create_wall_timer(50ms, std::bind(&CppScenarioNode::update, this));
 }


### PR DESCRIPTION
One of the onInitialize overrides uses api methods that, according to the ZMQ protocol documentation, should be called after Initialize Req/Rep.
Please consider adding a guard in the API to prevent uninitialized usage.

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

## How to review this PR.

## Others
