### PR TITLE
Traffic lights to stop line lookup fix

### DIFF
--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -1206,7 +1206,7 @@ lanelet::AutowareTrafficLightConstPtr HdMapUtils::getTrafficLight(
     for (auto light_string : light->lightBulbs()) {
       if (light_string.hasAttribute("traffic_light_id")) {
         auto id = light_string.attribute("traffic_light_id").asId();
-        if (id) {
+        if (id == traffic_light_id) {
           return light;
         }
       }


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
n/a

## Description
Traffic light lookup fix, otherwise it returned the first traffic light that had "traffic_light_id" attribute

## How to review this PR.

## Others
