### PR TITLE
initialize current_time_ with negative value 

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
@@ -113,6 +113,7 @@ public:
     broadcaster_(node),
     base_link_broadcaster_(node),
     clock_ptr_(node->get_clock()),
+    current_time_(0),
     entity_status_array_pub_ptr_(rclcpp::create_publisher<EntityStatusWithTrajectoryArray>(
       node, "entity/status", EntityMarkerQoS(),
       rclcpp::PublisherOptionsWithAllocator<AllocatorT>())),


### PR DESCRIPTION
Initialize `current_time_` with 0 so `setTargetSpeed` and `setTargetVelocity` are deterministic. 

Currently, half of the times call of the `setTargetSpeed` or `setTargetVelocity` results in error:
```
You cannot set entity status to the ego vehicle name:ego after starting scenario.
```
as half of the times `getCurrentTime()` returns positive value from randomly initialized double.

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [X] Bugfix

## Link to the issue

## Description

## How to review this PR.

## Others
