### PR TITLE
check yaw difference

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -5,6 +5,8 @@
 - Fix problem in warping NPCs spawned in world coordinate. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/686))
 - End of support for ROS2 Foxy and Autoware.Auto ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/696)).
 - Fix problem in ideal steer acc geard dynamics model. Vehicle was pulled back very slowly even if the vehicle is stopped. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/698))
+- Fix problem in igetFrontEntityName function, consider yaw difference while stopping at crossing entity. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/703))
+
 
 ## Version 0.6.2
 - Start supporting linear trajectory shape while changing lane. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/661))

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -5,7 +5,7 @@
 - Fix problem in warping NPCs spawned in world coordinate. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/686))
 - End of support for ROS2 Foxy and Autoware.Auto ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/696)).
 - Fix problem in ideal steer acc geard dynamics model. Vehicle was pulled back very slowly even if the vehicle is stopped. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/698))
-- Fix problem in igetFrontEntityName function, consider yaw difference while stopping at crossing entity. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/703))
+- Fix problem in getFrontEntityName function, consider yaw difference while stopping at crossing entity. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/703))
 
 
 ## Version 0.6.2

--- a/simulation/behavior_tree_plugin/CMakeLists.txt
+++ b/simulation/behavior_tree_plugin/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rclcpp REQUIRED)
 find_package(traffic_simulator REQUIRED)
 find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(pluginlib REQUIRED)
+find_package(quaternion_operation REQUIRED)
 
 add_library(behavior_tree_plugin SHARED
   src/action_node.cpp
@@ -44,6 +45,7 @@ ament_target_dependencies(behavior_tree_plugin
   traffic_simulator
   behaviortree_cpp_v3
   pluginlib
+  quaternion_operation
 )
 
 pluginlib_export_plugin_description_file(traffic_simulator plugins.xml)
@@ -64,6 +66,7 @@ ament_export_dependencies(behavior_tree_plugin
   traffic_simulator
   behaviortree_cpp_v3
   pluginlib
+  quaternion_operation
 )
 
 install(

--- a/simulation/behavior_tree_plugin/package.xml
+++ b/simulation/behavior_tree_plugin/package.xml
@@ -13,6 +13,7 @@
   <depend>pluginlib</depend>
   <depend>traffic_simulator</depend>
   <depend>behaviortree_cpp_v3</depend>
+  <depend>quaternion_operation</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <quaternion_operation/quaternion_operation.h>
+
 #include <algorithm>
 #include <behavior_tree_plugin/action_node.hpp>
 #include <memory>
@@ -208,8 +210,13 @@ boost::optional<std::string> ActionNode::getFrontEntityName(
   std::vector<std::string> entities;
   for (const auto & each : other_entity_status) {
     const auto distance = getDistanceToTargetEntityPolygon(spline, each.first);
-    if (distance) {
-      if (distance.get() < 40) {
+    const auto quat = quaternion_operation::getRotation(
+      entity_status.pose.orientation, other_entity_status.at(each.first).pose.orientation);
+    /**
+     * @note hard-coded parameter, if the Yaw value of RPY is in ~1.5708 -> 1.5708, entity is a candidate of front entity.
+     */
+    if (std::fabs(quaternion_operation::convertQuaternionToEulerAngle(quat).z) <= 1.5708) {
+      if (distance && distance.get() < 40) {
         entities.emplace_back(each.first);
         distances.emplace_back(distance.get());
       }

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -215,7 +215,9 @@ boost::optional<std::string> ActionNode::getFrontEntityName(
     /**
      * @note hard-coded parameter, if the Yaw value of RPY is in ~1.5708 -> 1.5708, entity is a candidate of front entity.
      */
-    if (std::fabs(quaternion_operation::convertQuaternionToEulerAngle(quat).z) <= 1.5708) {
+    if (
+      std::fabs(quaternion_operation::convertQuaternionToEulerAngle(quat).z) <=
+      boost::math::constants::half_pi<double>()) {
       if (distance && distance.get() < 40) {
         entities.emplace_back(each.first);
         distances.emplace_back(distance.get());


### PR DESCRIPTION
Signed-off-by: MasayaKataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

Fix problem in igetFrontEntityName function, consider yaw difference while stopping at crossing entity. 

## How to review this PR.

Please check passing all CI test cases.

## Others
