### PR TITLE
Fix/get longitudinal distance

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -10,6 +10,7 @@
 - Support new `CustomCommandAction` type `FaultInjectionAction` for ArchitectureProposal ([link](https://github.com/tier4/scenario_simulator_v2/pull/491))
 - Enable run cpp_mock_test with colcon test (with -DWITH_INTEGRATION_TEST=ON) ([link](https://github.com/tier4/scenario_simulator_v2/pull/529))
 - Support OpenSCENARIO 1.1 `DistanceCondition` ([link](https://github.com/tier4/scenario_simulator_v2/pull/533)).
+- Fix problems in getLongitudinalDistance function when the target entity does not matched to the lane. ([link](https://github.com/tier4/scenario_simulator_v2/pull/536)).
 
 ## Version 0.5.0
 - Add arrow markers to visualize goal poses of entities. (Contribution by [Utaro-M](https://github.com/Utaro-M)).

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
@@ -238,6 +238,8 @@ public:
 
   bool entityExists(const std::string & name);
 
+  bool laneMatchingSucceed(const std::string & name);
+
   // TODO (yamacir-kit) Rename to 'hasEntityStatus'
   bool entityStatusSet(const std::string & name) const;
 

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -264,6 +264,12 @@ auto EntityManager::getLongitudinalDistance(
   const std::string & from, const std::string & to, const double max_distance)
   -> boost::optional<double>
 {
+  if (!laneMatchingSucceed(from)) {
+    return boost::none;
+  }
+  if (!laneMatchingSucceed(to)) {
+    return boost::none;
+  }
   if (entityStatusSet(from)) {
     if (const auto status = getEntityStatus(from)) {
       return getLongitudinalDistance(status->lanelet_pose, to, max_distance);

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -274,6 +274,22 @@ auto EntityManager::getLongitudinalDistance(
 }
 
 /**
+ * @brief If the target entity's lanelet pose is valid, return true
+ * 
+ * @param name name of the target entity
+ * @return true lane matching is succeed
+ * @return false lane mathing is failed
+ */
+bool EntityManager::laneMatchingSucceed(const std::string & name)
+{
+  const auto status = getEntityStatus(name);
+  if (status && status->lanelet_pose_valid) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * @brief
  *
  * @param from from entity name

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -238,6 +238,9 @@ auto EntityManager::getLongitudinalDistance(
   const LaneletPose & from, const std::string & to, const double max_distance)
   -> boost::optional<double>
 {
+  if (!laneMatchingSucceed(to)) {
+    return boost::none;
+  }
   if (entityStatusSet(to)) {
     if (const auto status = getEntityStatus(to)) {
       return getLongitudinalDistance(from, status->lanelet_pose, max_distance);
@@ -251,6 +254,9 @@ auto EntityManager::getLongitudinalDistance(
   const std::string & from, const LaneletPose & to, const double max_distance)
   -> boost::optional<double>
 {
+  if (!laneMatchingSucceed(from)) {
+    return boost::none;
+  }
   if (entityStatusSet(from)) {
     if (const auto status = getEntityStatus(from)) {
       return getLongitudinalDistance(status->lanelet_pose, to, max_distance);


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

Fix problems in getLongitudinalDistance function when the target entity does not matched to the lane.

## How to review this PR.

Please check passing all test cases.

## Others
