### PR TITLE
delete metric when the entity was despawned

### DIFF
--- a/simulation/traffic_simulator/src/metrics/out_of_range_metric.cpp
+++ b/simulation/traffic_simulator/src/metrics/out_of_range_metric.cpp
@@ -30,6 +30,10 @@ void OutOfRangeMetric::setEntityManager(
 
 void OutOfRangeMetric::update()
 {
+  if (!entity_manager_ptr_->entityExists(target_entity)) {
+    success();
+    return;
+  }
   const auto status = entity_manager_ptr_->getEntityStatus(target_entity);
 
   linear_velocity_ = status.action_status.twist.linear.x;


### PR DESCRIPTION
Signed-off-by: Masaya Kataoka <ms.kataoka@gmail.com>

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

delete metric when the entity was despawned

## How to review this PR.

## Others
