### PR TITLE
Feature/interpreter/category

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/misc_object_category.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/misc_object_category.hpp
@@ -16,6 +16,7 @@
 #define OPENSCENARIO_INTERPRETER__SYNTAX__MISC_OBJECT_CATEGORY_HPP_
 
 #include <iostream>
+#include <traffic_simulator_msgs/msg/entity_subtype.hpp>
 
 namespace openscenario_interpreter
 {
@@ -61,11 +62,13 @@ inline namespace syntax
 struct MiscObjectCategory
 {
   enum value_type {
+    none,  // NOTE: This is the default value and should not be included in the sort.
+
+    // NOTE: Sorted by lexicographic order.
     barrier,
     building,
     crosswalk,
     gantry,
-    none,
     obstacle,
     parkingSpace,
     patch,
@@ -83,6 +86,20 @@ struct MiscObjectCategory
   explicit MiscObjectCategory() = default;
 
   constexpr operator value_type() const noexcept { return value; }
+
+  explicit operator traffic_simulator_msgs::msg::EntitySubtype() const
+  {
+    traffic_simulator_msgs::msg::EntitySubtype result;
+    {
+      switch (value) {  // NOTE: Sorted by lexicographic order.
+        default:
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::UNKNOWN;
+          break;
+      }
+    }
+
+    return result;
+  }
 };
 
 auto operator>>(std::istream &, MiscObjectCategory &) -> std::istream &;

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/pedestrian_category.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/pedestrian_category.hpp
@@ -16,6 +16,7 @@
 #define OPENSCENARIO_INTERPRETER__SYNTAX__PEDESTRIAN_CATEGORY_HPP_
 
 #include <iostream>
+#include <traffic_simulator_msgs/msg/entity_subtype.hpp>
 
 namespace openscenario_interpreter
 {
@@ -27,9 +28,9 @@ inline namespace syntax
  *    <xsd:union>
  *      <xsd:simpleType>
  *        <xsd:restriction base="xsd:string">
+ *          <xsd:enumeration value="animal"/>
  *          <xsd:enumeration value="pedestrian"/>
  *          <xsd:enumeration value="wheelchair"/>
- *          <xsd:enumeration value="animal"/>
  *        </xsd:restriction>
  *      </xsd:simpleType>
  *      <xsd:simpleType>
@@ -42,14 +43,33 @@ inline namespace syntax
 struct PedestrianCategory
 {
   enum value_type {
-    pedestrian,
-    wheelchair,
+    pedestrian,  // NOTE: This is the default value and should not be included in the sort.
+
+    // NOTE: Sorted by lexicographic order.
     animal,
+    wheelchair,
   } value;
 
   explicit constexpr PedestrianCategory(value_type value = pedestrian) : value(value) {}
 
   constexpr operator value_type() const noexcept { return value; }
+
+  explicit operator traffic_simulator_msgs::msg::EntitySubtype() const
+  {
+    traffic_simulator_msgs::msg::EntitySubtype result;
+    {
+      switch (value) {
+        case pedestrian:
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::PEDESTRIAN;
+          break;
+        default:  // animal, wheelchair
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::UNKNOWN;
+          break;
+      }
+    }
+
+    return result;
+  }
 };
 
 auto operator>>(std::istream &, PedestrianCategory &) -> std::istream &;

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/vehicle_category.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/vehicle_category.hpp
@@ -15,10 +15,8 @@
 #ifndef OPENSCENARIO_INTERPRETER__SYNTAX__VEHICLE_CATEGORY_HPP_
 #define OPENSCENARIO_INTERPRETER__SYNTAX__VEHICLE_CATEGORY_HPP_
 
-#include <openscenario_interpreter/object.hpp>
-#include <string>
+#include <iostream>
 #include <traffic_simulator_msgs/msg/entity_subtype.hpp>
-#include <utility>
 
 namespace openscenario_interpreter
 {
@@ -52,9 +50,11 @@ inline namespace syntax
 struct VehicleCategory
 {
   enum value_type {
+    car,  // NOTE: This is the default value and should not be included in the sort.
+
+    // NOTE: Sorted by lexicographic order.
     bicycle,
     bus,
-    car,
     motorbike,
     semitrailer,
     trailer,
@@ -72,7 +72,7 @@ struct VehicleCategory
   {
     traffic_simulator_msgs::msg::EntitySubtype result;
     {
-      switch (value) {
+      switch (value) {  // NOTE: Sorted by lexicographic order.
         case bicycle:
           result.value = traffic_simulator_msgs::msg::EntitySubtype::BICYCLE;
           break;

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/vehicle_category.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/vehicle_category.hpp
@@ -17,6 +17,7 @@
 
 #include <openscenario_interpreter/object.hpp>
 #include <string>
+#include <traffic_simulator_msgs/msg/entity_subtype.hpp>
 #include <utility>
 
 namespace openscenario_interpreter
@@ -29,16 +30,16 @@ inline namespace syntax
  *    <xsd:union>
  *      <xsd:simpleType>
  *        <xsd:restriction base="xsd:string">
- *          <xsd:enumeration value="car"/>
- *          <xsd:enumeration value="van"/>
- *          <xsd:enumeration value="truck"/>
- *          <xsd:enumeration value="trailer"/>
- *          <xsd:enumeration value="semitrailer"/>
- *          <xsd:enumeration value="bus"/>
- *          <xsd:enumeration value="motorbike"/>
  *          <xsd:enumeration value="bicycle"/>
+ *          <xsd:enumeration value="bus"/>
+ *          <xsd:enumeration value="car"/>
+ *          <xsd:enumeration value="motorbike"/>
+ *          <xsd:enumeration value="semitrailer"/>
+ *          <xsd:enumeration value="trailer"/>
  *          <xsd:enumeration value="train"/>
  *          <xsd:enumeration value="tram"/>
+ *          <xsd:enumeration value="truck"/>
+ *          <xsd:enumeration value="van"/>
  *        </xsd:restriction>
  *      </xsd:simpleType>
  *      <xsd:simpleType>
@@ -66,6 +67,38 @@ struct VehicleCategory
   explicit constexpr VehicleCategory(value_type value = car) : value(value) {}
 
   constexpr operator value_type() const noexcept { return value; }
+
+  explicit operator traffic_simulator_msgs::msg::EntitySubtype() const
+  {
+    traffic_simulator_msgs::msg::EntitySubtype result;
+    {
+      switch (value) {
+        case bicycle:
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::BICYCLE;
+          break;
+        case bus:
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::BUS;
+          break;
+        case car:
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::CAR;
+          break;
+        case motorbike:
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::MOTORCYCLE;
+          break;
+        case trailer:
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::TRAILER;
+          break;
+        case truck:
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::TRUCK;
+          break;
+        default:  // semitrailer, train, tram, van
+          result.value = traffic_simulator_msgs::msg::EntitySubtype::UNKNOWN;
+          break;
+      }
+    }
+
+    return result;
+  }
 };
 
 auto operator>>(std::istream &, VehicleCategory &) -> std::istream &;

--- a/openscenario/openscenario_interpreter/src/syntax/misc_object.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/misc_object.cpp
@@ -35,10 +35,11 @@ MiscObject::operator traffic_simulator_msgs::msg::MiscObjectParameters() const
 {
   traffic_simulator_msgs::msg::MiscObjectParameters misc_object_parameters;
   {
+    using namespace traffic_simulator_msgs;
+
     misc_object_parameters.name = name;
-    misc_object_parameters.subtype.value = traffic_simulator_msgs::msg::EntitySubtype::UNKNOWN;
-    misc_object_parameters.bounding_box =
-      static_cast<const traffic_simulator_msgs::msg::BoundingBox>(bounding_box);
+    misc_object_parameters.subtype = static_cast<msg::EntitySubtype>(misc_object_category);
+    misc_object_parameters.bounding_box = static_cast<msg::BoundingBox>(bounding_box);
   }
 
   return misc_object_parameters;

--- a/openscenario/openscenario_interpreter/src/syntax/pedestrian.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/pedestrian.cpp
@@ -36,9 +36,11 @@ Pedestrian::operator traffic_simulator_msgs::msg::PedestrianParameters() const
 {
   traffic_simulator_msgs::msg::PedestrianParameters parameter;
   {
+    using namespace traffic_simulator_msgs;
+
     parameter.name = name;
-    parameter.subtype.value = traffic_simulator_msgs::msg::EntitySubtype::PEDESTRIAN;
-    parameter.bounding_box = static_cast<traffic_simulator_msgs::msg::BoundingBox>(bounding_box);
+    parameter.subtype = static_cast<msg::EntitySubtype>(pedestrian_category);
+    parameter.bounding_box = static_cast<msg::BoundingBox>(bounding_box);
   }
 
   return parameter;

--- a/openscenario/openscenario_interpreter/src/syntax/vehicle.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/vehicle.cpp
@@ -36,11 +36,13 @@ Vehicle::operator traffic_simulator_msgs::msg::VehicleParameters() const
 {
   traffic_simulator_msgs::msg::VehicleParameters parameter;
   {
+    using namespace traffic_simulator_msgs;
+
     parameter.name = name;
-    parameter.subtype.value = traffic_simulator_msgs::msg::EntitySubtype::CAR;
-    parameter.bounding_box = static_cast<traffic_simulator_msgs::msg::BoundingBox>(bounding_box);
-    parameter.performance = static_cast<traffic_simulator_msgs::msg::Performance>(performance);
-    parameter.axles = static_cast<traffic_simulator_msgs::msg::Axles>(axles);
+    parameter.subtype = static_cast<msg::EntitySubtype>(vehicle_category);
+    parameter.bounding_box = static_cast<msg::BoundingBox>(bounding_box);
+    parameter.performance = static_cast<msg::Performance>(performance);
+    parameter.axles = static_cast<msg::Axles>(axles);
   }
 
   return parameter;


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

- Update syntax `VehicleCategory` to support `operator EntitySubtype`
- Update syntax `PedestrianCategory` to support `operator EntitySubtype`
- Update syntax `MiscObjectCategory` to support `operator EntitySubtype`
- Update syntax `Vehicle`, `Pedestrian` and `MiscObject` to set subtype correctly