### PR TITLE
Feature/remove lanelet2 from repos

### DIFF
--- a/dependency_galactic.repos
+++ b/dependency_galactic.repos
@@ -10,4 +10,3 @@ repositories:
     type: git
     url: https://github.com/tier4/pilot.auto.git
     version: ros2
-    


### PR DESCRIPTION
Signed-off-by: MasayaKataoka <ms.kataoka@gmail.com>

## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description
Lanelet2 was released in galactic distribution, so I removed lanelet2 package source form scenario_simulator_v2

## How to review this PR.
please check passing all test cases.

## Others
