### PR TITLE
Fix/interpreter/traffic signal state action

### DIFF
--- a/openscenario/openscenario_interpreter/src/syntax/traffic_signal_state.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/traffic_signal_state.cpp
@@ -40,16 +40,18 @@ auto TrafficSignalState::evaluate() const -> Object
   const auto color = boost::lexical_cast<boost::optional<Color>>(state);
   if (color.has_value()) {
     setTrafficSignalColor(id(), color.value());
-    return unspecified;
   }
 
   const auto arrow = boost::lexical_cast<boost::optional<Arrow>>(state);
   if (arrow.has_value()) {
     setTrafficSignalArrow(id(), arrow.value());
-    return unspecified;
   }
 
-  throw UNEXPECTED_ENUMERATION_VALUE_SPECIFIED(Color or Arrow, state);
+  if (not color.has_value() and not arrow.has_value()) {
+    throw UNEXPECTED_ENUMERATION_VALUE_SPECIFIED(Color or Arrow, state);
+  } else {
+    return unspecified;
+  }
 }
 
 auto TrafficSignalState::id() const -> LaneletId

--- a/openscenario/openscenario_interpreter/src/syntax/traffic_signal_state_action.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/traffic_signal_state_action.cpp
@@ -36,17 +36,19 @@ auto TrafficSignalStateAction::run() noexcept -> void {}
 
 auto TrafficSignalStateAction::start() const -> void
 {
-  const auto color_opt = boost::lexical_cast<boost::optional<Color>>(state);
-  if (color_opt.has_value()) {
-    setTrafficSignalColor(id(), color_opt.value());
+  const auto color = boost::lexical_cast<boost::optional<Color>>(state);
+  if (color.has_value()) {
+    setTrafficSignalColor(id(), color.value());
   }
 
-  const auto arrow_opt = boost::lexical_cast<boost::optional<Arrow>>(state);
-  if (arrow_opt.has_value()) {
-    setTrafficSignalArrow(id(), arrow_opt.value());
+  const auto arrow = boost::lexical_cast<boost::optional<Arrow>>(state);
+  if (arrow.has_value()) {
+    setTrafficSignalArrow(id(), arrow.value());
   }
 
-  throw UNEXPECTED_ENUMERATION_VALUE_SPECIFIED(Color or Arrow, state);
+  if (not color.has_value() and not arrow.has_value()) {
+    throw UNEXPECTED_ENUMERATION_VALUE_SPECIFIED(Color or Arrow, state);
+  }
 }
 
 auto TrafficSignalStateAction::id() const -> std::int64_t


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Description

- Fix `TrafficSignalStateAction::start` to not to throw error if given state is valid
- Update syntax `TrafficSignalState` to reset both of color and arrow if `none` is specified