### PR TITLE
disable throw errors while calling setDriverModel error

### DIFF
--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -121,7 +121,7 @@ auto EntityBase::getDriverModel() -> const traffic_simulator_msgs::msg::DriverMo
 
 void EntityBase::setDriverModel(const traffic_simulator_msgs::msg::DriverModel &)
 {
-  THROW_SIMULATION_ERROR("setDriverModel function can be used with only ego/vehicle entity.");
+  // THROW_SIMULATION_ERROR("setDriverModel function can be used with only ego/vehicle entity.");
 }
 }  // namespace entity
 }  // namespace traffic_simulator


### PR DESCRIPTION
Signed-off-by: MasayaKataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

disable throw errors while calling setDriverModel error

## How to review this PR.

Please check passing all test cases.

## Others
