### PR TITLE
Update Documentation.yaml

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: "3.6.14"
+          python-version: "3.6.15"
       - name: Install
         run: pip3 install mkdocs mkdocs-material pymdown-extensions mdx_unimoji fontawesome_markdown markdown python-markdown-math plantuml-markdown mkdocs-codeinclude-plugin
       - name: Install doxygen/depends of doxybook


### PR DESCRIPTION
update python version in document workflow

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

python 3.6.14 in python-setup action was already deprecated.

## How to review this PR.

## Others
