### PR TITLE
fix: no perform method in str object

### DIFF
--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -37,7 +37,7 @@ def architecture_types():
 def default_autoware_launch_package_of(architecture_type):
     if architecture_type not in architecture_types():
         raise KeyError(
-            f"architecture_type := {architecture_type.perform(context)} is not supported. Choose one of {architecture_types()}."
+            f"architecture_type := {architecture_type} is not supported. Choose one of {architecture_types()}."
         )
     return {
         "awf/universe": "autoware_launch",
@@ -47,7 +47,7 @@ def default_autoware_launch_package_of(architecture_type):
 def default_autoware_launch_file_of(architecture_type):
     if architecture_type not in architecture_types():
         raise KeyError(
-            f"architecture_type := {architecture_type.perform(context)} is not supported. Choose one of {architecture_types()}."
+            f"architecture_type := {architecture_type} is not supported. Choose one of {architecture_types()}."
         )
     return {
         "awf/universe": "planning_simulator.launch.xml",


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

```
Traceback (most recent call last):
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/launch_service.py", line 228, in _process_one_event
    await self.__process_event(next_event)
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/launch_service.py", line 248, in __process_event
    visit_all_entities_and_collect_futures(entity, self.__context))
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures
    futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures
    futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 45, in visit_all_entities_and_collect_futures
    futures_to_return += visit_all_entities_and_collect_futures(sub_entity, context)
  [Previous line repeated 1 more time]
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/utilities/visit_all_entities_and_collect_futures_impl.py", line 38, in visit_all_entities_and_collect_futures
    sub_entities = entity.visit(context)
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/action.py", line 108, in visit
    return self.execute(context)
  File "/opt/ros/galactic/lib/python3.8/site-packages/launch/actions/opaque_function.py", line 75, in execute
    return self.__function(context, *self.__args, **self.__kwargs)
  File "/home/autoware/autoware.proj/install/scenario_test_runner/share/scenario_test_runner/launch/scenario_test_runner.launch.py", line 60, in launch_setup
    autoware_launch_file    = LaunchConfiguration("autoware_launch_file",    default=default_autoware_launch_file_of(architecture_type.perform(context)))
  File "/home/autoware/autoware.proj/install/scenario_test_runner/share/scenario_test_runner/launch/scenario_test_runner.launch.py", line 50, in default_autoware_launch_file_of
    f"architecture_type := {architecture_type.perform(context)} is not supported. Choose one of {architecture_types()}."
AttributeError: 'str' object has no attribute 'perform'
```

An error occurred when entering an unsupported architecture_type.
fix it.

## How to review this PR.
Enter an unsupported architecture_type and make sure no error occurs.

## Others
