### PR TITLE
doc: fix links in SimpleSensorSimulator.md

### DIFF
--- a/docs/developer_guide/SimpleSensorSimulator.md
+++ b/docs/developer_guide/SimpleSensorSimulator.md
@@ -18,10 +18,10 @@ With this simulation, we can get lidar point-cloud data based on simple ray-cast
 
 ### Interfaces
 
-| interface                                   | type                                   | note                                                                                       |
-|---------------------------------------------|----------------------------------------|--------------------------------------------------------------------------------------------|
-| `traffic_simulator::API::attachLidarSensor` | C++ traffic simulator API interface    |                                                                                            |
-| `attach_lidar_sensor`                       | ZeroMQ traffic simulator API interface | See [ZeroMQ Interfaces documentation](/docs/developer_guide/ZeroMQ.md)<br/>TCP Port : 5563 |  
+| interface                                   | type                                   | note                                                                 |
+|---------------------------------------------|----------------------------------------|----------------------------------------------------------------------|
+| `traffic_simulator::API::attachLidarSensor` | C++ traffic simulator API interface    |                                                                      |
+| `attach_lidar_sensor`                       | ZeroMQ traffic simulator API interface | See [ZeroMQ Interfaces documentation](ZeroMQ.md)<br/>TCP Port : 5563 |  
 
 ### Configuration
 
@@ -44,10 +44,10 @@ This enables us to reduce computational resources when we want to test Autoware'
 
 ### Interfaces
 
-| interface                                           | type                                   | note                                                                                       |
-|-----------------------------------------------------|----------------------------------------|--------------------------------------------------------------------------------------------|
-| `traffic_simulator::API::attachOccupancyGridSensor` | C++ traffic simulator API interface    |                                                                                            |
-| `attach_occupancy_grid_sensor`                      | ZeroMQ traffic simulator API interface | See [ZeroMQ Interfaces documentation](/docs/developer_guide/ZeroMQ.md)<br/>TCP Port : 5565 |  
+| interface                                           | type                                   | note                                                                 |
+|-----------------------------------------------------|----------------------------------------|----------------------------------------------------------------------|
+| `traffic_simulator::API::attachOccupancyGridSensor` | C++ traffic simulator API interface    |                                                                      |
+| `attach_occupancy_grid_sensor`                      | ZeroMQ traffic simulator API interface | See [ZeroMQ Interfaces documentation](ZeroMQ.md)<br/>TCP Port : 5565 |  
 
 ### Occupancy Grid Values
 
@@ -69,10 +69,10 @@ This also enables you to reduce computational resources when you want to test Au
 
 ### Interfaces
 
-| interface                                       | type                                   | note                                                                                       |
-|-------------------------------------------------|----------------------------------------|--------------------------------------------------------------------------------------------|
-| `traffic_simulator::API::attachDetectionSensor` | C++ traffic simulator API interface    |                                                                                            |
-| `attach_detection_sensor`                       | ZeroMQ traffic simulator API interface | See [ZeroMQ Interfaces documentation](/docs/developer_guide/ZeroMQ.md)<br/>TCP Port : 5564 |  
+| interface                                       | type                                   | note                                                                 |
+|-------------------------------------------------|----------------------------------------|----------------------------------------------------------------------|
+| `traffic_simulator::API::attachDetectionSensor` | C++ traffic simulator API interface    |                                                                      |
+| `attach_detection_sensor`                       | ZeroMQ traffic simulator API interface | See [ZeroMQ Interfaces documentation](ZeroMQ.md)<br/>TCP Port : 5564 |  
 
 
 ### Configuration


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

In [this page](https://tier4.github.io/scenario_simulator_v2-docs/developer_guide/SimpleSensorSimulator/), there are some links to https://tier4.github.io/docs/developer_guide/ZeroMQ.md
But the link destination is not found.

The cause is that the format of the internal link is wrong.
And I modified them referring to [this line](https://github.com/tier4/scenario_simulator_v2/blob/master/docs/developer_guide/About.md?plain=1#L21) which works fine

## How to review this PR.

## Others
