### PR TITLE
remove hard coded parameters in behavior tree plugin and use accelear…

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,6 +4,7 @@
 - Remove newton methods in getSValue function. ([link](https://github.com/tier4/scenario_simulator_v2/pull/612))
 - Set withLaneChange parameter as false. ([link](https://github.com/tier4/scenario_simulator_v2/pull/618))
 - Change traffic light topic name to "/perception/traffic_light_recognition/traffic_light_states" ([link](https://github.com/tier4/scenario_simulator_v2/pull/621))
+- Remove hard coded parameters in behavior tree plugin and use accelearaion and deceleration value in traffic_simulator_msgs/msg/DriverModel. ([link](https://github.com/tier4/scenario_simulator_v2/pull/624))
 
 ## Version 0.5.7
 - Fix problem in getNormalVector function. (Contribution by [Utaro-M](https://github.com/Utaro-M)).

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,7 +4,7 @@
 - Remove newton methods in getSValue function. ([link](https://github.com/tier4/scenario_simulator_v2/pull/612))
 - Set withLaneChange parameter as false. ([link](https://github.com/tier4/scenario_simulator_v2/pull/618))
 - Change traffic light topic name to "/perception/traffic_light_recognition/traffic_light_states" ([link](https://github.com/tier4/scenario_simulator_v2/pull/621))
-- Remove hard coded parameters in behavior tree plugin and use accelearaion and deceleration value in traffic_simulator_msgs/msg/DriverModel. ([link](https://github.com/tier4/scenario_simulator_v2/pull/624))
+- Remove hard coded parameters in behavior tree plugin and use acceleration and deceleration value in traffic_simulator_msgs/msg/DriverModel. ([link](https://github.com/tier4/scenario_simulator_v2/pull/624))
 - Enable build with foxy latest version of behavior_tree_cpp_v3. ([link](https://github.com/tier4/scenario_simulator_v2/pull/625))
 
 ## Version 0.5.7

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
@@ -78,7 +78,7 @@ boost::optional<double> StopAtCrossingEntityAction::calculateTargetSpeed(double 
     distance_to_stop_target_.get() - (vehicle_parameters.bounding_box.dimensions.x + 3);
   if (rest_distance < calculateStopDistance()) {
     if (rest_distance > 0) {
-      return std::sqrt(2 * 5 * rest_distance);
+      return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {
       return 0;
     }

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
@@ -80,7 +80,7 @@ boost::optional<double> StopAtStopLineAction::calculateTargetSpeed(double curren
     distance_to_stopline_.get() - (vehicle_parameters.bounding_box.dimensions.x);
   if (rest_distance < calculateStopDistance()) {
     if (rest_distance > 0) {
-      return std::sqrt(2 * 5 * rest_distance);
+      return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {
       return 0;
     }

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
@@ -77,7 +77,7 @@ boost::optional<double> StopAtTrafficLightAction::calculateTargetSpeed(double cu
     distance_to_stop_target_.get() - (vehicle_parameters.bounding_box.dimensions.x + 3);
   if (rest_distance < calculateStopDistance()) {
     if (rest_distance > 0) {
-      return std::sqrt(2 * 5 * rest_distance);
+      return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {
       return 0;
     }

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/yield_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/yield_action.cpp
@@ -78,7 +78,7 @@ boost::optional<double> YieldAction::calculateTargetSpeed()
     distance_to_stop_target_.get() - (vehicle_parameters.bounding_box.dimensions.x) - 10;
   if (rest_distance < calculateStopDistance()) {
     if (rest_distance > 0) {
-      return std::sqrt(2 * 5 * rest_distance);
+      return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {
       return 0;
     }

--- a/simulation/behavior_tree_plugin/src/vehicle/vehicle_action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/vehicle_action_node.cpp
@@ -45,9 +45,9 @@ traffic_simulator_msgs::msg::EntityStatus VehicleActionNode::calculateEntityStat
   accel_new = entity_status.action_status.accel;
   double target_accel = (target_speed - entity_status.action_status.twist.linear.x) / step_time;
   if (entity_status.action_status.twist.linear.x > target_speed) {
-    target_accel = boost::algorithm::clamp(target_accel, -5, 0);
+    target_accel = boost::algorithm::clamp(target_accel, driver_model.deceleration * -1, 0);
   } else {
-    target_accel = boost::algorithm::clamp(target_accel, 0, 3);
+    target_accel = boost::algorithm::clamp(target_accel, 0, driver_model.acceleration);
   }
   accel_new.linear.x = target_accel;
   geometry_msgs::msg::Twist twist_new;


### PR DESCRIPTION
remove hard coded parameters in behavior tree plugin and use accelearaion and deceleration value in traffic_simulator_msgs/msg/DriverModel

Signed-off-by: MasayaKataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

remove hard coded parameters in behavior tree plugin and use accelearaion and deceleration value in traffic_simulator_msgs/msg/DriverModel

## How to review this PR.

Please check passing all test cases.

## Others
