### PR TITLE
Add missing dependencies

### DIFF
--- a/dependency_foxy.repos
+++ b/dependency_foxy.repos
@@ -14,3 +14,11 @@ repositories:
     type: git
     url: https://github.com/tier4/AutowareArchitectureProposal_api_msgs.git
     version: main
+  lexus_description:
+    type: git
+    url: https://github.com/tier4/lexus_description.iv.universe.git
+    version: ros2
+  ouxt_common:
+    type: git
+    url: https://github.com/OUXT-Polaris/ouxt_common.git
+    version: master

--- a/dependency_galactic.repos
+++ b/dependency_galactic.repos
@@ -14,3 +14,11 @@ repositories:
     type: git
     url: https://github.com/tier4/AutowareArchitectureProposal_api_msgs.git
     version: main
+  lexus_description:
+    type: git
+    url: https://github.com/tier4/lexus_description.iv.universe.git
+    version: ros2
+  ouxt_common:
+    type: git
+    url: https://github.com/OUXT-Polaris/ouxt_common.git
+    version: master


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

When I run `rosdep install` I got the following error:
```
$ rosdep install --from-paths . --ignore-src -y
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
scenario_test_runner: Cannot locate rosdep definition for [lexus_description]
quaternion_operation: Cannot locate rosdep definition for [ouxt_lint_common]
```

Therefore, I updated the `.repos` file to import missing dependencies.

## How to review this PR.

## Others
