### PR TITLE
Fix/docker build arg

### DIFF
--- a/docs/tutorials/RunWithDocker.md
+++ b/docs/tutorials/RunWithDocker.md
@@ -139,7 +139,7 @@ If you want to build a docker image in your local machine, please type the comma
 
 ```bash
 cd (path_to_scenario_simulator_v2)
-docker build -t scenario_simulator_v2 .
+docker build -t scenario_simulator_v2 . --build-arg ROS_DISTRO=galactic
 ```
 
 ## Running Simulation with docker.


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
In the Docker file, there is [ARG ROS_DISTRO](https://github.com/tier4/scenario_simulator_v2/blob/master/Dockerfile#L1), which suggests it needs arg parser.
So when executing `docker build`, it needs `--build-arg ROS_DISTRO=galactic`, for example. 

It seems there is a error in the previous version: 
```
$ docker build -t scenario_simulator_v2 .
Sending build context to Docker daemon  549.8MB
Step 1/22 : ARG ROS_DISTRO
Step 2/22 : FROM ros:${ROS_DISTRO}
invalid reference format
```
## How to review this PR.
Please check passing all CI tests.
## Others
