### PR TITLE
Fix the argument of `zmqpp::poller::poll()`

### DIFF
--- a/simulation/simulation_interface/src/zmq_multi_server.cpp
+++ b/simulation/simulation_interface/src/zmq_multi_server.cpp
@@ -138,7 +138,8 @@ MultiServer::~MultiServer() { thread_.join(); }
 
 void MultiServer::poll()
 {
-  poller_.poll(0.0001);
+  constexpr long timeout_ms = 1L;
+  poller_.poll(timeout_ms);
   if (poller_.has_input(initialize_sock_)) {
     zmqpp::message request;
     initialize_sock_.receive(request);


### PR DESCRIPTION
## Types of PR

- [X] Bugfix

## Link to the issue

## Description

The type of the argument of `poll()` is `long`, so that the current value 0.0001 is converted to 0 implicitly.

> bool zmqpp::poller::poll(long timeout = wait_forever)
<https://zeromq.github.io/zmqpp/classzmqpp_1_1poller.html#a01b41636a7851d0e1ddfdcfdf15d635b>

> If the value of timeout is 0, zmq_poll() shall return immediately.
http://api.zeromq.org/2-1:zmq-poll

I guess `timeout = 0` may increase the CPU usage slightly.

Detected by Clang-Tidy.
![image](https://user-images.githubusercontent.com/1256980/132809489-813914b3-14ee-4611-bf14-2792acec3a24.png)

## How to review this PR.

`poll(1L)` means `timeout = 1 millisecond`, but the current value 0.0001 may intend `0.1 millisecond`.
Sould I change the `1L` to `0L` or something?

## Others
