### PR TITLE
Fix/docker tag

### DIFF
--- a/docs/tutorials/RunTestScenarioWithDocker.md
+++ b/docs/tutorials/RunTestScenarioWithDocker.md
@@ -23,7 +23,7 @@ wget https://gist.github.com/hakuturu583/5e6a651df9abdf25dca7071ff5ea8ac3/archiv
 unzip d4225e88169749b748b3f3cd70d8b75198846362.zip
 mv 5e6a651df9abdf25dca7071ff5ea8ac3-d4225e88169749b748b3f3cd70d8b75198846362 scenarios
 sudo pip3 install git+https://github.com/sloretz/off-your-rocker.git
-docker pull tier4/scenario_simulator_v2
+docker pull tier4/scenario_simulator_v2:galactic
 rocker --x11 --oyr-mount $PWD/scenarios/UC-001-0001-Kashiwa.yaml -- tier4/scenario_simulator_v2 ros2 launch scenario_test_runner scenario_test_runner.launch.py scenario:=$PWD/scenarios/UC-001-0001-Kashiwa.yaml launch_rviz:=True
 ```
 


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
When pulling docker without specifying the tag, it is considered as  the "latest" tag. 
But "latest' tag does not exist in the [hub](https://hub.docker.com/r/tier4/scenario_simulator_v2/tags).
Thus we should specify the tag such as "galactic" 

## How to review this PR.

## Others
