### PR TITLE
Exclude too large topic from `ros2 bag record`

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -18,9 +18,10 @@ Bug Fixes:bug:
 
 Minor Tweaks :oncoming_police_car:
 
-| Feature                     | Brief summary                                                                                                        | Category                   | Pull request                                                    | Contributor                                   |
-|-----------------------------|----------------------------------------------------------------------------------------------------------------------|----------------------------|-----------------------------------------------------------------|-----------------------------------------------|
-| OpenSCENARIO simulator core | Changed to treat traffic_simulator as "Simulator Core" based on OpenSCENARIO standard Basic architecture components. | `openscenario_interpreter` | [#783](https://github.com/tier4/scenario_simulator_v2/pull/783) | [yamacir-kit](https://github.com/yamacir-kit) |
+| Feature                     | Brief summary                                                                                                                                           | Category                   | Pull request                                                    | Contributor                                   |
+|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|-----------------------------------------------------------------|-----------------------------------------------|
+| OpenSCENARIO simulator core | Changed to treat `traffic_simulator` as "Simulator Core" based on OpenSCENARIO standard Basic architecture components.                                  | `openscenario_interpreter` | [#783](https://github.com/tier4/scenario_simulator_v2/pull/783) | [yamacir-kit](https://github.com/yamacir-kit) |
+| Option `--record`           | Exclude a too large topic `/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection` from bag recording. | `openscenario_interpreter` | [#829](https://github.com/tier4/scenario_simulator_v2/pull/829) | [yamacir-kit](https://github.com/yamacir-kit) |
 
 ## Version 0.6.5
 

--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -174,8 +174,12 @@ auto Interpreter::on_activate(const rclcpp_lifecycle::State &) -> Result
       [this](auto &&...) { return Interpreter::Result::ERROR; },
       [&]() {
         if (getParameter<bool>("record", true)) {
+          // clang-format off
           record::start(
-            "-a", "-o", boost::filesystem::path(osc_path).replace_extension("").string());
+            "-a",
+            "-o", boost::filesystem::path(osc_path).replace_extension("").string(),
+            "-x", "/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection");
+          // clang-format on
         }
 
         SimulatorCore::activate(


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Description

Exclude a too large topic `/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection` from bag recording.