### PR TITLE
use detected objects instead of predicted ones

### DIFF
--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -17,7 +17,7 @@
 
 #include <simulation_api_schema.pb.h>
 
-#include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -65,7 +65,7 @@ public:
 };
 
 template <>
-void DetectionSensor<autoware_auto_perception_msgs::msg::PredictedObjects>::update(
+void DetectionSensor<autoware_auto_perception_msgs::msg::DetectedObjects>::update(
   const double, const std::vector<traffic_simulator_msgs::EntityStatus> &, const rclcpp::Time &,
   const std::vector<std::string> &);
 }  // namespace simple_sensor_simulator

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/sensor_simulation.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/sensor_simulation.hpp
@@ -55,7 +55,7 @@ public:
       using Message = autoware_auto_perception_msgs::msg::DetectedObjects;
       detection_sensors_.push_back(std::make_unique<DetectionSensor<Message>>(
         current_simulation_time, configuration,
-        node.create_publisher<Message>("/perception/detection/objects", 1)));
+        node.create_publisher<Message>("/perception/object_recognition/detection/objects", 1)));
     } else {
       std::stringstream ss;
       ss << "Unexpected architecture_type " << std::quoted(configuration.architecture_type())

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/sensor_simulation.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/sensor_simulation.hpp
@@ -52,10 +52,10 @@ public:
     -> void
   {
     if (configuration.architecture_type() == "awf/universe") {
-      using Message = autoware_auto_perception_msgs::msg::PredictedObjects;
+      using Message = autoware_auto_perception_msgs::msg::DetectedObjects;
       detection_sensors_.push_back(std::make_unique<DetectionSensor<Message>>(
         current_simulation_time, configuration,
-        node.create_publisher<Message>("/perception/object_recognition/objects", 1)));
+        node.create_publisher<Message>("/perception/detection/objects", 1)));
     } else {
       std::stringstream ss;
       ss << "Unexpected architecture_type " << std::quoted(configuration.architecture_type())

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
@@ -26,7 +26,7 @@
 namespace simple_sensor_simulator
 {
 template <>
-void DetectionSensor<autoware_auto_perception_msgs::msg::PredictedObjects>::update(
+void DetectionSensor<autoware_auto_perception_msgs::msg::DetectedObjects>::update(
   const double current_time, const std::vector<traffic_simulator_msgs::EntityStatus> & status,
   const rclcpp::Time & stamp, const std::vector<std::string> & detected_objects)
 {
@@ -41,14 +41,14 @@ void DetectionSensor<autoware_auto_perception_msgs::msg::PredictedObjects>::upda
   };
 
   if (current_time - last_update_stamp_ - configuration_.update_duration() >= -0.002) {
-    autoware_auto_perception_msgs::msg::PredictedObjects msg;
+    autoware_auto_perception_msgs::msg::DetectedObjects msg;
     msg.header.stamp = stamp;
     msg.header.frame_id = "map";
     last_update_stamp_ = current_time;
     for (const auto & s : status) {
       auto result = std::find(detected_objects.begin(), detected_objects.end(), s.name());
       if (result != detected_objects.end()) {
-        autoware_auto_perception_msgs::msg::PredictedObject object;
+        autoware_auto_perception_msgs::msg::DetectedObject object;
         bool is_ego = false;
         switch (s.type()) {
           case traffic_simulator_msgs::EntityType::EGO:
@@ -72,12 +72,12 @@ void DetectionSensor<autoware_auto_perception_msgs::msg::PredictedObjects>::upda
           simulation_interface::toMsg(s.bounding_box().dimensions(), object.shape.dimensions);
           geometry_msgs::msg::Pose pose;
           simulation_interface::toMsg(s.pose(), pose);
-          object.kinematics.initial_pose_with_covariance.pose = pose;
-          object.kinematics.initial_pose_with_covariance.covariance = {
+          object.kinematics.pose_with_covariance.pose = pose;
+          object.kinematics.pose_with_covariance.covariance = {
             1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
             0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1};
           simulation_interface::toMsg(
-            s.action_status().twist(), object.kinematics.initial_twist_with_covariance.twist);
+            s.action_status().twist(), object.kinematics.twist_with_covariance.twist);
           object.shape.type = object.shape.BOUNDING_BOX;
           msg.objects.emplace_back(object);
         }

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
@@ -73,9 +73,9 @@ void DetectionSensor<autoware_auto_perception_msgs::msg::DetectedObjects>::updat
           geometry_msgs::msg::Pose pose;
           simulation_interface::toMsg(s.pose(), pose);
           object.kinematics.pose_with_covariance.pose = pose;
-          object.kinematics.pose_with_covariance.covariance = {
-            1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
-            0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1};
+          object.kinematics.pose_with_covariance.covariance = {1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0,
+                                                               0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0,
+                                                               0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1};
           simulation_interface::toMsg(
             s.action_status().twist(), object.kinematics.twist_with_covariance.twist);
           object.shape.type = object.shape.BOUNDING_BOX;

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -141,7 +141,8 @@ auto makeAutoware(const Configuration & configuration) -> std::unique_ptr<concea
                  "sensor_model:=" + getParameter<std::string>("sensor_model"),
                  "vehicle_model:=" + getParameter<std::string>("vehicle_model"),
                  "rviz_config:=" + configuration.rviz_config_path.string(),
-                 "scenario_simulation:=true")
+                 "scenario_simulation:=true",
+                 "perception/enable_traffic_light:=false")
              : std::make_unique<concealer::AutowareUniverse>();
   } else {
     throw common::SemanticError(

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -141,8 +141,7 @@ auto makeAutoware(const Configuration & configuration) -> std::unique_ptr<concea
                  "sensor_model:=" + getParameter<std::string>("sensor_model"),
                  "vehicle_model:=" + getParameter<std::string>("vehicle_model"),
                  "rviz_config:=" + configuration.rviz_config_path.string(),
-                 "scenario_simulation:=true",
-                 "perception/enable_traffic_light:=false")
+                 "scenario_simulation:=true", "perception/enable_traffic_light:=false")
              : std::make_unique<concealer::AutowareUniverse>();
   } else {
     throw common::SemanticError(


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
https://github.com/autowarefoundation/autoware.universe/issues/455

## Description

In scenario sim v1, detected objects are published from scenario sim, and perception modules in autoware calculates and publishes tracking, and predicted objects.

However, currently in scenario sim v2, predicted objects are published, where prediction is not calculated and just detected objects are contained. As a result, some scenarios fail.

With this PR, scenario sim v2 publishes detected objects so that autoware can calculate tracking and predicted objects, which will result in failed scenarios passing.

## How to review this PR.

## Others
