### PR TITLE
Fix/AJD-655 terminates sigint and normal way

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -58,7 +58,14 @@ public:
 
   static auto active() { return static_cast<bool>(core); }
 
-  static auto deactivate() -> void { core.reset(); }
+  static auto deactivate() -> void 
+  { 
+    if(active())
+    {
+      core->closeZMQConnection();
+      core.reset(); 
+    }
+  }
 
   static auto update() -> void { core->updateFrame(); }
 

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -58,12 +58,11 @@ public:
 
   static auto active() { return static_cast<bool>(core); }
 
-  static auto deactivate() -> void 
-  { 
-    if(active())
-    {
+  static auto deactivate() -> void
+  {
+    if (active()) {
       core->closeZMQConnection();
-      core.reset(); 
+      core.reset();
     }
   }
 

--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -48,7 +48,7 @@ Interpreter::Interpreter(const rclcpp::NodeOptions & options)
   DECLARE_PARAMETER(output_directory);
 }
 
-Interpreter::~Interpreter() { SimulatorCore::deactivate(); }
+Interpreter::~Interpreter() {}
 
 auto Interpreter::currentLocalFrameRate() const -> std::chrono::milliseconds
 {
@@ -261,6 +261,8 @@ auto Interpreter::on_deactivate(const rclcpp_lifecycle::State &) -> Result
 
 auto Interpreter::on_cleanup(const rclcpp_lifecycle::State &) -> Result
 {
+  scenarios.clear();
+  script.reset();
   return Interpreter::Result::SUCCESS;  // => Unconfigured
 }
 
@@ -274,7 +276,9 @@ auto Interpreter::on_error(const rclcpp_lifecycle::State &) -> Result
 auto Interpreter::on_shutdown(const rclcpp_lifecycle::State &) -> Result
 {
   timer.reset();
-
+  scenarios.clear();
+  script.reset();  
+  SimulatorCore::deactivate();
   return Interpreter::Result::SUCCESS;  // => Finalized
 }
 

--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -277,7 +277,7 @@ auto Interpreter::on_shutdown(const rclcpp_lifecycle::State &) -> Result
 {
   timer.reset();
   scenarios.clear();
-  script.reset();  
+  script.reset();
   SimulatorCore::deactivate();
   return Interpreter::Result::SUCCESS;  // => Finalized
 }

--- a/simulation/simulation_interface/include/simulation_interface/zmq_multi_client.hpp
+++ b/simulation/simulation_interface/include/simulation_interface/zmq_multi_client.hpp
@@ -35,7 +35,7 @@ public:
   explicit MultiClient(
     const simulation_interface::TransportProtocol & protocol, const std::string & hostname);
   ~MultiClient();
-
+  void closeConnection();
   void call(
     const simulation_api_schema::InitializeRequest & req,
     simulation_api_schema::InitializeResponse & res);

--- a/simulation/simulation_interface/src/zmq_multi_client.cpp
+++ b/simulation/simulation_interface/src/zmq_multi_client.cpp
@@ -65,8 +65,7 @@ MultiClient::MultiClient(
 
 void MultiClient::closeConnection()
 {
-  if(is_running) 
-  {
+  if (is_running) {
     is_running = false;
     socket_initialize_.close();
     socket_update_frame_.close();
@@ -83,10 +82,7 @@ void MultiClient::closeConnection()
   }
 }
 
-MultiClient::~MultiClient()
-{
-  closeConnection();
-}
+MultiClient::~MultiClient() { closeConnection(); }
 
 void MultiClient::call(
   const simulation_api_schema::InitializeRequest & req,

--- a/simulation/simulation_interface/src/zmq_multi_client.cpp
+++ b/simulation/simulation_interface/src/zmq_multi_client.cpp
@@ -61,24 +61,31 @@ MultiClient::MultiClient(
     protocol, hostname, simulation_interface::ports::attach_occupancy_grid_sensor));
   socket_update_traffic_lights_.connect(simulation_interface::getEndPoint(
     protocol, hostname, simulation_interface::ports::update_traffic_lights));
+}
 
-  rclcpp::on_shutdown([this] { is_running = false; });
+void MultiClient::closeConnection()
+{
+  if(is_running) 
+  {
+    is_running = false;
+    socket_initialize_.close();
+    socket_update_frame_.close();
+    socket_update_sensor_frame_.close();
+    socket_spawn_vehicle_entity_.close();
+    socket_spawn_pedestrian_entity_.close();
+    socket_spawn_misc_object_entity_.close();
+    socket_despawn_entity_.close();
+    socket_update_entity_status_.close();
+    socket_attach_lidar_sensor_.close();
+    socket_attach_detection_sensor_.close();
+    socket_attach_occupancy_grid_sensor_.close();
+    socket_update_traffic_lights_.close();
+  }
 }
 
 MultiClient::~MultiClient()
 {
-  socket_initialize_.close();
-  socket_update_frame_.close();
-  socket_update_sensor_frame_.close();
-  socket_spawn_vehicle_entity_.close();
-  socket_spawn_pedestrian_entity_.close();
-  socket_spawn_misc_object_entity_.close();
-  socket_despawn_entity_.close();
-  socket_update_entity_status_.close();
-  socket_attach_lidar_sensor_.close();
-  socket_attach_detection_sensor_.close();
-  socket_attach_occupancy_grid_sensor_.close();
-  socket_update_traffic_lights_.close();
+  closeConnection();
 }
 
 void MultiClient::call(

--- a/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
@@ -81,7 +81,7 @@ public:
     setVerbose(configuration.verbose);
   }
 
-  void closeZMQConnection(){zeromq_client_.closeConnection();}
+  void closeZMQConnection() { zeromq_client_.closeConnection(); }
 
   template <typename T, typename... Ts>
   void addMetric(const std::string & name, Ts &&... xs)

--- a/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
@@ -81,6 +81,8 @@ public:
     setVerbose(configuration.verbose);
   }
 
+  void closeZMQConnection(){zeromq_client_.closeConnection();}
+
   template <typename T, typename... Ts>
   void addMetric(const std::string & name, Ts &&... xs)
   {

--- a/test_runner/scenario_test_runner/scenario_test_runner/scenario_test_runner.py
+++ b/test_runner/scenario_test_runner/scenario_test_runner/scenario_test_runner.py
@@ -24,6 +24,7 @@ from shutil import rmtree
 from sys import exit
 from typing import List
 import os
+from rclpy.executors import ExternalShutdownException
 
 import rclpy
 from openscenario_preprocessor_msgs.srv import (
@@ -212,7 +213,6 @@ class ScenarioTestRunner(LifecycleController):
                 exit(1)
 
         self.shutdown()
-        # rclpy.try_shutdown()
         self.destroy_node()
 
     def run_preprocessed_scenarios(self, scenarios: List[Scenario]):
@@ -259,10 +259,10 @@ class ScenarioTestRunner(LifecycleController):
 
                 self.cleanup_node()
 
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, ExternalShutdownException):
             self.get_logger().warn("KeyboardInterrupt")
-            rclpy.try_shutdown()
             self.destroy_node()
+            rclpy.try_shutdown()
             exit(0)
         except OSError as e:
             self.get_logger().warn("OSError: {}".format(e))

--- a/test_runner/scenario_test_runner/scenario_test_runner/scenario_test_runner.py
+++ b/test_runner/scenario_test_runner/scenario_test_runner/scenario_test_runner.py
@@ -163,20 +163,18 @@ class ScenarioTestRunner(LifecycleController):
     def spin(self):
         """Run scenario."""
         time.sleep(self.SLEEP_RATE)
-        # rate=self.create_rate(self.SLEEP_RATE)
         while self.activate_node():
             start = time.time()
             while rclpy.ok():
                 if self.get_lifecycle_state() == "inactive":
                     break
-                if ((time.time() - start) > self.global_timeout
+                elif ((time.time() - start) > self.global_timeout
                         if self.global_timeout is not None else False):
                     self.get_logger().error("The simulation has timed out. Forcibly inactivate.")
                     self.deactivate_node()
                     break
                 else:
                     time.sleep(self.SLEEP_RATE)
-                    # rate.sleep()
 
     def run_scenarios(self, scenarios: List[Scenario]):
 

--- a/test_runner/scenario_test_runner/scenario_test_runner/scenario_test_runner.py
+++ b/test_runner/scenario_test_runner/scenario_test_runner/scenario_test_runner.py
@@ -162,19 +162,20 @@ class ScenarioTestRunner(LifecycleController):
     def spin(self):
         """Run scenario."""
         time.sleep(self.SLEEP_RATE)
-
+        # rate=self.create_rate(self.SLEEP_RATE)
         while self.activate_node():
             start = time.time()
-            while True:
+            while rclpy.ok():
                 if self.get_lifecycle_state() == "inactive":
                     break
-                elif ((time.time() - start) > self.global_timeout
+                if ((time.time() - start) > self.global_timeout
                         if self.global_timeout is not None else False):
                     self.get_logger().error("The simulation has timed out. Forcibly inactivate.")
                     self.deactivate_node()
                     break
                 else:
                     time.sleep(self.SLEEP_RATE)
+                    # rate.sleep()
 
     def run_scenarios(self, scenarios: List[Scenario]):
 
@@ -211,6 +212,8 @@ class ScenarioTestRunner(LifecycleController):
                 exit(1)
 
         self.shutdown()
+        # rclpy.try_shutdown()
+        self.destroy_node()
 
     def run_preprocessed_scenarios(self, scenarios: List[Scenario]):
         """
@@ -258,6 +261,9 @@ class ScenarioTestRunner(LifecycleController):
 
         except KeyboardInterrupt:
             self.get_logger().warn("KeyboardInterrupt")
+            rclpy.try_shutdown()
+            self.destroy_node()
+            exit(0)
         except OSError as e:
             self.get_logger().warn("OSError: {}".format(e))
         except Exception as e:


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
https://tier4.atlassian.net/browse/AJD-655

## Description

### 1. Ctrl+c (sigint)

When terminating a program using ctrl+c I have noticed two problems with `scenario_test_runner`:
![image](https://user-images.githubusercontent.com/121798334/216854211-21703645-d075-4b66-9ad5-cf3a2ff95525.png)
![image](https://user-images.githubusercontent.com/121798334/216854217-2cadf83e-24fa-4a76-8b2e-b9fbd676c9ae.png)

I’ve fixed both errors, have made the following changes:
- ExternalShutdownException - catches exception from error 2,
- self.destroy_node() - fees resources used by the node,
- rospy.try_shutdown() - shutdown rclpy if not already shutdown,
- exit(0) - terminates a program with code 0 (terminates program before calling from error 2).

### 2. normal way
When normal way terminating a program I have noticed one problem with `openscenario_interpreter`:
![image](https://user-images.githubusercontent.com/121798334/216854494-8c97720c-bbe0-41ca-808b-abd27ee24d4a.png)
The directly source of the problem was a line in the MultiClient constructor:
`rclcpp::on_shutdown([this] { is_running = false; });`

I’ve removed the mentioned line of code. 
I’ve added `closeConnection` method definition to close the client connection without calling the `MultiClient` destructor.
I’ve added an intermediate `closeConnection` call to the `SimpleCore` deactivate method (`simulator_core.hpp`).
## How to review this PR.

## Others
Details and regression tests:
https://tier4.atlassian.net/browse/AJD-655?focusedCommentId=111282
https://tier4.atlassian.net/browse/AJD-655?focusedCommentId=111486
https://tier4.atlassian.net/browse/AJD-655?focusedCommentId=112809
