### PR TITLE
update trigger for heavy ci workflows

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -5,15 +5,13 @@ on:
   schedule:
     - cron: 0 0 * * *
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "README.md"
-      - "workflows/Docker.yaml"
-      - "workflows/Documentation.yaml"
-      - "workflows/NotifyFailure.yaml"
-      - "workflows/Release.yaml"
-      - "workflows/SpellCheck.yaml"
+    paths:
+      - '**''
+      - '!docs/**'
+      - '!README.md'
+      - '!.github/**'
+      - '.github/workflows/Build.yaml'
+      - '!mkdocs.yml'
 
 jobs:
   build:

--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -6,7 +6,7 @@ on:
     - cron: 0 0 * * *
   pull_request:
     paths:
-      - '**''
+      - '**'
       - '!docs/**'
       - '!README.md'
       - '!.github/**'

--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -5,16 +5,13 @@ on:
   schedule:
     - cron: 0 0 * * *
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "README.md"
-      - "workflows/Build.yaml"
-      - "workflows/Documentation.yaml"
-      - "workflows/NotifyFailure.yaml"
-      - "workflows/Release.yaml"
-      - "workflows/ScenarioTest.yaml"
-      - "workflows/SpellCheck.yaml"
+    paths:
+      - '**''
+      - '!docs/**'
+      - '!README.md'
+      - '!.github/**'
+      - '.github/workflows/Docker.yaml'
+      - '!mkdocs.yml'
   push:
     branches:
       - master

--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -6,7 +6,7 @@ on:
     - cron: 0 0 * * *
   pull_request:
     paths:
-      - '**''
+      - '**'
       - '!docs/**'
       - '!README.md'
       - '!.github/**'

--- a/.github/workflows/ScenarioTest.yaml
+++ b/.github/workflows/ScenarioTest.yaml
@@ -5,15 +5,13 @@ on:
   schedule:
     - cron: 0 0 * * *
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "README.md"
-      - "workflows/Docker.yaml"
-      - "workflows/Documentation.yaml"
-      - "workflows/NotifyFailure.yaml"
-      - "workflows/Release.yaml"
-      - "workflows/SpellCheck.yaml"
+    paths:
+      - '**''
+      - '!docs/**'
+      - '!README.md'
+      - '!.github/**'
+      - '.github/workflows/ScenarioTest.yaml'
+      - '!mkdocs.yml'
   push:
     branches:
       - master

--- a/.github/workflows/ScenarioTest.yaml
+++ b/.github/workflows/ScenarioTest.yaml
@@ -6,7 +6,7 @@ on:
     - cron: 0 0 * * *
   pull_request:
     paths:
-      - '**''
+      - '**'
       - '!docs/**'
       - '!README.md'
       - '!.github/**'


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description

If you write using `paths-ignore` filter to write triggers, you need to maintain all workflow triggers every time you add a workflow.
But it's cumbersome, and in fact, maintenance has been abandoned.

In this pull request, I suggest writting triggers with `paths` filter and `!` character.
With this, "All workflow files other than your own" can be expressed very simply, and maintenance is not required even if workflows are added.

reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths

## How to review this PR.

## Others
