### PR TITLE
chore(concealer): remove unused had_map_route msg 

### DIFF
--- a/external/concealer/include/concealer/autoware_universe.hpp
+++ b/external/concealer/include/concealer/autoware_universe.hpp
@@ -17,7 +17,6 @@
 
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 #include <autoware_auto_perception_msgs/msg/traffic_signal_array.hpp>
-#include <autoware_auto_planning_msgs/msg/had_map_route.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_system_msgs/msg/autoware_state.hpp>


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix
- [x] Chore

## Link to the issue

## Description

In https://github.com/autowarefoundation/autoware.universe/pull/2356 HadMapRoute is replaced with LaneletRoute, so remove this msg from concealer.

## How to review this PR.

## Others
