### PR TITLE
add Release option to the build instruction

### DIFF
--- a/docs/tutorials/BuildInstructions.md
+++ b/docs/tutorials/BuildInstructions.md
@@ -47,5 +47,5 @@ rosdep install -iry --from-paths src/scenario_simulator_v2 --rosdistro galactic
 ## Build scenario_simulator_vs
 
 ```bash
-colcon build --symlink-install
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```


### PR DESCRIPTION
Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>

## Types of PR

- [x] Upgrade of existing features

## Link to the issue
https://github.com/tier4/scenario_simulator_v2/issues/736

## Description
Current scenario simulator fails with a certain scenario files when the simulator is built with debug option. Until the fix is made, the instruction should suggest to add Release option when building the workspace.

## How to review this PR.
Follow the instruction in the attached issue and make sure that the simulator runs correctly.
## Others
