### PR TITLE
Fix SIGABRT due to accessing uninitialized optional

### DIFF
--- a/simulation/traffic_simulator/src/metrics/out_of_range_metric.cpp
+++ b/simulation/traffic_simulator/src/metrics/out_of_range_metric.cpp
@@ -50,7 +50,7 @@ void OutOfRangeMetric::update()
 
   if (!jerk_callback_ptr_) {
     const auto jerk_opt = entity_manager_ptr_->getLinearJerk(target_entity);
-    if (!jerk_opt) {
+    if (jerk_opt) {
       linear_jerk_ = jerk_opt.get();
     }
   }


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

This PR corrects SIGABRT due to accessing optional when it's not initialized.
Below is the stack trace dumped on the SIGABRT:

```
[scenario_test_runner-1] [INFO] [1633509827.928736236] [simulation.scenario_test_runner]: Activate interpreter.
[openscenario_interpreter_node-3] [INFO] [1633509827.930880801] [simulation.openscenario_interpreter]: Activating.
[openscenario_interpreter_node-3] openscenario_interpreter_node: /usr/include/boost/optional/optional.hpp:1206: boost::optional<T>::reference_const_type boost::optional<T>::get() const [with T = double; boost::optional<T>::reference_const_type = const double&]: Assertion `this->is_initialized()' failed.
[openscenario_interpreter_node-3] *** Aborted at 1633509828 (unix time) try "date -d @1633509828" if you are using GNU date ***
[openscenario_interpreter_node-3] PC: @     0x7fcc40df518b gsignal
[openscenario_interpreter_node-3] *** SIGABRT (@0x92d2) received by PID 37586 (TID 0x7fcc3e4811c0) from PID 37586; stack trace: ***
[openscenario_interpreter_node-3]     @     0x7fcc411b8631 (unknown)
[openscenario_interpreter_node-3]     @     0x7fcc40df5210 (unknown)
[openscenario_interpreter_node-3]     @     0x7fcc40df518b gsignal
[openscenario_interpreter_node-3]     @     0x7fcc40dd4859 abort
[openscenario_interpreter_node-3]     @     0x7fcc40dd4729 (unknown)
[openscenario_interpreter_node-3]     @     0x7fcc40de5f36 __assert_fail
[openscenario_interpreter_node-3]     @     0x7fcc41cebe8d boost::optional<>::get()
[openscenario_interpreter_node-3]     @     0x7fcc401fcdad metrics::OutOfRangeMetric::update()
[openscenario_interpreter_node-3]     @     0x7fcc401e7982 metrics::MetricsManager::calculate()
[openscenario_interpreter_node-3]     @     0x7fcc3fe2b8b2 traffic_simulator::API::updateFrame()
[openscenario_interpreter_node-3]     @     0x7fcc41ccdad0 _ZN24openscenario_interpreter11updateFrameIJEEEDcDpOT_
[openscenario_interpreter_node-3]     @     0x7fcc41ccdb43 openscenario_interpreter::syntax::ScenarioDefinition::evaluate()
[openscenario_interpreter_node-3]     @     0x7fcc41e5a184 openscenario_interpreter::type_traits::IfHasMemberFunctionEvaluate<>::invoke<>()
[openscenario_interpreter_node-3]     @     0x7fcc41e4fb02 openscenario_interpreter::Pointer<>::Binder<>::evaluate()
[openscenario_interpreter_node-3]     @     0x7fcc41cc65ae _ZNK24openscenario_interpreter7PointerINS_10ExpressionEE8evaluateIJEEEDcDpOT_
[openscenario_interpreter_node-3]     @     0x7fcc41ccdee9 openscenario_interpreter::syntax::OpenScenario::evaluate()
[openscenario_interpreter_node-3]     @     0x7fcc41caab1e _ZZZZN24openscenario_interpreter11Interpreter11on_activateERKN16rclcpp_lifecycle5StateEENKUlvE_clEvENKUlvE0_clEvENKUlvE_clEv
[openscenario_interpreter_node-3]     @     0x7fcc41cad725 _ZN24openscenario_interpreter7utility14ExecutionTimerINSt6chrono3_V212system_clockEE6invokeIZZZNS_11Interpreter11on_activateERKN16rclcpp_lifecycle5StateEENKUlvE_clEvENKUlvE0_clEvEUlvE_JEEENSt9enable_ifIXsrSt7is_sameINSt9result_ofIFT_DpT0_EE4typeEbE5valueENS2_8durationIlSt5ratioILl1ELl1000000000EEEEE4typeERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEOSI_DpOSJ_
[openscenario_interpreter_node-3]     @     0x7fcc41caac36 _ZZZN24openscenario_interpreter11Interpreter11on_activateERKN16rclcpp_lifecycle5StateEENKUlvE_clEvENKUlvE0_clEv
[openscenario_interpreter_node-3]     @     0x7fcc41cab405 _ZN24openscenario_interpreter11Interpreter20withExceptionHandlerIZZNS0_11on_activateERKN16rclcpp_lifecycle5StateEENKUlvE_clEvEUlDpOT_E_ZZNS0_11on_activateES5_ENKS6_clEvEUlvE0_EEDcOT_OT0_
[openscenario_interpreter_node-3]     @     0x7fcc41cab993 _ZZN24openscenario_interpreter11Interpreter11on_activateERKN16rclcpp_lifecycle5StateEENKUlvE_clEv
[openscenario_interpreter_node-3]     @     0x7fcc41cb2d28 _ZN6rclcpp12GenericTimerIZN24openscenario_interpreter11Interpreter11on_activateERKN16rclcpp_lifecycle5StateEEUlvE_LPv0EE25execute_callback_delegateIS7_LS8_0EEEvv
[openscenario_interpreter_node-3]     @     0x7fcc41cb2c66 _ZN6rclcpp12GenericTimerIZN24openscenario_interpreter11Interpreter11on_activateERKN16rclcpp_lifecycle5StateEEUlvE_LPv0EE16execute_callbackEv
[openscenario_interpreter_node-3]     @     0x7fcc4210c59d rclcpp::Executor::execute_any_executable()
[openscenario_interpreter_node-3]     @     0x7fcc421118bc rclcpp::executors::SingleThreadedExecutor::spin()
[openscenario_interpreter_node-3]     @     0x555cbe025b28 main
[openscenario_interpreter_node-3]     @     0x7fcc40dd60b3 __libc_start_main
[openscenario_interpreter_node-3]     @     0x555cbe02581e _start
[ERROR] [openscenario_interpreter_node-3]: process has died [pid 37586, exit code -6, cmd '/home/ubuntu/Desktop/scenario_simulator_ws/install/openscenario_interpreter/lib/openscenario_interpreter/openscenario_interpreter_node --ros-args -r __node:=openscenario_interpreter -r __ns:=/simulation --params-file /tmp/launch_params_qlwmm_3e --params-file /tmp/launch_params_l4audnz6 --params-file /tmp/launch_params_igu1cuxp --params-file /tmp/launch_params_dndhjc7u --params-file /tmp/launch_params_o3zia_oz --params-file /tmp/launch_params_7ug86u9t --params-file /tmp/launch_params_77pqv13r --params-file /tmp/launch_params_vgl4vm7i --params-file /tmp/launch_params_wigoc8__ --params-file /home/ubuntu/Desktop/scenario_simulator_ws/install/lexus_description/share/lexus_description/config/vehicle_info.param.yaml --params-file /home/ubuntu/Desktop/scenario_simulator_ws/install/lexus_description/share/lexus_description/config/simulator_model.param.yaml']
```

## How to review this PR.

It looks like a typo, but it would be good to check if the surrounding logic is still correct.

## Others
