### PR TITLE
specify clang-format version in BuildAndRun action

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -30,12 +30,6 @@ jobs:
       matrix:
         rosdistro: [galactic, humble]
     steps:
-      - name: Install Clang-Format (version 16.0.0)
-        run: |
-          apt update
-          apt install -y python3-pip
-          pip3 install clang-format==16.0.0
-        shell: bash
       - name: suppress warnings
         run: |
           git config --global --add safe.directory '*'
@@ -65,12 +59,14 @@ jobs:
           cd ~/ros2_ws
           vcs import src < src/scenario_simulator_v2/dependency_${{ matrix.rosdistro }}.repos
 
-      - name: Resolve rosdep
+      - name: Resolve rosdep and install clang-format (version 16.0.0)
         run: |
           cd ~/ros2_ws
           apt update
+          apt install -y python3-pip
           rosdep update --include-eol-distros
           rosdep install -iy --from-paths src --rosdistro ${{ matrix.rosdistro }}
+          pip3 install clang-format==16.0.0
         shell: bash
 
       - name: Build packages

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -30,6 +30,12 @@ jobs:
       matrix:
         rosdistro: [galactic, humble]
     steps:
+      - name: Install Clang-Format (version 16.0.0)
+        run: |
+          apt update
+          apt install -y python3-pip
+          pip3 install clang-format==16.0.0
+        shell: bash
       - name: suppress warnings
         run: |
           git config --global --add safe.directory '*'
@@ -62,8 +68,7 @@ jobs:
       - name: Resolve rosdep
         run: |
           cd ~/ros2_ws
-          apt-get update
-          apt install -y python3-pip
+          apt update
           rosdep update --include-eol-distros
           rosdep install -iy --from-paths src --rosdistro ${{ matrix.rosdistro }}
         shell: bash


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

Specify clang-format version in github actions environment.
Currently, we use `ros:humble` and `ros:galactic` docker image for github actions CI.
In these images, version of the clang-format is `Ubuntu clang-format version 14.0.0-1ubuntu1.1`
But, Ubuntu 22.04 desktop environment use `clang-format version 16.0.0`.
So, some format violation was detected only on github actions environment.

I install clang-format via [pypi](https://pypi.org/project/clang-format/) and specify it's version.

## How to review this PR.

Please check passing all CI.

## Others
