### PR TITLE
Fix undef macro target

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
@@ -218,7 +218,7 @@ public:
   FORWARD_TO_ENTITY(setDriverModel, );
   FORWARD_TO_ENTITY(setVelocityLimit, );
 
-#undef FORWARD_TO_SPECIFIED_ENTITY
+#undef FORWARD_TO_ENTITY
 
   visualization_msgs::msg::MarkerArray makeDebugMarker() const;
 


### PR DESCRIPTION
"FORWARD_TO_ENTITY" macro does not undefine inthis file.
And "FORWARD_TO_SPECIFIED_ENTITY" undefined without any definition.

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

## How to review this PR.

## Others
