### PR TITLE
Fix/cspell errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,5 +27,5 @@ If applicable, add screenshots to help explain your problem.
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
- - ROS2 version
+ - ROS 2 version
  - DDS

--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -22,9 +22,9 @@ jobs:
       - name: run protoc-gen-doc
         run: docker run --rm -v $(pwd)/simulation/simulation_interface/proto/:/protos -v $(pwd)/docs/proto_doc:/out pseudomuto/protoc-gen-doc --doc_opt=markdown,protobuf.md
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10.10"
+          python-version: "3.10"
       - name: Install
         run: pip3 install mkdocs mkdocs-material pymdown-extensions fontawesome_markdown markdown python-markdown-math plantuml-markdown mkdocs-codeinclude-plugin mkdocs-git-revision-date-localized-plugin plantuml
       - name: Install doxygen/depends of doxybook

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Scenario testing framework for Autoware.
 
 ## Documentation
 
-See [Github Pages](https://tier4.github.io/scenario_simulator_v2-docs/)
+See [GitHub Pages](https://tier4.github.io/scenario_simulator_v2-docs/)

--- a/common/simple_junit/package.xml
+++ b/common/simple_junit/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>simple_junit</name>
   <version>0.6.7</version>
-  <description>Lightweight JUnit library for ROS2</description>
+  <description>Lightweight JUnit library for ROS 2</description>
   <maintainer email="masaya.kataoka@tier4.jp">Masaya Kataoka</maintainer>
   <maintainer email="tatsuya.yamasaki@tier4.jp">Tatsuya Yamasaki</maintainer>
   <license>Apache License 2.0</license>

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -133,7 +133,7 @@ Major Changes :race_car: :red_car: :blue_car:
 | Feature                                       | Brief summary                                                                                                                                                            | Category                                                          | Pull request                                                    | Contributor                                   |
 |-----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|-----------------------------------------------------------------|-----------------------------------------------|
 | Entity label publisher                        | Enable specify and publish NPC semantic information such as `MOTORCYCLE`, `TRUCK`, `BUS`.                                                                                | `traffic_simulator`                                               | [#726](https://github.com/tier4/scenario_simulator_v2/pull/726) | [hakuturu583](https://github.com/hakuturu583) |
-| ROS2 Launch XML-like substitution syntax      | Add new substitution syntax `$(ros2 <argument>...)`.                                                                                                                     | `openscenario_interpreter`                                        | [#727](https://github.com/tier4/scenario_simulator_v2/pull/727) | [yamacir-kit](https://github.com/yamacir-kit) |
+| ROS 2 Launch XML-like substitution syntax      | Add new substitution syntax `$(ros2 <argument>...)`.                                                                                                                     | `openscenario_interpreter`                                        | [#727](https://github.com/tier4/scenario_simulator_v2/pull/727) | [yamacir-kit](https://github.com/yamacir-kit) |
 | `Filter by range` option                      | Add `filter by range` option for detection sensor. If false, simulate detection result by lidar detection. If true, simulate detection result by range.                  | `traffic_simulator`                                               | [#729](https://github.com/tier4/scenario_simulator_v2/pull/729) | [hakuturu583](https://github.com/hakuturu583) |
 | Optimization of the trajectory calculation    | Hermite curve optimization, entities' trajectories calculated only when route changes                                                                                    | `traffic_simulator`, `behavior_tree_plugin`                       | [#708](https://github.com/tier4/scenario_simulator_v2/pull/708) | [danielm1405](https://github.com/danielm1405) |
 | OpenSCENARIO `Controller.Properties.Property` | Support new controller property `isClairvoyant`.                                                                                                                         | `openscenario_interpreter`                                        | [#735](https://github.com/tier4/scenario_simulator_v2/pull/735) | [yamacir-kit](https://github.com/yamacir-kit) |
@@ -161,7 +161,7 @@ Minor Tweaks :oncoming_police_car:
 ## Version 0.6.3
 - Speed up metrics manger class in order to reduce frame-rate dropping problem. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/680))
 - Fix problem in warping NPCs spawned in world coordinate. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/686))
-- End of support for ROS2 Foxy and Autoware.Auto ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/696)).
+- End of support for ROS 2 Foxy and Autoware.Auto ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/696)).
 - Fix problem in ideal steer acc geared dynamics model. Vehicle was pulled back very slowly even if the vehicle is stopped. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/698))
 - Fix problem in getFrontEntityName function, consider yaw difference while stopping at crossing entity. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/703))
 - Fix problem in delay steer acc geared dynamics model. Vehicle was pulled back very slowly even if the vehicle is stopped. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/707))
@@ -206,7 +206,7 @@ Minor Tweaks :oncoming_police_car:
 - Add NPC Behavior Plugin and Behavior-Tree Plugin for Vehicle and Pedestrian. ([link](https://github.com/tier4/scenario_simulator_v2/pull/566))
 - Rename package `openscenario_msgs` to `traffic_simulator_msgs`
 - Start supporting galactic environment with Docker. ([link](https://github.com/tier4/scenario_simulator_v2/pull/576))
-- Update `UserDefinedValueCondition` to subscribe ROS2 topic if path-like name given ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/567)).
+- Update `UserDefinedValueCondition` to subscribe ROS 2 topic if path-like name given ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/567)).
 - Add new package `openscenario_msgs` ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/567)).
 - Add getNearbyLaneletIds and filterLaneletIds function in HdMapUtils class. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/585))
 - Fix calculating way of longitudinal distance. If forward distance and backward distance was calculated, choose smaller one. ([pull request](https://github.com/tier4/scenario_simulator_v2/pull/586))
@@ -288,7 +288,7 @@ Minor Tweaks :oncoming_police_car:
 - Update AcquirePositionAction to support WorldPosition as destination.
 - Update syntax 'RoadNetwork.LogicFile' to allow user to specify the directory that contains `lanelet2_map.osm`.
 - Check boost::none in TargetSpeedPlanner class.
-- Add ROS2 galactic support.
+- Add ROS 2 galactic support.
 - Update EgoEntity to publish self-position as PoseWithCovarianceStamped.
 
 ## Version 0.3.0

--- a/docs/developer_guide/OpenSCENARIOSupport.md
+++ b/docs/developer_guide/OpenSCENARIOSupport.md
@@ -1,6 +1,6 @@
 # OpenSCENARIO Support
 
-The ROS2 package `openscenario_interpreter` provides scenario-based simulation on [ASAM OpenSCENARIO 1.0](https://www.asam.net/standards/detail/openscenario/).
+The ROS 2 package `openscenario_interpreter` provides scenario-based simulation on [ASAM OpenSCENARIO 1.0](https://www.asam.net/standards/detail/openscenario/).
 This section describes the differences between our OpenSCENARIO Interpreter and the OpenSCENARIO standard set by ASAM, and the OpenSCENARIO implementation by other companies and organizations.
 If you want to know about OpenSCENARIO, refer to the link below.
 
@@ -168,10 +168,10 @@ See Reference for specific strings.
 | currentTurnIndicatorsState | `<ENTITY-REF>.currentTurnIndicatorsState`                                                                | Returns Autoware's [turn indicators state](https://github.com/tier4/autoware_auto_msgs/blob/tier4/main/autoware_auto_vehicle_msgs/msg/TurnIndicatorsCommand.idl). `<ENTITY-REF>` must be the name of Vehicle with ObjectController's property `isEgo` set to true. |
 | RelativeHeadingCondition   | `RelativeHeadingCondition(<ENTITY-REF>)` <br> `RelativeHeadingCondition(<ENTITY-REF>, <LANE-ID>, <S>)`   | Returns the relative angle to the lane heading.                                                                                                                                                                                                                    |
 
-#### External ROS2 topic condition
+#### External ROS 2 topic condition
 
-You can pass values from another ROS2 node to a scenario through ROS2 topics.
-The `name` field should be filled with the name of the ROS2 topic like below.
+You can pass values from another ROS 2 node to a scenario through ROS 2 topics.
+The `name` field should be filled with the name of the ROS 2 topic like below.
 ```XML
   <ByValueCondition>
      <UserDefinedValueCondition name="/count_up" rule="equalTo" value="500" />

--- a/docs/developer_guide/ZeroMQ.md
+++ b/docs/developer_guide/ZeroMQ.md
@@ -42,8 +42,8 @@ sequenceDiagram
       Traffic Simulator ->+ Simple Sensor Simulator : UpdateFrameRequest
       Simple Sensor Simulator ->-Traffic Simulator : UpdateFrameResponse
       Traffic Simulator ->+ Simple Sensor Simulator : UpdateEntityStatusRequest
-      Simple Sensor Simulator ->> Autoware : Send Pointcloud (ROS2 topic)
-      Simple Sensor Simulator ->> Autoware : Send Detection Result (ROS2 topic)
+      Simple Sensor Simulator ->> Autoware : Send Pointcloud (ROS 2 topic)
+      Simple Sensor Simulator ->> Autoware : Send Detection Result (ROS 2 topic)
       Simple Sensor Simulator ->-Traffic Simulator : UpdateEntityStatusResponse
     end
 ```

--- a/docs/developer_guide/uml/sequence.pu
+++ b/docs/developer_guide/uml/sequence.pu
@@ -17,15 +17,15 @@ loop run single test case
     scenario_test_runner -> openscenario_interpreter_node:configure
 
     openscenario_interpreter_node -> openscenario_interpreter_node: resolve path of the\nlanelet2 map and load it.
-    openscenario_interpreter_node -> Autoware : send lanelet2 map via ROS2 topic.
+    openscenario_interpreter_node -> Autoware : send lanelet2 map via ROS 2 topic.
 
     openscenario_interpreter_node -> simulator: initialize via ZeroMQ
     simulator -> openscenario_interpreter_node: response to initialize\nvia ZeroMQ
 
     loop until the simulation was finished
         openscenario_interpreter_node -> simulator: update simulation frame\nvia ZeroMQ
-        simulator -> Autoware: send sensor data via ROS2 topic.
-        Autoware -> simulator: send vehicle command via ROS2 topic.
+        simulator -> Autoware: send sensor data via ROS 2 topic.
+        Autoware -> simulator: send vehicle command via ROS 2 topic.
         openscenario_interpreter_node <-- simulator: response to update simulation\nframe via ZeroMQ
     end
     openscenario_interpreter_node -> scenario_writer : output test result as junit file

--- a/docs/user_guide/BuildInstructions.md
+++ b/docs/user_guide/BuildInstructions.md
@@ -1,10 +1,10 @@
 # Build Instructions
 
-This setup instruction is based on ROS2-galactic.
+This setup instruction is based on ROS 2 galactic.
 
 ## Setup ROS 2 environment
 
-This framework only supports ROS 2 Galactic Geochelone now. (We are planning to support ROS2 Humble Hawksbill)  
+This framework only supports ROS 2 Galactic Geochelone now. (We are planning to support ROS 2 Humble Hawksbill)  
 You can install Galactic by executing the command below in your terminal.
 
 ```bash

--- a/docs/user_guide/QuickStart.md
+++ b/docs/user_guide/QuickStart.md
@@ -5,7 +5,7 @@ This document contains step-by-step instruction on how to build and run [AWF Aut
 ## Prerequisites 
 
 1. Ubuntu 20.04 machine
-3. ROS2 Galactic Geochelone desktop version [installed](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html)
+3. ROS 2 Galactic Geochelone desktop version [installed](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html)
 
 ## How to build
 

--- a/docs/user_guide/deprected/RunWithAutowareArchitectureProposal.md
+++ b/docs/user_guide/deprected/RunWithAutowareArchitectureProposal.md
@@ -6,7 +6,7 @@ This document contains step-by-step instruction on how to build and run [Autowar
 
 1. Ubuntu 20.04 machine
 2. Hardware with CUDA 11.1 capable graphics card
-3. ROS2 Galactic Geochelone desktop version [installed](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html) and sourced:
+3. ROS 2 Galactic Geochelone desktop version [installed](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html) and sourced:
    ```bash
    source /opt/ros/galactic/setup.bash
    ```

--- a/docs/user_guide/random_test_runner/README.md
+++ b/docs/user_guide/random_test_runner/README.md
@@ -141,7 +141,7 @@ TBD
 [//]: # (|----------------------------------------------------------------------------------------------------------------|)
 
 [//]: # ()
-[//]: # (|  NOTE: Kashiwanoha project is only supported on ROS2 `galactic` but simulation interfaces are distribution-independent and random tests can be executed safely on `foxy` |)
+[//]: # (|  NOTE: Kashiwanoha project is only supported on ROS 2 `galactic` but simulation interfaces are distribution-independent and random tests can be executed safely on `foxy` |)
 
 [//]: # (|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|)
 

--- a/docs/user_guide/scenario_test_runner/HowToWriteWorkflowFile.md
+++ b/docs/user_guide/scenario_test_runner/HowToWriteWorkflowFile.md
@@ -13,7 +13,7 @@ The workflow file defines how to execute scenarios and its expected results.
 ## Examples of writing parameters
 ### path
 
-You can solve relative path from the "share" directories in your ROS2 packages.
+You can solve relative path from the "share" directories in your ROS 2 packages.
 ```yaml
 path: $(find-pkg-share PACKAGE_NAME)/test/scenario/simple.xosc
 ```

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/reader/attribute.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/reader/attribute.hpp
@@ -81,7 +81,7 @@ auto substitute(std::string attribute, Scope & scope)
       // TODO {"find-exec", find_exec},
       // TODO {"find-pkg-prefix", find_pkg_prefix},
       {"find-pkg-share", find_pkg_share},
-      {"ros2", ros2},  // NOTE: TIER IV extension (Not included in the ROS2 Launch XML Substitution)
+      {"ros2", ros2},  // NOTE: TIER IV extension (Not included in the ROS 2 Launch XML Substitution)
       {"var", var},
     };
 

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/reader/attribute.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/reader/attribute.hpp
@@ -81,7 +81,8 @@ auto substitute(std::string attribute, Scope & scope)
       // TODO {"find-exec", find_exec},
       // TODO {"find-pkg-prefix", find_pkg_prefix},
       {"find-pkg-share", find_pkg_share},
-      {"ros2", ros2},  // NOTE: TIER IV extension (Not included in the ROS 2 Launch XML Substitution)
+      {"ros2",
+       ros2},  // NOTE: TIER IV extension (Not included in the ROS 2 Launch XML Substitution)
       {"var", var},
     };
 

--- a/openscenario/openscenario_interpreter/src/syntax/user_defined_value_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/user_defined_value_condition.cpp
@@ -160,7 +160,7 @@ UserDefinedValueCondition::UserDefinedValueCondition(const pugi::xml_node & node
     };
 #else
     throw SyntaxError(
-      "The ability to have ROS2 topics as values for `UserDefinedValueCondition` is enabled only "
+      "The ability to have ROS 2 topics as values for `UserDefinedValueCondition` is enabled only "
       "when the `UserDefinedValue` type is present in the `tier4_simulation_msgs` package.");
 #endif
   } else {

--- a/openscenario/openscenario_interpreter_example/src/count_up.cpp
+++ b/openscenario/openscenario_interpreter_example/src/count_up.cpp
@@ -103,7 +103,7 @@ int main(const int argc, char const * const * const argv)
     std::chrono::milliseconds(100), [&]() { publisher->publish(make_message()); });
 #else
   std::cout
-    << "The ability to have ROS2 topics as values for `UserDefinedValueCondition` is enabled only "
+    << "The ability to have ROS 2 topics as values for `UserDefinedValueCondition` is enabled only "
        "when the `UserDefinedValue` type is present in the `tier4_simulation_msgs` package."
     << std::endl;
 #endif

--- a/openscenario/openscenario_interpreter_example/src/timeout.cpp
+++ b/openscenario/openscenario_interpreter_example/src/timeout.cpp
@@ -123,7 +123,7 @@ int main(const int argc, char const * const * const argv)
     std::chrono::milliseconds(100), [&]() { publisher->publish(make_message(status)); });
 #else
   std::cout
-    << "The ability to have ROS2 topics as values for `UserDefinedValueCondition` is enabled only "
+    << "The ability to have ROS 2 topics as values for `UserDefinedValueCondition` is enabled only "
        "when the `UserDefinedValue` type is present in the `tier4_simulation_msgs` package."
     << std::endl;
 #endif

--- a/openscenario/openscenario_visualization/include/openscenario_visualization/openscenario_visualization_component.hpp
+++ b/openscenario/openscenario_visualization/include/openscenario_visualization/openscenario_visualization_component.hpp
@@ -75,7 +75,7 @@ extern "C" {
 namespace openscenario_visualization
 {
 /**
- * @brief ROS2 component for visualizing simulation result.
+ * @brief ROS 2 component for visualizing simulation result.
  */
 class OpenscenarioVisualizationComponent : public rclcpp::Node
 {

--- a/openscenario/openscenario_visualization/src/openscenario_visualization_component.cpp
+++ b/openscenario/openscenario_visualization/src/openscenario_visualization_component.cpp
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 /**
- * @mainpage ROS2 visualization component for OpenSCENARIO entities
+ * @mainpage ROS 2 visualization component for OpenSCENARIO entities
  * @tableofcontents
  * @image html images/rviz.png width=1280px height=540px
  * @author Masaya Kataoka
  * @date 2020-11-19
  * @section interface
   <table>
-    <caption id="multi_row">ROS2 Topic interface</caption>
+    <caption id="multi_row">ROS 2 Topic interface</caption>
     <tr>
       <th>Name</th>
       <th>Type</th>

--- a/openscenario/openscenario_visualization/src/openscenario_visualization_node.cpp
+++ b/openscenario/openscenario_visualization/src/openscenario_visualization_node.cpp
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 /**
- * @mainpage ROS2 visualization node for OpenSCENARIO entities
+ * @mainpage ROS 2 visualization node for OpenSCENARIO entities
  * @image html images/rviz.png width=1280px height=540px
  * @author Masaya Kataoka
  * @date 2020-11-19
  * @section interface
   <table>
-    <caption id="multi_row">ROS2 Topic interface</caption>
+    <caption id="multi_row">ROS 2 Topic interface</caption>
     <tr>
       <th>Name</th>
       <th>Type</th>

--- a/simulation/simulation_interface/proto/builtin_interfaces.proto
+++ b/simulation/simulation_interface/proto/builtin_interfaces.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package builtin_interfaces;
 
 /**
- * Protobuf definition of builtin_interface/msg/Duration type in ROS2.
+ * Protobuf definition of builtin_interface/msg/Duration type in ROS 2.
  **/
 message Duration {
   int32 sec = 1; // The seconds component, valid over all int32 values.
@@ -11,7 +11,7 @@ message Duration {
 }
 
 /**
- * Protobuf definition of builtin_interface/msg/Time type in ROS2.
+ * Protobuf definition of builtin_interface/msg/Time type in ROS 2.
  **/
 message Time {
   int32 sec = 1; // The seconds component, valid over all int32 values.

--- a/simulation/simulation_interface/proto/geometry_msgs.proto
+++ b/simulation/simulation_interface/proto/geometry_msgs.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
 /**
- * Protobuf package to define [geometry_msgs in ROS2.](https://github.com/ros2/common_interfaces/tree/master/geometry_msgs)
+ * Protobuf package to define [geometry_msgs in ROS 2.](https://github.com/ros2/common_interfaces/tree/master/geometry_msgs)
  */
 package geometry_msgs;
 
 /**
- * Protobuf definition of [geometry_msgs/msg/Point type in ROS2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Point.msg)
+ * Protobuf definition of [geometry_msgs/msg/Point type in ROS 2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Point.msg)
  **/
 message Point {
   double x = 1; // X value in a cartesian coordinate.
@@ -15,7 +15,7 @@ message Point {
 }
 
 /**
- * Protobuf definition of [geometry_msgs/msg/Quaternion type in ROS2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Quaternion.msg)
+ * Protobuf definition of [geometry_msgs/msg/Quaternion type in ROS 2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Quaternion.msg)
  **/
 message Quaternion {
   double x = 1; // X value in a quaternion. (0 <= x <= 1)
@@ -25,7 +25,7 @@ message Quaternion {
 }
 
 /**
- * Protobuf definition of [geometry_msgs/msg/Pose type in ROS2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Pose.msg)
+ * Protobuf definition of [geometry_msgs/msg/Pose type in ROS 2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Pose.msg)
  **/
 message Pose {
   Point position = 1;         // Position of the pose.
@@ -33,7 +33,7 @@ message Pose {
 }
 
 /**
- * Protobuf definition of [geometry_msgs/msg/Vector3 type in ROS2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Vector3.msg)
+ * Protobuf definition of [geometry_msgs/msg/Vector3 type in ROS 2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Vector3.msg)
  **/
 message Vector3 {
   double x = 1; // First variable in vector
@@ -42,7 +42,7 @@ message Vector3 {
 }
 
 /**
- * Protobuf definition of [geometry_msgs/msg/Twist type in ROS2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Twist.msg)
+ * Protobuf definition of [geometry_msgs/msg/Twist type in ROS 2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Twist.msg)
  **/
 message Twist {
   Vector3 linear = 1;  // Linear velocity
@@ -50,7 +50,7 @@ message Twist {
 }
 
 /**
- * Protobuf definition of [geometry_msgs/msg/Accel type in ROS2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Accel.msg)
+ * Protobuf definition of [geometry_msgs/msg/Accel type in ROS 2.](https://github.com/ros2/common_interfaces/blob/master/geometry_msgs/msg/Accel.msg)
  **/
 message Accel {
   Vector3 linear = 1;  // Linear acceleration

--- a/simulation/simulation_interface/proto/rosgraph_msgs.proto
+++ b/simulation/simulation_interface/proto/rosgraph_msgs.proto
@@ -4,7 +4,7 @@ import "builtin_interfaces.proto";
 package rosgraph_msgs;
 
 /**
- * Protobuf definition of the rosgraph_msgs/msg/Clock type in ROS2.
+ * Protobuf definition of the rosgraph_msgs/msg/Clock type in ROS 2.
  **/
 message Clock {
   builtin_interfaces.Time clock = 1; // Describe current ros time.

--- a/simulation/simulation_interface/proto/std_msgs.proto
+++ b/simulation/simulation_interface/proto/std_msgs.proto
@@ -4,7 +4,7 @@ import "builtin_interfaces.proto";
 package std_msgs;
 
 /**
- * Protobuf definition of [std_msgs::msgs::Header type in ROS2.](https://github.com/ros2/common_interfaces/blob/master/std_msgs/msg/Header.msg)
+ * Protobuf definition of [std_msgs::msgs::Header type in ROS 2.](https://github.com/ros2/common_interfaces/blob/master/std_msgs/msg/Header.msg)
  **/
 message Header {
   /**

--- a/simulation/simulation_interface/proto/traffic_simulator_msgs.proto
+++ b/simulation/simulation_interface/proto/traffic_simulator_msgs.proto
@@ -7,7 +7,7 @@ import "geometry_msgs.proto";
 package traffic_simulator_msgs;
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/ActionStatus type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/ActionStatus type in ROS 2.
  **/
 message ActionStatus {
   string current_action = 1;     // Current action of the entity.
@@ -17,7 +17,7 @@ message ActionStatus {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/BoundingBox type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/BoundingBox type in ROS 2.
  **/
 message BoundingBox {
   geometry_msgs.Point center = 1;       // Center point of the bounding box.
@@ -25,7 +25,7 @@ message BoundingBox {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/LaneletPose type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/LaneletPose type in ROS 2.
  **/
 message LaneletPose {
   int64 lanelet_id = 1;           // Lanelet id of the entity exists.
@@ -35,7 +35,7 @@ message LaneletPose {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/EntityType type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/EntityType type in ROS 2.
  **/
 
 message EntityType {
@@ -49,7 +49,7 @@ message EntityType {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/EntitySubtype type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/EntitySubtype type in ROS 2.
  **/
 message EntitySubtype {
   enum Enum {
@@ -66,7 +66,7 @@ message EntitySubtype {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/EntityStatus type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/EntityStatus type in ROS 2.
  **/
 message EntityStatus {
   EntityType type = 1;            // Type of the entity.
@@ -81,7 +81,7 @@ message EntityStatus {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/Performance type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/Performance type in ROS 2.
  **/
 message Performance {
   double max_speed = 1;             // Max speed of the entity.
@@ -92,7 +92,7 @@ message Performance {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/Axle type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/Axle type in ROS 2.
  **/
 message Axle {
   double max_steering = 1;   // Max steering of the entity axle.
@@ -103,7 +103,7 @@ message Axle {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/Axles type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/Axles type in ROS 2.
  **/
 message Axles {
   Axle front_axle = 1; // Parameters of the front axle of the entity.
@@ -111,12 +111,12 @@ message Axles {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/Property type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/Property type in ROS 2.
  **/
 message Property {}
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/VehicleParameters type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/VehicleParameters type in ROS 2.
  **/
 message VehicleParameters {
   string name = 1;              // Name of the vehicle entity
@@ -127,7 +127,7 @@ message VehicleParameters {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/PedestrianParameters type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/PedestrianParameters type in ROS 2.
  **/
 message PedestrianParameters {
   string name = 1;                // Name of the pedestrian entity.
@@ -140,7 +140,7 @@ message MiscObjectParameters {
 }
 
 /**
- * Protobuf definition of traffic_simulator_msgs/msg/Waypoints type in ROS2.
+ * Protobuf definition of traffic_simulator_msgs/msg/Waypoints type in ROS 2.
  **/
 message Waypoints {
   repeated geometry_msgs.Point waypoints = 1; // Waypoints of the entity.


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

Due to update of cspell dictionary, some wrong brand names are made to be prohibited and they come to appear as cspell errors.
This pull-request fixs them. 

## How to review this PR.

## Others
