### PR TITLE
Set name in the proto request for non-ego vehicles

### DIFF
--- a/simulation/traffic_simulator/src/api/api.cpp
+++ b/simulation/traffic_simulator/src/api/api.cpp
@@ -58,14 +58,15 @@ bool API::spawn(
   const bool is_ego, const std::string & name,
   const openscenario_msgs::msg::VehicleParameters & params)
 {
-  if (is_ego and
-    not entity_manager_ptr_->entityExists(name) and
+  if (
+    is_ego and not entity_manager_ptr_->entityExists(name) and
     not entity_manager_ptr_->spawnEntity<traffic_simulator::entity::EgoEntity>(
       name, configuration, clock_.getStepTime(), params)) {
     return false;
   }
-  if (not is_ego and
-      not entity_manager_ptr_->spawnEntity<traffic_simulator::entity::VehicleEntity>(name, params)) {
+  if (
+    not is_ego and
+    not entity_manager_ptr_->spawnEntity<traffic_simulator::entity::VehicleEntity>(name, params)) {
     return false;
   }
   if (configuration.standalone_mode) {


### PR DESCRIPTION
In the previous PR I forgot to set the name in all if-branches when spawning a vehicle.
Noticed that the code is largely the same for both branches, so I propose to simplify this code to avoid future mistakes like mine. The code logic should be preserved, only set_is_ego is moved after toProto() (pure subjective aesthetics), which should not affect semantics.

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

## How to review this PR.

## Others
