### PR TITLE
ci(docker): use GitHub Container Registry

### DIFF
--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          tags: ${{ matrix.rosdistro }}
+          tags: ghcr.io/${{ github.repository_owner }}/scenario_simulator_v2:${{ matrix.rosdistro }}
           no-cache: true
           build-args: ROS_DISTRO=${{ matrix.rosdistro }}
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -29,30 +29,22 @@ jobs:
       matrix:
         rosdistro: [galactic]
     steps:
-      - uses: actions/checkout@v2-beta
-      - name: Build and Push Docker Image
-        if: ${{ github.event_name != 'pull_request'}}
-        uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
+      - uses: actions/checkout@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: tier4/scenario_simulator_v2
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
           tags: ${{ matrix.rosdistro }}
           no-cache: true
-          build_args: ROS_DISTRO=${{ matrix.rosdistro }}
-          push: true
-      - name: Build Docker Image
-        if: ${{ github.event_name == 'pull_request'}}
-        uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: tier4/scenario_simulator_v2
-          tags: ${{ matrix.rosdistro }}
-          no-cache: true
-          build_args: ROS_DISTRO=${{ matrix.rosdistro }}
-          push: false
+          build-args: ROS_DISTRO=${{ matrix.rosdistro }}
+          push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description

Since TIER IV will stop using DockerHub, I've replaced DockerHub with GitHub Container Registry.

```bash
# Current
docker pull tier4/scenario_simulator_v2:galactic

# New
docker pull ghcr.io/tier4/scenario_simulator_v2:galactic
```

## How to review this PR.

Check my test result.
https://github.com/kenji-miyake/scenario_simulator_v2/runs/7443721307?check_suite_focus=true
https://github.com/kenji-miyake/scenario_simulator_v2/pkgs/container/scenario_simulator_v2

## Others
