### PR TITLE
get jerk limits from ObjectController's property

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/object_controller.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/object_controller.hpp
@@ -70,9 +70,9 @@ struct ObjectController : public ComplexType
   {
     if (is<Unspecified>()) {
       static auto controller = DefaultController();
-      return controller["isEgo"];
+      return bool(controller["isEgo"]);
     } else {
-      return as<Controller>()["isEgo"];
+      return bool(as<Controller>()["isEgo"]);
     }
   }
 
@@ -85,7 +85,7 @@ struct ObjectController : public ComplexType
       }
       return controller;
     } else {
-      return as<Controller>();
+      return openscenario_msgs::msg::DriverModel(as<Controller>());
     }
   }
 };

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/property.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/property.hpp
@@ -69,7 +69,7 @@ struct Property
   {
   }
 
-  operator bool() const
+  explicit operator bool() const
   {
     if (value.empty()) {
       return Boolean();

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/scenario_object.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/scenario_object.hpp
@@ -15,6 +15,7 @@
 #ifndef OPENSCENARIO_INTERPRETER__SYNTAX__SCENARIO_OBJECT_HPP_
 #define OPENSCENARIO_INTERPRETER__SYNTAX__SCENARIO_OBJECT_HPP_
 
+#include <boost/lexical_cast.hpp>
 #include <openscenario_interpreter/procedure.hpp>
 #include <openscenario_interpreter/syntax/entity_object.hpp>
 #include <openscenario_interpreter/syntax/object_controller.hpp>
@@ -72,6 +73,20 @@ struct ScenarioObject
       configuration.max_velocity = +parameters.performance.max_speed;
       configuration.min_acceleration = -parameters.performance.max_deceleration;
       configuration.max_acceleration = +parameters.performance.max_acceleration;
+
+      if (object_controller.is<Controller>()) {
+        auto controller = object_controller.as<Controller>();
+        auto max_jerk = controller["max_jerk"];
+        auto min_jerk = controller["min_jerk"];
+
+        if (not max_jerk.name.empty()) {
+          configuration.max_jerk = boost::lexical_cast<double>(max_jerk.value);
+        }
+        if (not min_jerk.name.empty()) {
+          configuration.min_jerk = boost::lexical_cast<double>(min_jerk.value);
+        }
+      }
+
       if (object_controller.isEgo()) {
         configuration.jerk_topic =
           "/planning/scenario_planning/motion_velocity_optimizer/closest_jerk";

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/scenario_object.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/scenario_object.hpp
@@ -76,8 +76,8 @@ struct ScenarioObject
 
       if (object_controller.is<Controller>()) {
         auto controller = object_controller.as<Controller>();
-        auto max_jerk = controller["max_jerk"];
-        auto min_jerk = controller["min_jerk"];
+        auto max_jerk = controller["maxJerk"];
+        auto min_jerk = controller["minJerk"];
 
         if (not max_jerk.name.empty()) {
           configuration.max_jerk = boost::lexical_cast<double>(max_jerk.value);

--- a/test_runner/scenario_test_runner/test/scenario/autoware-simple.yaml
+++ b/test_runner/scenario_test_runner/test/scenario/autoware-simple.yaml
@@ -52,8 +52,8 @@ OpenSCENARIO:
             Properties:
               Property:
                 - { name: isEgo, value: 'true' }
-                - { name: min_jerk, value: -1.5 }
-                - { name: max_jerk, value:  1.5 }
+                - { name: minJerk, value: -1.5 }
+                - { name: maxJerk, value:  1.5 }
   Storyboard:
     Init:
       Actions:

--- a/test_runner/scenario_test_runner/test/scenario/autoware-simple.yaml
+++ b/test_runner/scenario_test_runner/test/scenario/autoware-simple.yaml
@@ -52,6 +52,8 @@ OpenSCENARIO:
             Properties:
               Property:
                 - { name: isEgo, value: 'true' }
+                - { name: min_jerk, value: -1.5 }
+                - { name: max_jerk, value:  1.5 }
   Storyboard:
     Init:
       Actions:


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
Fix to get jerk limits from ObjectController's property
Add max_jerk/min_jerk property to autoware-simple.yaml

## How to review this PR.
Please check passing all CI test

## Others
