### PR TITLE
remove current_action_ member variable from inherit class

### DIFF
--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/transition_events/logging_event.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/transition_events/logging_event.hpp
@@ -32,7 +32,6 @@ private:
     BT::Duration timestamp, const BT::TreeNode & node, BT::NodeStatus prev_status,
     BT::NodeStatus status) override;
   rclcpp::Logger ros_logger_;
-  std::string current_action_;
 };
 }  // namespace behavior_tree_plugin
 


### PR DESCRIPTION
Signed-off-by: MasayaKataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

#615 

## Description

remove current_action_ member variable from inherit class

## How to review this PR.

Please check passing all test cases.

## Others
