### PR TITLE
add comment about PR #1074

### DIFF
--- a/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
+++ b/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
@@ -45,6 +45,12 @@ private:
     if (api_.entityExists("bob") && api_.checkCollision("ego", "bob")) {
       stop(cpp_mock_scenarios::Result::FAILURE);
     }
+    /**
+     * @note The simulation time is internally managed as a fraction and must exactly equal to x.0
+     * in the floating-point literal when the simulation time is an integer multiple of the frame rate frame,
+     * so in this case `std::abs(t - 1.0) <= std::numeric Decides that `t == 1.0` is more appropriate than `std::numeric_limits<double>::epsilon();`.
+     * @sa https://wandbox.org/permlink/dSNRX7K2bQiqSI7P
+     */
     if (t == 1.0) {
       if (t != api_.getCurrentTwist("bob").linear.x) {
         stop(cpp_mock_scenarios::Result::FAILURE);

--- a/mock/cpp_mock_scenarios/src/pedestrian/walk_straight.cpp
+++ b/mock/cpp_mock_scenarios/src/pedestrian/walk_straight.cpp
@@ -45,6 +45,12 @@ private:
     if (api_.entityExists("bob") && api_.checkCollision("ego", "bob")) {
       stop(cpp_mock_scenarios::Result::FAILURE);
     }
+    /**
+     * @note The simulation time is internally managed as a fraction and must exactly equal to x.0
+     * in the floating-point literal when the simulation time is an integer multiple of the frame rate frame,
+     * so in this case `std::abs(t - 1.0) <= std::numeric Decides that `t == 1.0` is more appropriate than `std::numeric_limits<double>::epsilon();`.
+     * @sa https://wandbox.org/permlink/dSNRX7K2bQiqSI7P
+     */
     if (t == 1.0) {
       const auto vel = api_.getCurrentTwist("bob").linear.x;
       if (t != vel) {


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

#1074 

## Description

Adding comment about PR #1074 
Some part of #1074 is hard to guess why the test code should be `t==1.0`.
So I add comment about it.

## How to review this PR.

Please check passing github actions test.

## Others
