### PR TITLE
Fixed error in RVIZ2 config path in launch file

### DIFF
--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -183,7 +183,8 @@ def launch_setup(context, *args, **kwargs):
             arguments=[
                 "-d",
                 str(
-                    Path(get_package_share_directory("scenario_test_runner"))
+                    # Path(get_package_share_directory("scenario_test_runner"))
+                    Path(get_package_share_directory("traffic_simulator"))
                     / "config/scenario_simulator_v2.rviz"
                 ),
             ],


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
RVIZ2 does not run with the correct configuration because the path in `scenario_test_runner.launch.py` is incorrect.

## How to review this PR.

Execute the following with the old `scenario_test_runner.launch.py`. RVIZ2 will show with whatever the default config is.
```
ros2 launch scenario_test_runner scenario_test_runner.launch.py scenario:='<PATH-TO-SOME-SCENARIO-FILE.yaml>' launch_rviz:=true
```
Result:
![image](https://user-images.githubusercontent.com/16696954/138427356-285ccaeb-0253-41e5-a0e3-1beef9aad8eb.png)

Apply the correction above and RVIZ2 will start with the correct configuration, according to the launch file anyway.

![image](https://user-images.githubusercontent.com/16696954/138427540-9de724dc-ba43-4c6c-803d-3aa413c34997.png)

## Others
