### PR TITLE
add missing boost depend

### DIFF
--- a/common/simple_junit/package.xml
+++ b/common/simple_junit/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>pugixml-dev</depend>
-  <depend>libboost-dev</depend>
+  <depend>boost</depend>
   <depend>ament_index_cpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/external/concealer/package.xml
+++ b/external/concealer/package.xml
@@ -29,6 +29,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>traffic_simulator_msgs</depend>
+  <depend>libboost-dev</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>

--- a/openscenario/openscenario_interpreter/package.xml
+++ b/openscenario/openscenario_interpreter/package.xml
@@ -26,6 +26,7 @@
   <depend>tier4_simulation_msgs</depend>
   <depend>traffic_simulator</depend>
   <depend>traffic_simulator_msgs</depend>
+  <depend>libboost-dev</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>

--- a/openscenario/openscenario_interpreter_example/package.xml
+++ b/openscenario/openscenario_interpreter_example/package.xml
@@ -12,6 +12,7 @@
 
   <depend>openscenario_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>libboost-dev</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>

--- a/openscenario/user_defined_value_condition_example/package.xml
+++ b/openscenario/user_defined_value_condition_example/package.xml
@@ -13,6 +13,7 @@
   <depend>autoware_auto_system_msgs</depend>
   <depend>openscenario_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>boost</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>

--- a/simulation/simulation_interface/package.xml
+++ b/simulation/simulation_interface/package.xml
@@ -22,6 +22,7 @@
   <depend>rosgraph_msgs</depend>
   <depend>scenario_simulator_exception</depend>
   <depend>traffic_simulator_msgs</depend>
+  <depend>boost</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

Fix errors in dependency of concealer and interpreter.
This error was detected by this action.
https://github.com/tier4/scenario_simulator_v2/actions/workflows/BuildIsolate.yaml

## How to review this PR.

## Others
