### PR TITLE
fix(action): fix fault injection action - qos

### DIFF
--- a/openscenario/openscenario_interpreter/src/syntax/custom_command_action.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/custom_command_action.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iterator>  // std::distance
 #include <openscenario_interpreter/error.hpp>
 #include <openscenario_interpreter/posix/fork_exec.hpp>
 #include <openscenario_interpreter/reader/attribute.hpp>
@@ -21,6 +20,8 @@
 #include <openscenario_interpreter/simulator_core.hpp>
 #include <openscenario_interpreter/syntax/custom_command_action.hpp>
 #include <openscenario_interpreter/syntax/storyboard_element.hpp>
+
+#include <iterator>  // std::distance
 #include <unordered_map>
 
 namespace openscenario_interpreter
@@ -46,7 +47,7 @@ struct ApplyFaultInjectionAction : public CustomCommand
   {
     static auto publisher =
       node().template create_publisher<tier4_simulation_msgs::msg::SimulationEvents>(
-        "events", rclcpp::QoS(1).reliable());
+        "events", rclcpp::QoS(rclcpp::KeepLast(10)).reliable());
     return *publisher;
   }
 

--- a/openscenario/openscenario_interpreter/src/syntax/custom_command_action.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/custom_command_action.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <iterator>  // std::distance
 #include <openscenario_interpreter/error.hpp>
 #include <openscenario_interpreter/posix/fork_exec.hpp>
 #include <openscenario_interpreter/reader/attribute.hpp>
@@ -20,8 +21,6 @@
 #include <openscenario_interpreter/simulator_core.hpp>
 #include <openscenario_interpreter/syntax/custom_command_action.hpp>
 #include <openscenario_interpreter/syntax/storyboard_element.hpp>
-
-#include <iterator>  // std::distance
 #include <unordered_map>
 
 namespace openscenario_interpreter


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
https://tier4.atlassian.net/browse/AJD-801

## Description
The change applies to the `history_depth` in `QoS` set in the publication of messages to the `fault_injection_node` in action.
In a situation where there are many messages published almost at the same time  in the scenario - queue depth must be greater for all messages to be processed by node.

## How to review this PR.

## Others
