### PR TITLE
fix(concealer): remove unnecessary wait for autoware states

### DIFF
--- a/external/concealer/src/autoware_universe.cpp
+++ b/external/concealer/src/autoware_universe.cpp
@@ -65,7 +65,6 @@ auto AutowareUniverse::initialize(const geometry_msgs::msg::Pose & initial_pose)
   if (not std::exchange(initialize_was_called, true)) {
     task_queue.delay([this, initial_pose]() {
       set(initial_pose);
-      waitForAutowareStateToBeInitializing();
       waitForAutowareStateToBeWaitingForRoute([&]() {
         InitialPose initial_pose;
         {
@@ -98,8 +97,7 @@ auto AutowareUniverse::plan(const std::vector<geometry_msgs::msg::PoseStamped> &
     for (const auto & each : route | boost::adaptors::sliced(0, route.size() - 1)) {
       setCheckpoint(each);
     }
-    waitForAutowareStateToBePlanning();
-    waitForAutowareStateToBeWaitingForEngage();  // NOTE: Autoware.IV 0.11.1 waits about 3 sec from the completion of Planning until the transition to WaitingForEngage.
+    waitForAutowareStateToBeWaitingForEngage();
   });
 }
 


### PR DESCRIPTION
Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>

## Types of PR

- [ ] New Features
- [x] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description
This PR removes unnecessary waits for autoware state.

For example, in L101-102 current implementation has `waitForAutowareStateToBePlanning()` followed by `waitForAutowareStateToBeWaitingForEngage()`, but we don't have any operation needed from scenario simulator during Planning state so the first wait is unnecessary. If Autoware transition from Planning to WaitForEngage instantaneously, sometimes simulator miss the topic and gets stuck at the first wait function. This PR avoids such issues.

## How to review this PR.
Run example scenarios.
e.g., https://evaluation.tier4.jp/evaluation/reports/fd4a0518-fa39-5d71-b26a-16d671aa1560/tests/5c59b439-3fe4-53a5-9ee6-2f9b7a552ee6/9a90f6f5-c5cd-5be0-b347-616f750d105c/17a5d073-deea-54af-af1e-6987f42b7a21?project_id=awf#

## Others
