### PR TITLE
Fix/AJD-658 abnormal longitudinal speed

### DIFF
--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/move_backward_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/move_backward_action.cpp
@@ -75,10 +75,9 @@ BT::NodeStatus MoveBackwardAction::tick()
   if (waypoints.waypoints.empty()) {
     return BT::NodeStatus::FAILURE;
   }
-  auto following_lanelets =
-    hdmap_utils->getPreviousLanelets(entity_status.lanelet_pose.lanelet_id);
   if (!target_speed) {
-    target_speed = hdmap_utils->getSpeedLimit(following_lanelets);
+    target_speed = hdmap_utils->getSpeedLimit(
+      hdmap_utils->getPreviousLanelets(entity_status.lanelet_pose.lanelet_id));
   }
   setOutput("updated_status", calculateUpdatedEntityStatus(target_speed.get()));
   const auto obstacle = calculateObstacle(waypoints);

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/move_backward_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/move_backward_action.cpp
@@ -75,6 +75,11 @@ BT::NodeStatus MoveBackwardAction::tick()
   if (waypoints.waypoints.empty()) {
     return BT::NodeStatus::FAILURE;
   }
+  auto following_lanelets =
+    hdmap_utils->getPreviousLanelets(entity_status.lanelet_pose.lanelet_id);
+  if (!target_speed) {
+    target_speed = hdmap_utils->getSpeedLimit(following_lanelets);
+  }
   setOutput("updated_status", calculateUpdatedEntityStatus(target_speed.get()));
   const auto obstacle = calculateObstacle(waypoints);
   setOutput("waypoints", waypoints);


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description
Problem:
![image](https://user-images.githubusercontent.com/121798334/216856042-706d80d9-30b2-4ae4-a5e6-d14c17c4a503.png)

The problem was related to the sometimes missing initialization of the `target_seed` variable during the tick of `MoveBackwordAction`.

- I’ve added a check before using it, if the variable is already initialized.
- If it isn't then it is assigned a value with is calculated on the basis of previous lanelets - because it's `MoveBackwordAction`.
- The changes I’ve made are based on other actions implemented in the `behavior_tree_plugin` package (there are analogous checks).

Details and tests: https://tier4.atlassian.net/browse/AJD-658?focusedCommentId=112178

## How to review this PR.

## Others
Regression tests: 
https://tier4.atlassian.net/browse/AJD-658?focusedCommentId=112334
https://tier4.atlassian.net/browse/AJD-658?focusedCommentId=112437
https://tier4.atlassian.net/browse/AJD-658?focusedCommentId=112801
