### PR TITLE
chore(topic_status_checker): update timeout

### DIFF
--- a/common/topic_status_checker/README.md
+++ b/common/topic_status_checker/README.md
@@ -29,6 +29,6 @@ The meaning of the return codes is shown in the table below.
 | parameter name          | description                                                    | default value |
 |-------------------------|----------------------------------------------------------------|---------------|
 | topic_name              | name of the topic                                              | ""            |
-| timeout_ms              | timeout for waiting to receive the topic (unit : milliseconds) | 1000          |
+| timeout_ms              | timeout for waiting to receive the topic (unit : milliseconds) | 2000          |
 | topic_discovery_time_ms | discovery time for the topic (unit : milliseconds)             | 500           |
 | verbose                 | whether to give verbose output                                 | false         |

--- a/common/topic_status_checker/README.md
+++ b/common/topic_status_checker/README.md
@@ -30,5 +30,5 @@ The meaning of the return codes is shown in the table below.
 |-------------------------|----------------------------------------------------------------|---------------|
 | topic_name              | name of the topic                                              | ""            |
 | timeout_ms              | timeout for waiting to receive the topic (unit : milliseconds) | 2000          |
-| topic_discovery_time_ms | discovery time for the topic (unit : milliseconds)             | 500           |
+| topic_discovery_time_ms | discovery time for the topic (unit : milliseconds)             | 1000           |
 | verbose                 | whether to give verbose output                                 | false         |

--- a/common/topic_status_checker/src/topic_status_checker.cpp
+++ b/common/topic_status_checker/src/topic_status_checker.cpp
@@ -33,7 +33,7 @@ int main(int argc, char * argv[])
   std::string topic_name;
   node->get_parameter<std::string>("topic_name", topic_name);
 
-  node->declare_parameter<int>("timeout_ms", 1000);
+  node->declare_parameter<int>("timeout_ms", 2000);
   int timeout_ms;
   node->get_parameter<int>("timeout_ms", timeout_ms);
 

--- a/common/topic_status_checker/src/topic_status_checker.cpp
+++ b/common/topic_status_checker/src/topic_status_checker.cpp
@@ -42,7 +42,7 @@ int main(int argc, char * argv[])
   node->get_parameter<int>("topic_discovery_time_ms", topic_discovery_time_ms);
 
   bool verbose;
-  node->declare_parameter<bool>("verbose", false);
+  node->declare_parameter<bool>("verbose", true);
   node->get_parameter<bool>("verbose", verbose);
 
   // wait for topic discovery

--- a/common/topic_status_checker/src/topic_status_checker.cpp
+++ b/common/topic_status_checker/src/topic_status_checker.cpp
@@ -38,7 +38,7 @@ int main(int argc, char * argv[])
   node->get_parameter<int>("timeout_ms", timeout_ms);
 
   int topic_discovery_time_ms;
-  node->declare_parameter<int>("topic_discovery_time_ms", 500);
+  node->declare_parameter<int>("topic_discovery_time_ms", 1000);
   node->get_parameter<int>("topic_discovery_time_ms", topic_discovery_time_ms);
 
   bool verbose;


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description
Update default timeout of`topic_status_checker` 
## How to review this PR.

## Others
