### PR TITLE
update release note

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -42,6 +42,10 @@ Minor Tweaks :oncoming_police_car:
 
 ## Version 0.7.0
 
+!!! Note
+    In version 0.8.x, we will drop ROS 2 [Galactic Geochelone](https://docs.ros.org/en/rolling/Releases/Release-Galactic-Geochelone.html) support.
+    We recommend to use version 0.7.0 for [Galactic Geochelone](https://docs.ros.org/en/rolling/Releases/Release-Galactic-Geochelone.html) user.
+
 Major Changes :race_car: :red_car: :blue_car:
 
 | Feature                                                  | Brief summary                                                                                                                                             | Category                                        | Pull request                                                      | Contributor                                   |

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,6 +4,26 @@
 
 Major Changes :race_car: :red_car: :blue_car:
 
+| Feature | Brief summary | Category | Pull request | Contributor |
+|---------|---------------|----------|--------------|-------------|
+|         |               |          |              |             |
+
+Bug Fixes:bug:
+
+| Feature | Brief summary | Category | Pull request | Contributor |
+|---------|---------------|----------|--------------|-------------|
+|         |               |          |              |             |
+
+Minor Tweaks :oncoming_police_car:
+
+| Feature | Brief summary | Category | Pull request | Contributor |
+|---------|---------------|----------|--------------|-------------|
+|         |               |          |              |             |
+
+## Version 0.8.0
+
+Major Changes :race_car: :red_car: :blue_car:
+
 | Feature                                            | Brief summary                                                                                                                                                          | Category                                              | Pull request                                                      | Contributor                             |
 |----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|-------------------------------------------------------------------|-----------------------------------------|
 | Ground truth topic for perception detected objects | Add ground truth topic for detected objects in `simple_sensor_simulator`. The delay of the topic can be set by `detectedObjectGroundTruthPublishingDelay` in scenario. | `simple_sensor_simulator`, `openscenario_interpreter` | [#1024](https://github.com/tier4/scenario_simulator_v2/pull/1024) | [HansRobo](https://github.com/HansRobo) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ plugins:
 copyright: "Copyright &copy; 2022 TIER IV, Inc."
 
 markdown_extensions:
+  - admonition
   - attr_list
   - codehilite: { guess_lang: false }
   - fontawesome_markdown


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue

## Description

Update release note for version 0.8.0 release.
Add notification of [Galactic Geochelone](https://docs.ros.org/en/rolling/Releases/Release-Galactic-Geochelone.html) support drop.
![image](https://github.com/tier4/scenario_simulator_v2/assets/10348912/c5077b8c-f775-4fe8-844a-b1b774bda082)


## How to review this PR.

## Others
