### PR TITLE
Fix/AJD-653 map path files

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -339,10 +339,11 @@ public:
     template <typename... Ts>
     static auto evaluateSimulationTime(Ts &&... xs) -> double
     {
-      if(SimulatorCore::active())
+      if (SimulatorCore::active()) {
         return core->getCurrentTime(std::forward<decltype(xs)>(xs)...);
-      else
+      } else {
         return std::numeric_limits<double>::quiet_NaN();
+      }
     }
 
     template <typename... Ts>

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -339,7 +339,10 @@ public:
     template <typename... Ts>
     static auto evaluateSimulationTime(Ts &&... xs) -> double
     {
-      return core->getCurrentTime(std::forward<decltype(xs)>(xs)...);
+      if(SimulatorCore::active())
+        return core->getCurrentTime(std::forward<decltype(xs)>(xs)...);
+      else
+        return std::numeric_limits<double>::quiet_NaN();
     }
 
     template <typename... Ts>

--- a/simulation/traffic_simulator/include/traffic_simulator/api/configuration.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/api/configuration.hpp
@@ -85,10 +85,9 @@ struct Configuration
         "The map_path must be a directory (given an ", std::quoted(map_path.string()), ")");
     } else if (not contains(map_path, ".osm")) {
       throw common::SimulationError("The map_path must contain at least one *.osm file");
+    } else if (not contains(map_path, ".pcd")) {
+      throw common::SimulationError("The map_path must contain at least one *.pcd file");
     }
-    // else if (not contains(map_path, ".pcd")) {
-    //   throw common::SimulationError("The map_path must contain at least one *.pcd file");
-    // }
     else {
       return map_path;
     }

--- a/simulation/traffic_simulator/include/traffic_simulator/api/configuration.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/api/configuration.hpp
@@ -87,8 +87,7 @@ struct Configuration
       throw common::SimulationError("The map_path must contain at least one *.osm file");
     } else if (not contains(map_path, ".pcd")) {
       throw common::SimulationError("The map_path must contain at least one *.pcd file");
-    }
-    else {
+    } else {
       return map_path;
     }
   }


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
https://tier4.atlassian.net/browse/AJD-653?atlOrigin=eyJpIjoiYzgyM2I2OTAzYzUzNDcwNGExOWJlYjJlZDhkMGM1MzYiLCJwIjoiaiJ9

## Description
Two changes were introduced:
- Throwing an exception for missing `*.osm` file in map path has been uncommented.
- The situation with exception handling before `SimulationCore` is `activated` (or after it was `deactivated`) has been fixed - in this case getting simulation time is not possible.

## How to review this PR.

## Others
Regression tests have been done, details of the analysis are described here:
- https://tier4.atlassian.net/browse/AJD-658?focusedCommentId=112243
- https://tier4.atlassian.net/browse/AJD-658?focusedCommentId=112241

Tsutake-san has made sure the results of regression tests.