### PR TITLE
Fix/lane change trajectory shape

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -9,6 +9,7 @@
 - Enable control multiple traffic lights by relation ID from lanelet2 map. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/667)).
 - Start supporting requestSpeedChange API in pedestrian. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/670)).
 - Update syntax `LaneChangeAction` to use `API::requestLaneChange` ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/668)).
+- Fix logic in calculating lane change trajectory shape. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/671)).
 
 ## Version 0.6.1
 - Add API::requestSpeedChange function. ([link](https://github.com/tier4/scenario_simulator_v2/pull/618))

--- a/mock/cpp_mock_scenarios/src/lane_change/CMakeLists.txt
+++ b/mock/cpp_mock_scenarios/src/lane_change/CMakeLists.txt
@@ -28,6 +28,11 @@ ament_auto_add_executable(lanechange_linear_time
 )
 target_link_libraries(lanechange_linear_time cpp_scenario_node)
 
+ament_auto_add_executable(lanechange_longitudinal_distance
+  lanechange_longitudinal_distance.cpp
+)
+target_link_libraries(lanechange_longitudinal_distance cpp_scenario_node)
+
 ament_auto_add_executable(lanechange_linear_lateral_velocity
   lanechange_linear_lateral_velocity.cpp
 )
@@ -44,6 +49,7 @@ install(TARGETS
   lanechange_linear
   lanechange_linear_lateral_velocity
   lanechange_linear_time
+  lanechange_longitudinal_distance
   lanechange_right
   lanechange_right_with_id
   lanechange_time
@@ -57,6 +63,7 @@ if(BUILD_TESTING)
   add_cpp_mock_scenario_test(${PROJECT_NAME} "lanechange_linear_lateral_velocity" "15.0")
   add_cpp_mock_scenario_test(${PROJECT_NAME} "lanechange_linear_time" "30.0")
   add_cpp_mock_scenario_test(${PROJECT_NAME} "lanechange_linear" "15.0")
+  add_cpp_mock_scenario_test(${PROJECT_NAME} "lanechange_longitudinal_distance" "15.0")
   add_cpp_mock_scenario_test(${PROJECT_NAME} "lanechange_right_with_id" "15.0")
   add_cpp_mock_scenario_test(${PROJECT_NAME} "lanechange_right" "15.0")
   add_cpp_mock_scenario_test(${PROJECT_NAME} "lanechange_time" "30.0")

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_longitudinal_distance.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_longitudinal_distance.cpp
@@ -1,0 +1,74 @@
+// Copyright 2015-2020 Tier IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <quaternion_operation/quaternion_operation.h>
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <cpp_mock_scenarios/catalogs.hpp>
+#include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <traffic_simulator/api/api.hpp>
+#include <traffic_simulator_msgs/msg/driver_model.hpp>
+
+// headers in STL
+#include <memory>
+#include <string>
+#include <vector>
+
+class LaneChangeLeftScenario : public cpp_mock_scenarios::CppScenarioNode
+{
+public:
+  explicit LaneChangeLeftScenario(const rclcpp::NodeOptions & option)
+  : cpp_mock_scenarios::CppScenarioNode(
+      "lanechange_left", ament_index_cpp::get_package_share_directory("kashiwanoha_map") + "/map",
+      "lanelet2_map.osm", __FILE__, false, option)
+  {
+    start();
+  }
+
+private:
+  bool requested = false;
+  bool lanechange_finished = false;
+  void onUpdate() override
+  {
+    if (api_.isInLanelet("ego", 34513, 0.1)) {
+      stop(cpp_mock_scenarios::Result::SUCCESS);
+    }
+  }
+  void onInitialize() override
+  {
+    api_.spawn("ego", getVehicleParameters());
+    api_.setEntityStatus(
+      "ego", traffic_simulator::helper::constructLaneletPose(34462, 10, 0, 0, 0, 0),
+      traffic_simulator::helper::constructActionStatus(1));
+    api_.requestSpeedChange("ego", 1, true);
+    api_.requestLaneChange(
+      "ego",
+      traffic_simulator::lane_change::RelativeTarget(
+        "ego", traffic_simulator::lane_change::Direction::LEFT, 1, 0),
+      traffic_simulator::lane_change::TrajectoryShape::CUBIC,
+      traffic_simulator::lane_change::Constraint(
+        traffic_simulator::lane_change::Constraint::Type::LONGITUDINAL_DISTANCE, 3.0));
+  }
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::NodeOptions options;
+  auto component = std::make_shared<LaneChangeLeftScenario>(options);
+  rclcpp::spin(component);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/simulation/behavior_tree_plugin/src/vehicle/lane_change_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/lane_change_action.cpp
@@ -108,8 +108,6 @@ BT::NodeStatus LaneChangeAction::tick()
         return BT::NodeStatus::FAILURE;
       }
       boost::optional<std::pair<traffic_simulator::math::HermiteCurve, double>> traj_with_goal;
-      double tangent_vector_size =
-        boost::algorithm::clamp(10.0, 30.0, entity_status.action_status.twist.linear.x * 30);
       traffic_simulator_msgs::msg::LaneletPose along_pose, goal_pose;
       switch (lane_change_parameters_->constraint.type) {
         case traffic_simulator::lane_change::Constraint::Type::NONE:
@@ -122,20 +120,20 @@ BT::NodeStatus LaneChangeAction::tick()
           break;
         case traffic_simulator::lane_change::Constraint::Type::LATERAL_VELOCITY:
           traj_with_goal = hdmap_utils->getLaneChangeTrajectory(
-            entity_status.lanelet_pose, lane_change_parameters_.get(), tangent_vector_size);
+            entity_status.lanelet_pose, lane_change_parameters_.get());
           along_pose = hdmap_utils->getAlongLaneletPose(
             entity_status.lanelet_pose,
             traffic_simulator::lane_change::Parameter::default_lanechange_distance);
           break;
         case traffic_simulator::lane_change::Constraint::Type::LONGITUDINAL_DISTANCE:
           traj_with_goal = hdmap_utils->getLaneChangeTrajectory(
-            entity_status.lanelet_pose, lane_change_parameters_.get(), tangent_vector_size);
+            entity_status.lanelet_pose, lane_change_parameters_.get());
           along_pose = hdmap_utils->getAlongLaneletPose(
             entity_status.lanelet_pose, lane_change_parameters_->constraint.value);
           break;
         case traffic_simulator::lane_change::Constraint::Type::TIME:
           traj_with_goal = hdmap_utils->getLaneChangeTrajectory(
-            entity_status.lanelet_pose, lane_change_parameters_.get(), tangent_vector_size);
+            entity_status.lanelet_pose, lane_change_parameters_.get());
           along_pose = hdmap_utils->getAlongLaneletPose(
             entity_status.lanelet_pose, lane_change_parameters_->constraint.value);
           break;

--- a/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
@@ -119,8 +119,7 @@ public:
   bool canChangeLane(std::int64_t from_lanelet_id, std::int64_t to_lanelet_id);
   boost::optional<std::pair<traffic_simulator::math::HermiteCurve, double>> getLaneChangeTrajectory(
     const traffic_simulator_msgs::msg::LaneletPose & from_pose,
-    const traffic_simulator::lane_change::Parameter & lane_change_parameter,
-    double tangent_vector_size);
+    const traffic_simulator::lane_change::Parameter & lane_change_parameter);
   boost::optional<std::pair<traffic_simulator::math::HermiteCurve, double>> getLaneChangeTrajectory(
     const geometry_msgs::msg::Pose & from_pose,
     const traffic_simulator::lane_change::Parameter & lane_change_parameter,

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -922,8 +922,7 @@ traffic_simulator_msgs::msg::LaneletPose HdMapUtils::getAlongLaneletPose(
 boost::optional<std::pair<traffic_simulator::math::HermiteCurve, double>>
 HdMapUtils::getLaneChangeTrajectory(
   const traffic_simulator_msgs::msg::LaneletPose & from_pose,
-  const traffic_simulator::lane_change::Parameter & lane_change_parameter,
-  double tangent_vector_size)
+  const traffic_simulator::lane_change::Parameter & lane_change_parameter)
 {
   double longitudinal_distance =
     traffic_simulator::lane_change::Parameter::default_lanechange_distance;
@@ -957,9 +956,16 @@ HdMapUtils::getLaneChangeTrajectory(
   const auto to_pose = traffic_simulator::helper::constructLaneletPose(
     lane_change_parameter.target.lanelet_id, collision_point.get(),
     lane_change_parameter.target.offset);
+  const auto goal_pose_in_map = toMapPose(to_pose).pose;
+  const auto from_pose_in_map = toMapPose(from_pose).pose;
+  double start_to_goal_distance = std::sqrt(
+    std::pow(from_pose_in_map.position.x - goal_pose_in_map.position.x, 2) +
+    std::pow(from_pose_in_map.position.y - goal_pose_in_map.position.y, 2) +
+    std::pow(from_pose_in_map.position.z - goal_pose_in_map.position.z, 2));
+
   auto traj = getLaneChangeTrajectory(
     toMapPose(from_pose).pose, to_pose, lane_change_parameter.trajectory_shape,
-    tangent_vector_size);
+    start_to_goal_distance * 0.5);
   return std::make_pair(traj, collision_point.get());
 }
 


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

fix logic in calculating lane change trajectory shape.
In previous version, if you want to change headings rapidly, trajectory with backward was generated.

https://user-images.githubusercontent.com/10348912/150288060-83147d0c-2ad0-4f9f-a847-1148b3c794c8.mp4

https://user-images.githubusercontent.com/10348912/150288067-4ea74c1c-e9e4-4483-8772-9ae7b36455b4.mp4

## How to review this PR.

Please check passing all CI test cases.

## Others
