### PR TITLE
Fix/calculate stop distance

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -19,6 +19,7 @@ Bug Fixes:bug:
 | -------------------------------------- | ----------------------------------------------------------------------------------- | -------------------------- | --------------------------------------------------------------- | --------------------------------------------- |
 | OpenSCENARIO `Storyboard.Init.Actions` | Fix `Init.Actions.GlobalAction` and `Init.Actions.UserDefinedAction` to work.       | `openscenario_interpreter` | [#734](https://github.com/tier4/scenario_simulator_v2/pull/734) | [yamacir-kit](https://github.com/yamacir-kit) |
 | Fix waypoint height                    | Height of the NPC waypoint was 0. Get waypoint height from center point of lanelet. | `traffic_simulator`        | [#718](https://github.com/tier4/scenario_simulator_v2/pull/718) | [hakuturu583](https://github.com/hakuturu583) |
+| Fix calculateStopDistance function     | While calculating stop distance, deceleration was always 5.                         | `behavior_tree_plugin`     | [#747](https://github.com/tier4/scenario_simulator_v2/pull/747) | [hakuturu583](https://github.com/hakuturu583) |
 
 Minor Tweaks :oncoming_police_car:
 

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
@@ -43,7 +43,7 @@ public:
     const traffic_simulator::math::CatmullRomSpline & spline);
   boost::optional<std::string> getFrontEntityName(
     const traffic_simulator::math::CatmullRomSpline & spline);
-  double calculateStopDistance() const;
+  double calculateStopDistance(double deceleration) const;
   boost::optional<double> getDistanceToFrontEntity(
     const traffic_simulator::math::CatmullRomSpline & spline);
   boost::optional<double> getDistanceToStopLine(

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -363,8 +363,9 @@ bool ActionNode::foundConflictingEntity(const std::vector<std::int64_t> & follow
   return false;
 }
 
-double ActionNode::calculateStopDistance() const
+double ActionNode::calculateStopDistance(double deceleration) const
 {
-  return std::pow(entity_status.action_status.twist.linear.x, 2) / (2 * 5);
+  return (entity_status.action_status.twist.linear.x * entity_status.action_status.twist.linear.x) /
+         (2 * std::fabs(deceleration));
 }
 }  // namespace entity_behavior

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
@@ -119,8 +119,8 @@ BT::NodeStatus FollowFrontEntityAction::tick()
     return BT::NodeStatus::RUNNING;
   }
   if (
-    distance_to_front_entity_.get() >=
-    (calculateStopDistance() + vehicle_parameters.bounding_box.dimensions.x + 5)) {
+    distance_to_front_entity_.get() >= (calculateStopDistance(getDriverModel().deceleration) +
+                                        vehicle_parameters.bounding_box.dimensions.x + 5)) {
     auto entity_status_updated =
       calculateEntityStatusUpdated(front_entity_status.action_status.twist.linear.x + 2);
     setOutput("updated_status", entity_status_updated);
@@ -128,7 +128,8 @@ BT::NodeStatus FollowFrontEntityAction::tick()
     setOutput("waypoints", waypoints);
     setOutput("obstacle", obstacle);
     return BT::NodeStatus::RUNNING;
-  } else if (distance_to_front_entity_.get() <= calculateStopDistance()) {
+  } else if (
+    distance_to_front_entity_.get() <= calculateStopDistance(getDriverModel().deceleration)) {
     auto entity_status_updated =
       calculateEntityStatusUpdated(front_entity_status.action_status.twist.linear.x - 2);
     setOutput("updated_status", entity_status_updated);

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
@@ -128,8 +128,7 @@ BT::NodeStatus FollowFrontEntityAction::tick()
     setOutput("waypoints", waypoints);
     setOutput("obstacle", obstacle);
     return BT::NodeStatus::RUNNING;
-  } else if (
-    distance_to_front_entity_.get() <= calculateStopDistance(driver_model.deceleration)) {
+  } else if (distance_to_front_entity_.get() <= calculateStopDistance(driver_model.deceleration)) {
     auto entity_status_updated =
       calculateEntityStatusUpdated(front_entity_status.action_status.twist.linear.x - 2);
     setOutput("updated_status", entity_status_updated);

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
@@ -119,7 +119,7 @@ BT::NodeStatus FollowFrontEntityAction::tick()
     return BT::NodeStatus::RUNNING;
   }
   if (
-    distance_to_front_entity_.get() >= (calculateStopDistance(getDriverModel().deceleration) +
+    distance_to_front_entity_.get() >= (calculateStopDistance(driver_model.deceleration) +
                                         vehicle_parameters.bounding_box.dimensions.x + 5)) {
     auto entity_status_updated =
       calculateEntityStatusUpdated(front_entity_status.action_status.twist.linear.x + 2);
@@ -129,7 +129,7 @@ BT::NodeStatus FollowFrontEntityAction::tick()
     setOutput("obstacle", obstacle);
     return BT::NodeStatus::RUNNING;
   } else if (
-    distance_to_front_entity_.get() <= calculateStopDistance(getDriverModel().deceleration)) {
+    distance_to_front_entity_.get() <= calculateStopDistance(driver_model.deceleration)) {
     auto entity_status_updated =
       calculateEntityStatusUpdated(front_entity_status.action_status.twist.linear.x - 2);
     setOutput("updated_status", entity_status_updated);

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_lane_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_lane_action.cpp
@@ -87,8 +87,8 @@ BT::NodeStatus FollowLaneAction::tick()
     auto distance_to_front_entity = getDistanceToFrontEntity(spline);
     if (distance_to_front_entity) {
       if (
-        distance_to_front_entity.get() <=
-        calculateStopDistance() + vehicle_parameters.bounding_box.dimensions.x + 5) {
+        distance_to_front_entity.get() <= calculateStopDistance(getDriverModel().deceleration) +
+                                            vehicle_parameters.bounding_box.dimensions.x + 5) {
         return BT::NodeStatus::FAILURE;
       }
     }
@@ -104,15 +104,16 @@ BT::NodeStatus FollowLaneAction::tick()
     auto distance_to_conflicting_entity = getDistanceToConflictingEntity(route_lanelets, spline);
     if (distance_to_stopline) {
       if (
-        distance_to_stopline.get() <=
-        calculateStopDistance() + vehicle_parameters.bounding_box.dimensions.x * 0.5 + 5) {
+        distance_to_stopline.get() <= calculateStopDistance(getDriverModel().deceleration) +
+                                        vehicle_parameters.bounding_box.dimensions.x * 0.5 + 5) {
         return BT::NodeStatus::FAILURE;
       }
     }
     if (distance_to_conflicting_entity) {
       if (
         distance_to_conflicting_entity.get() <
-        (vehicle_parameters.bounding_box.dimensions.x + calculateStopDistance())) {
+        (vehicle_parameters.bounding_box.dimensions.x +
+         calculateStopDistance(getDriverModel().deceleration))) {
         return BT::NodeStatus::FAILURE;
       }
     }

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_lane_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_lane_action.cpp
@@ -111,9 +111,8 @@ BT::NodeStatus FollowLaneAction::tick()
     }
     if (distance_to_conflicting_entity) {
       if (
-        distance_to_conflicting_entity.get() <
-        (vehicle_parameters.bounding_box.dimensions.x +
-         calculateStopDistance(driver_model.deceleration))) {
+        distance_to_conflicting_entity.get() < (vehicle_parameters.bounding_box.dimensions.x +
+                                                calculateStopDistance(driver_model.deceleration))) {
         return BT::NodeStatus::FAILURE;
       }
     }

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_lane_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_lane_action.cpp
@@ -87,7 +87,7 @@ BT::NodeStatus FollowLaneAction::tick()
     auto distance_to_front_entity = getDistanceToFrontEntity(spline);
     if (distance_to_front_entity) {
       if (
-        distance_to_front_entity.get() <= calculateStopDistance(getDriverModel().deceleration) +
+        distance_to_front_entity.get() <= calculateStopDistance(driver_model.deceleration) +
                                             vehicle_parameters.bounding_box.dimensions.x + 5) {
         return BT::NodeStatus::FAILURE;
       }
@@ -104,7 +104,7 @@ BT::NodeStatus FollowLaneAction::tick()
     auto distance_to_conflicting_entity = getDistanceToConflictingEntity(route_lanelets, spline);
     if (distance_to_stopline) {
       if (
-        distance_to_stopline.get() <= calculateStopDistance(getDriverModel().deceleration) +
+        distance_to_stopline.get() <= calculateStopDistance(driver_model.deceleration) +
                                         vehicle_parameters.bounding_box.dimensions.x * 0.5 + 5) {
         return BT::NodeStatus::FAILURE;
       }
@@ -113,7 +113,7 @@ BT::NodeStatus FollowLaneAction::tick()
       if (
         distance_to_conflicting_entity.get() <
         (vehicle_parameters.bounding_box.dimensions.x +
-         calculateStopDistance(getDriverModel().deceleration))) {
+         calculateStopDistance(driver_model.deceleration))) {
         return BT::NodeStatus::FAILURE;
       }
     }

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
@@ -74,7 +74,7 @@ boost::optional<double> StopAtCrossingEntityAction::calculateTargetSpeed(double 
   }
   double rest_distance =
     distance_to_stop_target_.get() - (vehicle_parameters.bounding_box.dimensions.x + 3);
-  if (rest_distance < calculateStopDistance(getDriverModel().deceleration)) {
+  if (rest_distance < calculateStopDistance(driver_model.deceleration)) {
     if (rest_distance > 0) {
       return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
@@ -74,7 +74,7 @@ boost::optional<double> StopAtCrossingEntityAction::calculateTargetSpeed(double 
   }
   double rest_distance =
     distance_to_stop_target_.get() - (vehicle_parameters.bounding_box.dimensions.x + 3);
-  if (rest_distance < calculateStopDistance()) {
+  if (rest_distance < calculateStopDistance(getDriverModel().deceleration)) {
     if (rest_distance > 0) {
       return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
@@ -76,7 +76,7 @@ boost::optional<double> StopAtStopLineAction::calculateTargetSpeed(double curren
   }
   double rest_distance =
     distance_to_stopline_.get() - (vehicle_parameters.bounding_box.dimensions.x);
-  if (rest_distance < calculateStopDistance(getDriverModel().deceleration)) {
+  if (rest_distance < calculateStopDistance(driver_model.deceleration)) {
     if (rest_distance > 0) {
       return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
@@ -76,7 +76,7 @@ boost::optional<double> StopAtStopLineAction::calculateTargetSpeed(double curren
   }
   double rest_distance =
     distance_to_stopline_.get() - (vehicle_parameters.bounding_box.dimensions.x);
-  if (rest_distance < calculateStopDistance()) {
+  if (rest_distance < calculateStopDistance(getDriverModel().deceleration)) {
     if (rest_distance > 0) {
       return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
@@ -73,7 +73,7 @@ boost::optional<double> StopAtTrafficLightAction::calculateTargetSpeed(double cu
   }
   double rest_distance =
     distance_to_stop_target_.get() - (vehicle_parameters.bounding_box.dimensions.x + 3);
-  if (rest_distance < calculateStopDistance()) {
+  if (rest_distance < calculateStopDistance(getDriverModel().deceleration)) {
     if (rest_distance > 0) {
       return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
@@ -73,7 +73,7 @@ boost::optional<double> StopAtTrafficLightAction::calculateTargetSpeed(double cu
   }
   double rest_distance =
     distance_to_stop_target_.get() - (vehicle_parameters.bounding_box.dimensions.x + 3);
-  if (rest_distance < calculateStopDistance(getDriverModel().deceleration)) {
+  if (rest_distance < calculateStopDistance(driver_model.deceleration)) {
     if (rest_distance > 0) {
       return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/yield_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/yield_action.cpp
@@ -75,7 +75,7 @@ boost::optional<double> YieldAction::calculateTargetSpeed()
   }
   double rest_distance =
     distance_to_stop_target_.get() - (vehicle_parameters.bounding_box.dimensions.x) - 10;
-  if (rest_distance < calculateStopDistance(getDriverModel().deceleration)) {
+  if (rest_distance < calculateStopDistance(driver_model.deceleration)) {
     if (rest_distance > 0) {
       return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/yield_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/yield_action.cpp
@@ -75,7 +75,7 @@ boost::optional<double> YieldAction::calculateTargetSpeed()
   }
   double rest_distance =
     distance_to_stop_target_.get() - (vehicle_parameters.bounding_box.dimensions.x) - 10;
-  if (rest_distance < calculateStopDistance()) {
+  if (rest_distance < calculateStopDistance(getDriverModel().deceleration)) {
     if (rest_distance > 0) {
       return std::sqrt(2 * driver_model.deceleration * rest_distance);
     } else {


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

While calculating stop distance, deceleration was always 5.

## How to review this PR.

Please check passing all CI test cases.

## Others
