### PR TITLE
Limit overrides by final keyword rather than comments

### DIFF
--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
@@ -65,8 +65,7 @@ public:
   /// throws if the derived class return RUNNING.
   BT::NodeStatus executeTick() override;
 
-  /// You don't need to override this
-  void halt() override { setStatus(BT::NodeStatus::IDLE); }
+  void halt() override final { setStatus(BT::NodeStatus::IDLE); }
 
   static BT::PortsList providedPorts()
   {


### PR DESCRIPTION
## Types of PR
**refactoring**
- [ ] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix


## Link to the issue

## Description
Marked the function that you don't want to override(ActionNode::halt ) with the final keyword
This change prohibits overriding in inherited classes as a language specification with final keyword

## How to review this PR.

## Others
