### PR TITLE
set default driver model in pedestrian entity class

### DIFF
--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -117,7 +117,7 @@ auto PedestrianEntity::getDriverModel() const -> traffic_simulator_msgs::msg::Dr
 
 void PedestrianEntity::setDriverModel(const traffic_simulator_msgs::msg::DriverModel & driver_model)
 {
-  setDriverModel(driver_model);
+  behavior_plugin_ptr_->setDriverModel(driver_model);
 }
 
 void PedestrianEntity::onUpdate(double current_time, double step_time)

--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -38,6 +38,7 @@ PedestrianEntity::PedestrianEntity(
   behavior_plugin_ptr_->configure(rclcpp::get_logger(name));
   behavior_plugin_ptr_->setPedestrianParameters(parameters);
   behavior_plugin_ptr_->setDebugMarker({});
+  behavior_plugin_ptr_->setDriverModel(traffic_simulator_msgs::msg::DriverModel());
 }
 
 void PedestrianEntity::appendDebugMarker(visualization_msgs::msg::MarkerArray & marker_array)


### PR DESCRIPTION
Signed-off-by: MasayaKataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description

For backward compatibility, enable get drier model from pedestrian entity. 

## How to review this PR.

## Others
