### PR TITLE
add updateStandStillDuration(step_time) and updateTraveledDistance(st…

### DIFF
--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -247,6 +247,8 @@ void PedestrianEntity::onUpdate(double current_time, double step_time)
         hdmap_utils_ptr_->getFollowingLanelets(lanelet_pose.lanelet_id).size() == 1 &&
         hdmap_utils_ptr_->getLaneletLength(lanelet_pose.lanelet_id) <= lanelet_pose.s) {
         stopAtCurrentPosition();
+        updateStandStillDuration(step_time);
+        updateTraveledDistance(step_time);
         return;
       }
     }

--- a/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
@@ -159,6 +159,8 @@ void VehicleEntity::onUpdate(double current_time, double step_time)
         hdmap_utils_ptr_->getFollowingLanelets(lanelet_pose.lanelet_id).size() == 1 &&
         hdmap_utils_ptr_->getLaneletLength(lanelet_pose.lanelet_id) <= lanelet_pose.s) {
         stopAtCurrentPosition();
+        updateStandStillDuration(step_time);
+        updateTraveledDistance(step_time);
         return;
       }
     }


### PR DESCRIPTION
…ep_time) when the entity failed to match lanelet

## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

When the entity is at the end of the lanelet, traveled distance and standstill duration does not update.
So I fixed this problem.

## How to review this PR.

Please check passing all CI.

## Others
