### PR TITLE
fix/distance-condition

### DIFF
--- a/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
@@ -295,7 +295,7 @@ auto DistanceCondition::evaluate() -> Object
 
   return asBoolean(triggering_entities.apply([&](auto && triggering_entity) {
     results.push_back(distance(triggering_entity));
-    return rule(results.back(), value);
+    return rule(static_cast<double>(results.back()), value);
   }));
 }
 }  // namespace syntax


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

I've noticed that not every `DistanceCondition` is evaluated properly when the rule is `equalTo`

For a sample scenario presented below the defined `DistanceCondition` is false (from topic `/simulation/context`) 
```
{"currentEvaluation":"Are all of [ego]''s distance to given position = [-0.330000] equalTo -0.330000?","currentValue":"false","name":"","type":"DistanceCondition"}
```
and the scenario fails.

I think that according to the sample scenario description, the lateral distance is `-0.83 - -0.5` and equals to `-0.33`, so the distance condition should be `true` and the scenario should pass. 

The checking, if two values are equal, is [here](https://github.com/tier4/scenario_simulator_v2/blob/bfd3344a828d24c4e22bfa7fab1b556a34bf91a5/openscenario/openscenario_interpreter/include/openscenario_interpreter/functional/equal_to.hpp#L37). 

The `results.back()` and `value` variables (from [here](https://github.com/tier4/scenario_simulator_v2/blob/bfd3344a828d24c4e22bfa7fab1b556a34bf91a5/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp#L298)) are of type `Double` which `std::numeric_limits<Double>::epsilon` is equal `0.00000000000000000`

One of solutions is (as proposed in this PR) to cast `results.back()` to type `double` which `std::numeric_limits<double>::epsilon` is equal `0.00000000000000022`

After applying this PR the `DistanceCondition` is true
```
{"currentEvaluation":"Are all of [ego]''s distance to given position = [-0.330000] equalTo -0.330000?","currentValue":"true","name":"","type":"DistanceCondition"}
```
and sample scenario passes.

### Sample scenario
```yaml
OpenSCENARIO:
  FileHeader:
    revMajor: 0
    revMinor: 0
    date: "1970-01-01T09:00:00+09:00"
    author: Test
    description: ""
  ParameterDeclarations:
    ParameterDeclaration: []
  CatalogLocations:
    VehicleCatalog:
      Directory:
        path: $(ros2 pkg prefix --share openscenario_experimental_catalog)/vehicle
  RoadNetwork:
    LogicFile:
      filepath: $(find-pkg-share kashiwanoha_map)/map
  Entities:
    ScenarioObject:
      - name: ego
        CatalogReference:
          catalogName: sample_vehicle
          entryName: sample_vehicle
  Storyboard:
    Init:
      Actions:
        Private:
          - entityRef: ego
            PrivateAction:
              - TeleportAction:
                  Position:
                    LanePosition:
                      roadId: ""
                      laneId: 34513
                      s: 10
                      offset: -0.5
                      Orientation:
                        type: relative
                        h: 0
                        p: 0
                        r: 0
              - LongitudinalAction:
                  SpeedAction:
                    SpeedActionDynamics:
                      dynamicsDimension: time
                      value: 0
                      dynamicsShape: step
                    SpeedActionTarget:
                      AbsoluteTargetSpeed:
                        value: 0
    Story:
      - name: story
        Act:
          - name: act
            ManeuverGroup:
              - maximumExecutionCount: 1
                name: maneuver_group
                Actors:
                  selectTriggeringEntities: false
                  EntityRef:
                    - entityRef: ego
                Maneuver:
                  - name: maneuver
                    Event:
                      - name: success
                        priority: parallel
                        Action:
                          - name: ""
                            UserDefinedAction:
                              CustomCommandAction:
                                type: exitSuccess
                        StartTrigger:
                          ConditionGroup:
                            - Condition:
                                - name: ""
                                  delay: 0
                                  conditionEdge: none
                                  ByEntityCondition:
                                    TriggeringEntities:
                                      triggeringEntitiesRule: all
                                      EntityRef:
                                        - entityRef: ego
                                    EntityCondition:
                                      DistanceCondition:
                                        coordinateSystem: lane
                                        freespace: false
                                        relativeDistanceType: lateral
                                        rule: equalTo
                                        value: -0.33
                                        Position: &POSITION_1
                                          LanePosition:
                                            roadId: ""
                                            laneId: 34513
                                            s: 10
                                            offset: -0.83
                                            Orientation: &DEFAULT_ORIENTATION
                                              type: relative
                                              h: 0
                                              p: 0
                                              r: 0
                                - name: ""
                                  delay: 0
                                  conditionEdge: none
                                  ByValueCondition:
                                    SimulationTimeCondition:
                                      value: 5
                                      rule: greaterThan
                      - name: failure
                        priority: parallel
                        Action:
                          - name: ""
                            UserDefinedAction:
                              CustomCommandAction:
                                type: exitFailure
                        StartTrigger:
                          ConditionGroup:
                            - Condition:
                                - name: ""
                                  delay: 0
                                  conditionEdge: none
                                  ByValueCondition:
                                    SimulationTimeCondition:
                                      value: 7
                                      rule: greaterThan
            StartTrigger:
              ConditionGroup:
                - Condition:
                    - name: ""
                      delay: 0
                      conditionEdge: none
                      ByValueCondition:
                        SimulationTimeCondition:
                          value: 0
                          rule: greaterThan
    StopTrigger:
      ConditionGroup: []

```

## How to review this PR.

## Others
