### PR TITLE
add AutowareDummy to be able to initialize ego without launching autoware

### DIFF
--- a/external/concealer/include/concealer/autoware_dummy.hpp
+++ b/external/concealer/include/concealer/autoware_dummy.hpp
@@ -1,0 +1,52 @@
+// Copyright 2015-2022 Tier IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONCEALER__AUTOWARE_DUMMY_HPP_
+#define CONCEALER__AUTOWARE_DUMMY_HPP_
+
+#include <concealer/autoware.hpp>
+
+namespace concealer
+{
+class AutowareDummy : public Autoware
+{
+  void sendSIGINT() override{};
+
+public:
+  auto engage() -> void override {}
+  auto initialize(const geometry_msgs::msg::Pose &) -> void override {}
+  auto plan(const std::vector<geometry_msgs::msg::PoseStamped> &) -> void override {}
+  auto update() -> void override {}
+  auto getAcceleration() const -> double override { return 0.0; }
+  auto getAutowareStateMessage() const -> std::string override { return "DummyState"; }
+  auto getGearSign() const -> double override { return 1.0; }
+  auto getSteeringAngle() const -> double override { return 0.0; }
+  auto getVehicleCommand() const -> std::tuple<
+    autoware_auto_control_msgs::msg::AckermannControlCommand,
+    autoware_auto_vehicle_msgs::msg::GearCommand> override
+  {
+    return std::tuple<
+      autoware_auto_control_msgs::msg::AckermannControlCommand,
+      autoware_auto_vehicle_msgs::msg::GearCommand>();
+  }
+  auto getVelocity() const -> double override { return 0.0; }
+  auto getWaypoints() const -> traffic_simulator_msgs::msg::WaypointsArray
+  {
+    return traffic_simulator_msgs::msg::WaypointsArray();
+  }
+  auto restrictTargetSpeed(double) const -> double override { return 0.0; }
+};
+}  // namespace concealer
+
+#endif  // CONCEALER__AUTOWARE_DUMMY_HPP_

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <boost/filesystem.hpp>
 #include <boost/optional.hpp>
+#include <concealer/autoware_dummy.hpp>
 #include <concealer/autoware_universe.hpp>
 #include <memory>
 #include <string>

--- a/simulation/traffic_simulator/src/api/api.cpp
+++ b/simulation/traffic_simulator/src/api/api.cpp
@@ -271,7 +271,10 @@ bool API::setEntityStatus(
 
 bool API::initialize(double realtime_factor, double step_time)
 {
-  clock_.initialize(-1 * configuration.initialize_duration, step_time);
+  const auto initial_simulation_time =
+    getParameter<bool>("launch_autoware", true) ? (-1 * configuration.initialize_duration) : 0.0;
+
+  clock_.initialize(initial_simulation_time, step_time);
 
   if (configuration.standalone_mode) {
     return true;

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -128,21 +128,22 @@ auto makeSimulationModel(
 
 auto makeAutoware(const Configuration & configuration) -> std::unique_ptr<concealer::Autoware>
 {
+  if (!getParameter<bool>("launch_autoware", true)) {
+    return std::make_unique<concealer::AutowareDummy>();
+  }
+
   const auto architecture_type = getParameter<std::string>("architecture_type", "awf/universe");
 
   if (architecture_type == "awf/universe") {
-    return getParameter<bool>("launch_autoware", true)
-             ? std::make_unique<concealer::AutowareUniverse>(
-                 getParameter<std::string>("autoware_launch_package"),
-                 getParameter<std::string>("autoware_launch_file"),
-                 "map_path:=" + configuration.map_path.string(),
-                 "lanelet2_map_file:=" + configuration.getLanelet2MapFile(),
-                 "pointcloud_map_file:=" + configuration.getPointCloudMapFile(),
-                 "sensor_model:=" + getParameter<std::string>("sensor_model"),
-                 "vehicle_model:=" + getParameter<std::string>("vehicle_model"),
-                 "rviz_config:=" + configuration.rviz_config_path.string(),
-                 "scenario_simulation:=true")
-             : std::make_unique<concealer::AutowareUniverse>();
+    return std::make_unique<concealer::AutowareUniverse>(
+      getParameter<std::string>("autoware_launch_package"),
+      getParameter<std::string>("autoware_launch_file"),
+      "map_path:=" + configuration.map_path.string(),
+      "lanelet2_map_file:=" + configuration.getLanelet2MapFile(),
+      "pointcloud_map_file:=" + configuration.getPointCloudMapFile(),
+      "sensor_model:=" + getParameter<std::string>("sensor_model"),
+      "vehicle_model:=" + getParameter<std::string>("vehicle_model"),
+      "rviz_config:=" + configuration.rviz_config_path.string(), "scenario_simulation:=true");
   } else {
     throw common::SemanticError(
       "Unexpected architecture_type ", std::quoted(architecture_type), " was given.");


### PR DESCRIPTION
add AutowareDummy to be able to initialize ego without launching autoware

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [X] Bugfix

## Link to the issue

https://github.com/tier4/scenario_simulator_v2/issues/543

## Description

Before this change, `scenario_test_runner` waited for Autoware to change its state even when `launch_autoware:=False`.

This change introduces `AutowareDummy` that is spawned when `launch_autoware:=False`. The ego vehicle is spawned but it does not move.

## How to review this PR.

## Others
