### PR TITLE
Fix for JUnit wrong count of testcases

### DIFF
--- a/common/simple_junit/test/expected/pass.junit.xml
+++ b/common/simple_junit/test/expected/pass.junit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<testsuites failures="0" errors="0" tests="0">
-  <testsuite name="example_suite" failures="0" errors="0" tests="0">
+<testsuites failures="0" errors="0" tests="1">
+  <testsuite name="example_suite" failures="0" errors="0" tests="1">
     <testcase name="example_case"/>
   </testsuite>
   <testsuite name="example_suites" failures="0" errors="0" tests="0"/>

--- a/common/simple_junit/test/src/test.cpp
+++ b/common/simple_junit/test/src/test.cpp
@@ -71,7 +71,7 @@ TEST(SIMPLE_JUNIT, PASS)
 {
   common::junit::JUnit5 junit;
   junit.testsuite("example_suites");
-  junit.testsuite("example_suite").testcase("example_case");
+  junit.testsuite("example_suite").testcase("example_case").pass.push_back(common::junit::Pass());
   junit.write_to("result_pass.junit.xml", "  ");
   EXPECT_TEXT_FILE_EQ(
     "result_pass.junit.xml",

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/openscenario_interpreter.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/openscenario_interpreter.hpp
@@ -130,7 +130,9 @@ public:
 
     boost::apply_visitor(
       overload(
-        [&](const common::junit::Pass &) { results.testsuite(suite_name).testcase(case_name); },
+        [&](const common::junit::Pass & it) {
+          results.testsuite(suite_name).testcase(case_name).pass.push_back(it);
+        },
         [&](const common::junit::Failure & it) {
           results.testsuite(suite_name).testcase(case_name).failure.push_back(it);
         },


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

- close #1017 

## Description

JUnit output library uses length of `pass` array as a passed test count. However, interpreter does not push passed case to `pass` array.
It caused writing inconsistent result to JUnit format XML.

## How to review this PR.

As no algorithm changes, regression test seems to be optional.

## Others
