### PR TITLE
Add mkdocs-redirects plugin for renaming documentation

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Install
-        run: pip3 install mkdocs mkdocs-material pymdown-extensions fontawesome_markdown markdown python-markdown-math plantuml-markdown mkdocs-codeinclude-plugin mkdocs-git-revision-date-localized-plugin plantuml
+        run: pip3 install mkdocs mkdocs-material pymdown-extensions fontawesome_markdown markdown python-markdown-math plantuml-markdown mkdocs-codeinclude-plugin mkdocs-git-revision-date-localized-plugin plantuml mkdocs-redirects
       - name: Install doxygen/depends of doxybook
         run: sudo apt install -y doxygen wget
       - name: Wget package

--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -93,13 +93,13 @@ jobs:
           doxybook2 --input ./build/ --output ./markdown -c config.json
       - name: Generate documentation
         run: mkdocs build
-      - name: "Upload Artifact"
+      - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
           name: site
           path: site
           retention-days: 1
-      - name: Publish Report
+      - name: Publish Documentation
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,16 @@ If you want to force-push the commit during the review, please contact the maint
 If more than one maintainer approves your pull request and all checks are passed, your pull request will be merged into the `master` branch.
 Your contribution will be recorded in the [release note](https://tier4.github.io/scenario_simulator_v2-docs/ReleaseNotes/).
 
+## Update Documentation
+
+If your pull request changes the behavior of the software, please update the documentation in the `docs/` directory.
+The documentation is built by [mkdocs](https://www.mkdocs.org/).
+
+You may rename existing files or add new files to the `docs/` directory.
+* If you add new files, you should add the file name to the `nav` section in the `mkdocs.yml` file.
+
+* If you rename existing files, you should set up a redirect from the old file to the new file.
+Redirects are defined in the `mkdocs.yml` file using `mkdocs-redirects` plugin, so you will edit `plugins.redirects.redirect_maps` in the `mkdocs.yml` file.
 
 ## License
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,8 @@ extra:
 plugins:
   - search
   - git-revision-date-localized
+  - redirects:
+      redirect_maps:
 
 copyright: "Copyright &copy; 2022 TIER IV, Inc."
 


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Description
Currently, renamed documentation became 404 Not Found due to no redirects.
To setup redirects, I added mkdocs-redirects plugin and instruction of add / renaming pages.

## How to review this PR.
This PR does not changes simulator, no regression test needed.

## Others
mkdocs-redirects uses `location.href` or `Refresh` meta tag to redirect.
In addition, it uses `canonical` tag to indicate true URL and uses `robots` meta tag to remove the page from search engine.
This way is enough to redirect for users and search engines.

```html
<!doctype html>
<html lang="en">
<head>
    <meta charset="utf-8">
    <title>Redirecting...</title>
    <link rel="canonical" href="../ReleaseNotes/">
    <meta name="robots" content="noindex">
    <script>var anchor=window.location.hash.substr(1);location.href="../ReleaseNotes/"+(anchor?"#"+anchor:"")</script>
    <meta http-equiv="refresh" content="0; url=../ReleaseNotes/">
</head>
<body>
Redirecting...
</body>
</html>```
