### PR TITLE
enable call getDriverModel function in pedestrian entity.

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
@@ -93,7 +93,7 @@ public:
 
   auto getCurrentAction() const -> const std::string override;
 
-  auto getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel override;
+  auto getDriverModel() const -> traffic_simulator_msgs::msg::DriverModel override;
 
   auto getEntityStatus(const double, const double) const
     -> const traffic_simulator_msgs::msg::EntityStatus;

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -93,7 +93,7 @@ public:
 
   virtual auto getGoalPoses() -> std::vector<traffic_simulator_msgs::msg::LaneletPose> = 0;
 
-  virtual auto getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel = 0;
+  virtual auto getDriverModel() const -> traffic_simulator_msgs::msg::DriverModel = 0;
 
   virtual void setDriverModel(const traffic_simulator_msgs::msg::DriverModel &) = 0;
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -93,9 +93,9 @@ public:
 
   virtual auto getGoalPoses() -> std::vector<traffic_simulator_msgs::msg::LaneletPose> = 0;
 
-  virtual auto getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel;
+  virtual auto getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel = 0;
 
-  virtual void setDriverModel(const traffic_simulator_msgs::msg::DriverModel &);
+  virtual void setDriverModel(const traffic_simulator_msgs::msg::DriverModel &) = 0;
 
   virtual void setAccelerationLimit(double acceleration);
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/misc_object_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/misc_object_entity.hpp
@@ -81,7 +81,7 @@ public:
     THROW_SEMANTIC_ERROR("requestAcquirePosition function cannot not use in MiscObjectEntity");
   }
 
-  auto getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel override;
+  auto getDriverModel() const -> traffic_simulator_msgs::msg::DriverModel override;
 
   void setDriverModel(const traffic_simulator_msgs::msg::DriverModel &) override;
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/misc_object_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/misc_object_entity.hpp
@@ -81,6 +81,10 @@ public:
     THROW_SEMANTIC_ERROR("requestAcquirePosition function cannot not use in MiscObjectEntity");
   }
 
+  auto getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel override;
+
+  void setDriverModel(const traffic_simulator_msgs::msg::DriverModel &) override;
+
 private:
   const traffic_simulator_msgs::msg::MiscObjectParameters params_;
 };

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
@@ -98,6 +98,10 @@ public:
     return parameters.bounding_box;
   }
 
+  auto getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel;
+
+  void setDriverModel(const traffic_simulator_msgs::msg::DriverModel &);
+
   void requestAssignRoute(
     const std::vector<traffic_simulator_msgs::msg::LaneletPose> & waypoints) override;
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
@@ -98,7 +98,7 @@ public:
     return parameters.bounding_box;
   }
 
-  auto getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel;
+  auto getDriverModel() const -> traffic_simulator_msgs::msg::DriverModel;
 
   void setDriverModel(const traffic_simulator_msgs::msg::DriverModel &);
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
@@ -93,7 +93,7 @@ public:
 
   void setDecelerationLimit(double deceleration) override;
 
-  auto getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel override;
+  auto getDriverModel() const -> traffic_simulator_msgs::msg::DriverModel override;
 
   void setHdMapUtils(const std::shared_ptr<hdmap_utils::HdMapUtils> & ptr) override
   {

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -213,7 +213,7 @@ auto EgoEntity::getCurrentAction() const -> const std::string
   return state.empty() ? "Launching" : state;
 }
 
-auto EgoEntity::getDriverModel() const-> traffic_simulator_msgs::msg::DriverModel
+auto EgoEntity::getDriverModel() const -> traffic_simulator_msgs::msg::DriverModel
 {
   traffic_simulator_msgs::msg::DriverModel model;
   /**

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -213,7 +213,7 @@ auto EgoEntity::getCurrentAction() const -> const std::string
   return state.empty() ? "Launching" : state;
 }
 
-auto EgoEntity::getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel
+auto EgoEntity::getDriverModel() const-> traffic_simulator_msgs::msg::DriverModel
 {
   traffic_simulator_msgs::msg::DriverModel model;
   /**

--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -114,16 +114,6 @@ void EntityBase::stopAtEndOfRoad()
   }
 }
 
-auto EntityBase::getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel
-{
-  THROW_SIMULATION_ERROR("getDriverModel function can be used with only ego/vehicle entity.");
-}
-
-void EntityBase::setDriverModel(const traffic_simulator_msgs::msg::DriverModel &)
-{
-  // THROW_SIMULATION_ERROR("setDriverModel function can be used with only ego/vehicle entity.");
-}
-
 void EntityBase::setAccelerationLimit(double)
 {
   THROW_SIMULATION_ERROR("setAccelerationLimit function can be used with only ego/vehicle entity.");

--- a/simulation/traffic_simulator/src/entity/misc_object_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/misc_object_entity.cpp
@@ -50,7 +50,7 @@ auto MiscObjectEntity::getCurrentAction() const -> const std::string
   return "";
 }
 
-auto MiscObjectEntity::getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel
+auto MiscObjectEntity::getDriverModel() const -> traffic_simulator_msgs::msg::DriverModel
 {
   THROW_SEMANTIC_ERROR("getDriverModel function does not support in MiscObjectEntity.");
 }

--- a/simulation/traffic_simulator/src/entity/misc_object_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/misc_object_entity.cpp
@@ -49,5 +49,15 @@ auto MiscObjectEntity::getCurrentAction() const -> const std::string
   }
   return "";
 }
+
+auto MiscObjectEntity::getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel
+{
+  THROW_SEMANTIC_ERROR("getDriverModel function does not support in MiscObjectEntity.");
+}
+
+void MiscObjectEntity::setDriverModel(const traffic_simulator_msgs::msg::DriverModel &)
+{
+  THROW_SEMANTIC_ERROR("setDriverModel function does not support in MiscObjectEntity.");
+}
 }  // namespace entity
 }  // namespace traffic_simulator

--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -109,6 +109,16 @@ void PedestrianEntity::setTargetSpeed(double target_speed, bool continuous)
   target_speed_planner_.setTargetSpeed(target_speed, continuous);
 }
 
+auto PedestrianEntity::getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel
+{
+  return behavior_plugin_ptr_->getDriverModel();
+}
+
+void PedestrianEntity::setDriverModel(const traffic_simulator_msgs::msg::DriverModel & driver_model)
+{
+  setDriverModel(driver_model);
+}
+
 void PedestrianEntity::onUpdate(double current_time, double step_time)
 {
   EntityBase::onUpdate(current_time, step_time);

--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -109,7 +109,7 @@ void PedestrianEntity::setTargetSpeed(double target_speed, bool continuous)
   target_speed_planner_.setTargetSpeed(target_speed, continuous);
 }
 
-auto PedestrianEntity::getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel
+auto PedestrianEntity::getDriverModel() const -> traffic_simulator_msgs::msg::DriverModel
 {
   return behavior_plugin_ptr_->getDriverModel();
 }

--- a/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
@@ -106,7 +106,7 @@ void VehicleEntity::setTargetSpeed(double target_speed, bool continuous)
   target_speed_planner_.setTargetSpeed(target_speed, continuous);
 }
 
-auto VehicleEntity::getDriverModel() -> const traffic_simulator_msgs::msg::DriverModel
+auto VehicleEntity::getDriverModel() const -> traffic_simulator_msgs::msg::DriverModel
 {
   return behavior_plugin_ptr_->getDriverModel();
 }


### PR DESCRIPTION
Signed-off-by: MasayaKataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description

enable call getDriverModel function in pedestrian entity.

## How to review this PR.

Please check passing all test cases.

## Others
