### PR TITLE
feat(behavior_tree): follow polyline action for pedestrian and bicycle

### DIFF
--- a/simulation/behavior_tree_plugin/config/pedestrian_entity_behavior.xml
+++ b/simulation/behavior_tree_plugin/config/pedestrian_entity_behavior.xml
@@ -3,6 +3,9 @@
     <Fallback name="root">
         <FollowLane name="follow_lane" />
         <WalkStraightAction name="walk_straight" />
+        <Fallback name="follow_trajectory_sequence">
+            <FollowPolylineTrajectory name="follow_polyline_trajectory" />
+        </Fallback>
     </Fallback>
     </BehaviorTree>
 </root>

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp
@@ -1,0 +1,44 @@
+// Copyright 2023 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BEHAVIOR_TREE_PLUGIN__PEDESTRIAN__FOLLOW_POLYLINE_TRAJECTORY_ACTION_HPP_
+#define BEHAVIOR_TREE_PLUGIN__PEDESTRIAN__FOLLOW_POLYLINE_TRAJECTORY_ACTION_HPP_
+
+#include <behavior_tree_plugin/pedestrian/pedestrian_action_node.hpp>
+
+namespace entity_behavior
+{
+namespace pedestrian
+{
+struct FollowPolylineTrajectoryAction : public PedestrianActionNode
+{
+  std::shared_ptr<traffic_simulator_msgs::msg::PolylineTrajectory> polyline_trajectory;
+
+  std::optional<double> target_speed;
+
+  using PedestrianActionNode::PedestrianActionNode;
+
+  auto calculateWaypoints() -> const traffic_simulator_msgs::msg::WaypointsArray;
+
+  auto calculateObstacle(const traffic_simulator_msgs::msg::WaypointsArray &)
+    -> const std::optional<traffic_simulator_msgs::msg::Obstacle>;
+
+  static auto providedPorts() -> BT::PortsList;
+
+  auto tick() -> BT::NodeStatus override;
+};
+}  // namespace pedestrian
+}  // namespace entity_behavior
+
+#endif  // BEHAVIOR_TREE_PLUGIN__PEDESTRIAN__FOLLOW_POLYLINE_TRAJECTORY_ACTION_HPP_

--- a/simulation/behavior_tree_plugin/src/pedestrian/behavior_tree.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/behavior_tree.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <behavior_tree_plugin/pedestrian/behavior_tree.hpp>
+#include <behavior_tree_plugin/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp>
 #include <iostream>
 #include <memory>
 #include <pugixml.hpp>
@@ -28,6 +29,7 @@ void PedestrianBehaviorTree::configure(const rclcpp::Logger & logger)
   namespace pedestrian = entity_behavior::pedestrian;
   factory_.registerNodeType<pedestrian::FollowLaneAction>("FollowLane");
   factory_.registerNodeType<pedestrian::WalkStraightAction>("WalkStraightAction");
+  factory_.registerNodeType<pedestrian::FollowPolylineTrajectoryAction>("FollowPolylineTrajectory");
 
   auto base_path = ament_index_cpp::get_package_share_directory("behavior_tree_plugin");
   auto format_path = base_path + "/config/pedestrian_entity_behavior.xml";

--- a/simulation/behavior_tree_plugin/src/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
@@ -1,0 +1,81 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <behavior_tree_plugin/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp>
+
+namespace entity_behavior
+{
+namespace pedestrian
+{
+auto FollowPolylineTrajectoryAction::calculateWaypoints()
+  -> const traffic_simulator_msgs::msg::WaypointsArray
+{
+  auto waypoints = traffic_simulator_msgs::msg::WaypointsArray();
+  waypoints.waypoints.push_back(entity_status->getMapPose().position);
+  for (const auto & vertex : polyline_trajectory->shape.vertices) {
+    waypoints.waypoints.push_back(vertex.position.position);
+  }
+  return waypoints;
+}
+
+auto FollowPolylineTrajectoryAction::calculateObstacle(
+  const traffic_simulator_msgs::msg::WaypointsArray &)
+  -> const std::optional<traffic_simulator_msgs::msg::Obstacle>
+{
+  /**
+     Obstacle avoidance is not implemented for this action.
+
+     @todo If you implement obstacle avoidance for this action, implement this
+     virtual function to return the location of any obstacles blocking the path
+     of this action's actor. However, this virtual function is currently used
+     only for the visualization of obstacle information, so the obstacle
+     avoidance algorithm does not necessarily need to use this virtual
+     function.
+  */
+  return std::nullopt;
+}
+
+auto FollowPolylineTrajectoryAction::providedPorts() -> BT::PortsList
+{
+  auto ports = PedestrianActionNode::providedPorts();
+  ports.emplace(BT::InputPort<decltype(polyline_trajectory)>("polyline_trajectory"));
+  ports.emplace(BT::InputPort<decltype(target_speed)>("target_speed"));
+  return ports;
+}
+
+auto FollowPolylineTrajectoryAction::tick() -> BT::NodeStatus
+{
+  if (getBlackBoardValues();
+      request != traffic_simulator::behavior::Request::FOLLOW_POLYLINE_TRAJECTORY or
+      not getInput<decltype(polyline_trajectory)>("polyline_trajectory", polyline_trajectory) or
+      not getInput<decltype(target_speed)>("target_speed", target_speed) or
+      not polyline_trajectory) {
+    return BT::NodeStatus::FAILURE;
+  } else if (
+    const auto updated_status = traffic_simulator::follow_trajectory::makeUpdatedStatus(
+      static_cast<traffic_simulator::EntityStatus>(*entity_status), *polyline_trajectory,
+      behavior_parameter, step_time)) {
+    setOutput(
+      "updated_status",
+      std::make_shared<traffic_simulator::CanonicalizedEntityStatus>(
+        traffic_simulator::CanonicalizedEntityStatus(*updated_status, hdmap_utils)));
+    setOutput("waypoints", calculateWaypoints());
+    setOutput("obstacle", calculateObstacle(calculateWaypoints()));
+    return BT::NodeStatus::RUNNING;
+  } else {
+    return BT::NodeStatus::SUCCESS;
+  }
+}
+}  // namespace pedestrian
+}  // namespace entity_behavior

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
@@ -99,6 +99,9 @@ public:
 
   void requestAssignRoute(const std::vector<geometry_msgs::msg::Pose> &) override;
 
+  auto requestFollowTrajectory(
+    const std::shared_ptr<traffic_simulator_msgs::msg::PolylineTrajectory> &) -> void override;
+
   std::string getCurrentAction() const override;
 
   auto getDefaultDynamicConstraints() const

--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -77,6 +77,13 @@ void PedestrianEntity::requestAssignRoute(const std::vector<geometry_msgs::msg::
   requestAssignRoute(route);
 }
 
+auto PedestrianEntity::requestFollowTrajectory(
+  const std::shared_ptr<traffic_simulator_msgs::msg::PolylineTrajectory> & parameter) -> void
+{
+  behavior_plugin_ptr_->setPolylineTrajectory(parameter);
+  behavior_plugin_ptr_->setRequest(behavior::Request::FOLLOW_POLYLINE_TRAJECTORY);
+}
+
 std::string PedestrianEntity::getCurrentAction() const
 {
   if (!npc_logic_started_) {

--- a/test_runner/scenario_test_runner/config/workflow_example.yaml
+++ b/test_runner/scenario_test_runner/config/workflow_example.yaml
@@ -9,6 +9,8 @@ Scenario:
   - path: $(find-pkg-share scenario_test_runner)/scenario/Property.isBlind.yaml
   - path: $(find-pkg-share scenario_test_runner)/scenario/RoutingAction.FollowTrajectoryAction-star.yaml
   - path: $(find-pkg-share scenario_test_runner)/scenario/RoutingAction.FollowTrajectoryAction-straight.yaml
+  - path: $(find-pkg-share scenario_test_runner)/scenario/RoutingAction.FollowTrajectoryAction-straight-pedestrian.yaml
+  - path: $(find-pkg-share scenario_test_runner)/scenario/RoutingAction.FollowTrajectoryAction-straight-bicycle.yaml
   - path: $(find-pkg-share scenario_test_runner)/scenario/RoutingAction.FollowTrajectoryAction-zero-distance.yaml
   - path: $(find-pkg-share scenario_test_runner)/scenario/all-in-one.yaml
   - path: $(find-pkg-share scenario_test_runner)/scenario/minimal.yaml

--- a/test_runner/scenario_test_runner/scenario/RoutingAction.FollowTrajectoryAction-straight-bicycle.yaml
+++ b/test_runner/scenario_test_runner/scenario/RoutingAction.FollowTrajectoryAction-straight-bicycle.yaml
@@ -1,0 +1,209 @@
+OpenSCENARIO:
+  FileHeader:
+    revMajor: 0
+    revMinor: 0
+    date: "2023-09-18T09:25:53+02:00"
+    description: "This scenario is used to test the FollowTrajectory (polyline) action performed by a Bicycle entity."
+    author: "Moszynski Dawid"
+  ParameterDeclarations:
+    ParameterDeclaration: []
+  CatalogLocations:
+    VehicleCatalog:
+      Directory:
+        path: $(ros2 pkg prefix --share openscenario_experimental_catalog)/vehicle
+  RoadNetwork:
+    LogicFile:
+      filepath: $(ros2 pkg prefix --share kashiwanoha_map)/map
+  Entities:
+    ScenarioObject:
+      - name: Bicycle0
+        Vehicle:
+          name: ""
+          vehicleCategory: bicycle
+          BoundingBox:
+            Center:
+              x: 0
+              y: 0
+              z: 1.25
+            Dimensions:
+              width: 0.8
+              length: 2
+              height: 2.5
+          Performance:
+            maxSpeed: 50
+            maxAcceleration: INF
+            maxDeceleration: INF
+          Axles:
+            FrontAxle:
+              maxSteering: 0.5236
+              wheelDiameter: 0.6
+              trackWidth: 0.8
+              positionX: 1
+              positionZ: 0.3
+            RearAxle:
+              maxSteering: 0.5236
+              wheelDiameter: 0.6
+              trackWidth: 0.8
+              positionX: 0
+              positionZ: 0.3
+          Properties:
+            Property: []
+  Storyboard:
+    Init:
+      Actions:
+        Private:
+          - entityRef: Bicycle0
+            PrivateAction:
+              - TeleportAction:
+                  Position:
+                    LanePosition:
+                      roadId: ""
+                      laneId: "34513"
+                      s: 1
+                      offset: 0
+                      Orientation: &ORIENTATION
+                        type: relative
+                        h: 0
+                        p: 0
+                        r: 0
+    Story:
+      - name: ""
+        Act:
+          - name: ""
+            ManeuverGroup:
+              - maximumExecutionCount: 1
+                name: ""
+                Actors:
+                  selectTriggeringEntities: false
+                  EntityRef:
+                    - entityRef: Bicycle0
+                Maneuver:
+                  - name: ""
+                    Event:
+                      - name: ""
+                        priority: parallel
+                        StartTrigger:
+                          ConditionGroup:
+                            - Condition:
+                                - name: ""
+                                  delay: 0
+                                  conditionEdge: none
+                                  ByValueCondition:
+                                    SimulationTimeCondition:
+                                      value: 0
+                                      rule: greaterThan
+                        Action:
+                          - name: "follow_trajectory"
+                            PrivateAction:
+                              - RoutingAction:
+                                  FollowTrajectoryAction:
+                                    initialDistanceOffset: 1
+                                    TimeReference:
+                                      Timing:
+                                        domainAbsoluteRelative: relative
+                                        offset: 0
+                                        scale: 1
+                                    TrajectoryFollowingMode:
+                                      followingMode: position
+                                    TrajectoryRef:
+                                      Trajectory:
+                                        closed: false
+                                        name: straight
+                                        Shape:
+                                          Polyline:
+                                            Vertex:
+                                              - Position:
+                                                  LanePosition:
+                                                    roadId: ""
+                                                    laneId: "34513"
+                                                    s: 10
+                                                    offset: 0
+                                                    Orientation: *ORIENTATION
+                                              - time: 15
+                                                Position: &destination
+                                                  LanePosition:
+                                                    roadId: ""
+                                                    laneId: "34507"
+                                                    s: 50
+                                                    offset: 0
+                                                    Orientation: *ORIENTATION
+            StartTrigger:
+              ConditionGroup:
+                - Condition:
+                    - name: ""
+                      delay: 0
+                      conditionEdge: none
+                      ByValueCondition:
+                        SimulationTimeCondition:
+                          value: 0
+                          rule: greaterThan
+          - name: _EndCondition
+            ManeuverGroup:
+              - maximumExecutionCount: 1
+                name: ""
+                Actors:
+                  selectTriggeringEntities: false
+                  EntityRef:
+                    - entityRef: Bicycle0
+                Maneuver:
+                  - name: ""
+                    Event:
+                      - name: ""
+                        priority: parallel
+                        StartTrigger:
+                          ConditionGroup:
+                            - Condition:
+                                - name: ""
+                                  delay: 0
+                                  conditionEdge: none
+                                  ByValueCondition:
+                                    StoryboardElementStateCondition:
+                                      storyboardElementRef: follow_trajectory
+                                      storyboardElementType: action
+                                      state: completeState
+                                - name: ""
+                                  delay: 0
+                                  conditionEdge: none
+                                  ByEntityCondition:
+                                    TriggeringEntities:
+                                      triggeringEntitiesRule: any
+                                      EntityRef:
+                                        - entityRef: Bicycle0
+                                    EntityCondition:
+                                      ReachPositionCondition:
+                                        Position: *destination
+                                        tolerance: 1.1
+                        Action:
+                          - name: ""
+                            UserDefinedAction:
+                              CustomCommandAction:
+                                type: exitSuccess
+                      - name: ""
+                        priority: parallel
+                        StartTrigger:
+                          ConditionGroup:
+                            - Condition:
+                                - name: ""
+                                  delay: 0
+                                  conditionEdge: none
+                                  ByValueCondition:
+                                    SimulationTimeCondition:
+                                      value: 30
+                                      rule: greaterThan
+                        Action:
+                          - name: ""
+                            UserDefinedAction:
+                              CustomCommandAction:
+                                type: exitFailure
+            StartTrigger:
+              ConditionGroup:
+                - Condition:
+                    - name: ""
+                      delay: 0
+                      conditionEdge: none
+                      ByValueCondition:
+                        SimulationTimeCondition:
+                          value: 0
+                          rule: greaterThan
+    StopTrigger:
+      ConditionGroup: []

--- a/test_runner/scenario_test_runner/scenario/RoutingAction.FollowTrajectoryAction-straight-pedestrian.yaml
+++ b/test_runner/scenario_test_runner/scenario/RoutingAction.FollowTrajectoryAction-straight-pedestrian.yaml
@@ -1,0 +1,194 @@
+OpenSCENARIO:
+  FileHeader:
+    revMajor: 0
+    revMinor: 0
+    date: "2023-09-18T09:25:53+02:00"
+    description: "This scenario is used to test the FollowTrajectory (polyline) action performed by a Pedestrian entity."
+    author: "Moszynski Dawid"
+  ParameterDeclarations:
+    ParameterDeclaration: []
+  CatalogLocations:
+    VehicleCatalog:
+      Directory:
+        path: $(ros2 pkg prefix --share openscenario_experimental_catalog)/vehicle
+  RoadNetwork:
+    LogicFile:
+      filepath: $(ros2 pkg prefix --share kashiwanoha_map)/map
+  Entities:
+    ScenarioObject:
+      - name: Pedestrian0
+        Pedestrian:
+          name: Pedestrian
+          mass: 60
+          model: ""
+          pedestrianCategory: pedestrian
+          BoundingBox:
+            Center:
+              x: 0
+              y: 0
+              z: 1
+            Dimensions:
+              width: 0.8
+              length: 0.8
+              height: 2
+          Properties:
+            Property: []
+  Storyboard:
+    Init:
+      Actions:
+        Private:
+          - entityRef: Pedestrian0
+            PrivateAction:
+              - TeleportAction:
+                  Position:
+                    LanePosition:
+                      roadId: ""
+                      laneId: "34513"
+                      s: 1
+                      offset: 0
+                      Orientation: &ORIENTATION
+                        type: relative
+                        h: 0
+                        p: 0
+                        r: 0
+    Story:
+      - name: ""
+        Act:
+          - name: ""
+            ManeuverGroup:
+              - maximumExecutionCount: 1
+                name: ""
+                Actors:
+                  selectTriggeringEntities: false
+                  EntityRef:
+                    - entityRef: Pedestrian0
+                Maneuver:
+                  - name: ""
+                    Event:
+                      - name: ""
+                        priority: parallel
+                        StartTrigger:
+                          ConditionGroup:
+                            - Condition:
+                                - name: ""
+                                  delay: 0
+                                  conditionEdge: none
+                                  ByValueCondition:
+                                    SimulationTimeCondition:
+                                      value: 0
+                                      rule: greaterThan
+                        Action:
+                          - name: "follow_trajectory"
+                            PrivateAction:
+                              - RoutingAction:
+                                  FollowTrajectoryAction:
+                                    initialDistanceOffset: 1
+                                    TimeReference:
+                                      Timing:
+                                        domainAbsoluteRelative: relative
+                                        offset: 0
+                                        scale: 1
+                                    TrajectoryFollowingMode:
+                                      followingMode: position
+                                    TrajectoryRef:
+                                      Trajectory:
+                                        closed: false
+                                        name: straight
+                                        Shape:
+                                          Polyline:
+                                            Vertex:
+                                              - Position:
+                                                  LanePosition:
+                                                    roadId: ""
+                                                    laneId: "34513"
+                                                    s: 10
+                                                    offset: 0
+                                                    Orientation: *ORIENTATION
+                                              - time: 25
+                                                Position: &destination
+                                                  LanePosition:
+                                                    roadId: ""
+                                                    laneId: "34507"
+                                                    s: 50
+                                                    offset: 0
+                                                    Orientation: *ORIENTATION
+            StartTrigger:
+              ConditionGroup:
+                - Condition:
+                    - name: ""
+                      delay: 0
+                      conditionEdge: none
+                      ByValueCondition:
+                        SimulationTimeCondition:
+                          value: 0
+                          rule: greaterThan
+          - name: _EndCondition
+            ManeuverGroup:
+              - maximumExecutionCount: 1
+                name: ""
+                Actors:
+                  selectTriggeringEntities: false
+                  EntityRef:
+                    - entityRef: Pedestrian0
+                Maneuver:
+                  - name: ""
+                    Event:
+                      - name: ""
+                        priority: parallel
+                        StartTrigger:
+                          ConditionGroup:
+                            - Condition:
+                                - name: ""
+                                  delay: 0
+                                  conditionEdge: none
+                                  ByValueCondition:
+                                    StoryboardElementStateCondition:
+                                      storyboardElementRef: follow_trajectory
+                                      storyboardElementType: action
+                                      state: completeState
+                                - name: ""
+                                  delay: 0
+                                  conditionEdge: none
+                                  ByEntityCondition:
+                                    TriggeringEntities:
+                                      triggeringEntitiesRule: any
+                                      EntityRef:
+                                        - entityRef: Pedestrian0
+                                    EntityCondition:
+                                      ReachPositionCondition:
+                                        Position: *destination
+                                        tolerance: 1.1
+                        Action:
+                          - name: ""
+                            UserDefinedAction:
+                              CustomCommandAction:
+                                type: exitSuccess
+                      - name: ""
+                        priority: parallel
+                        StartTrigger:
+                          ConditionGroup:
+                            - Condition:
+                                - name: ""
+                                  delay: 0
+                                  conditionEdge: none
+                                  ByValueCondition:
+                                    SimulationTimeCondition:
+                                      value: 30
+                                      rule: greaterThan
+                        Action:
+                          - name: ""
+                            UserDefinedAction:
+                              CustomCommandAction:
+                                type: exitFailure
+            StartTrigger:
+              ConditionGroup:
+                - Condition:
+                    - name: ""
+                      delay: 0
+                      conditionEdge: none
+                      ByValueCondition:
+                        SimulationTimeCondition:
+                          value: 0
+                          rule: greaterThan
+    StopTrigger:
+      ConditionGroup: []


### PR DESCRIPTION
## Types of PR

- [x] New Features
- [ ] Upgrade of existing features
- [ ] Bugfix

## Link to the issue
https://tier4.atlassian.net/browse/RJD-614
## Description

- to Make [FollowTrajectoryAction](https://github.com/tier4/scenario_simulator_v2/blob/7adb1f5d4f9907e6d3136ae4e69d31f6773523b9/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/follow_trajectory_action.hpp#L56) support pedestrian / cyclist 
- to Create 2 scenarios for regression tests for FollowTrajectoryAction (with Pedestrian, withCyclist)
## How to review this PR.
These are small changes, but you can compare them to the behavior tree for Vehicle.
## Others
