### PR TITLE
Fix/entities right of way

### DIFF
--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -113,10 +113,14 @@ auto ActionNode::getYieldStopDistance(const lanelet::Ids & following_lanelets) c
       const auto other_status = getOtherEntityStatus(right_of_way_id);
       if (!other_status.empty() && entity_status->laneMatchingSucceed()) {
         const auto lanelet_pose = entity_status->getLaneletPose();
-        auto distance = hdmap_utils->getLongitudinalDistance(
+        const auto distance_forward = hdmap_utils->getLongitudinalDistance(
           lanelet_pose, traffic_simulator::helper::constructLaneletPose(lanelet, 0));
-        if (distance) {
-          distances.insert(distance.value());
+        const auto distance_backward = hdmap_utils->getLongitudinalDistance(
+          traffic_simulator::helper::constructLaneletPose(lanelet, 0), lanelet_pose);
+        if (distance_forward) {
+          distances.insert(distance_forward.value());
+        } else if (distance_backward) {
+          distances.insert(-distance_backward.value());
         }
       }
     }

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -130,6 +130,14 @@ auto ActionNode::getYieldStopDistance(const lanelet::Ids & following_lanelets) c
 auto ActionNode::getRightOfWayEntities(const lanelet::Ids & following_lanelets) const
   -> std::vector<traffic_simulator::CanonicalizedEntityStatus>
 {
+  auto is_the_same_right_of_way =
+    [&](const std::int64_t & lanelet_id, const std::int64_t & following_lanelet) {
+      const auto right_of_way_lanelet_ids = hdmap_utils->getRightOfWayLaneletIds(lanelet_id);
+      const auto the_same_right_of_way_it = std::find(
+        right_of_way_lanelet_ids.begin(), right_of_way_lanelet_ids.end(), following_lanelet);
+      return the_same_right_of_way_it != std::end(right_of_way_lanelet_ids);
+    };
+
   std::vector<traffic_simulator::CanonicalizedEntityStatus> ret;
   const auto lanelet_ids_list = hdmap_utils->getRightOfWayLaneletIds(following_lanelets);
   for (const auto & status : other_entity_status) {
@@ -137,7 +145,8 @@ auto ActionNode::getRightOfWayEntities(const lanelet::Ids & following_lanelets) 
       for (const lanelet::Id & lanelet_id : lanelet_ids_list.at(following_lanelet)) {
         if (
           status.second.laneMatchingSucceed() &&
-          traffic_simulator::isSameLaneletId(status.second, lanelet_id)) {
+          traffic_simulator::isSameLaneletId(status.second, lanelet_id) &&
+          not is_the_same_right_of_way(lanelet_id, following_lanelet)) {
           ret.emplace_back(status.second);
         }
       }


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
https://tier4.atlassian.net/browse/RJD-645

## Description

### Issue Description
For the situation presented in the pictures below, lanelets 3301 and 3300 have the same right of way

![lanelet_right_of_way drawio](https://github.com/tier4/scenario_simulator_v2/assets/8416175/02c61bb9-ef5a-4dd8-9373-731b4ce7cafb)

![Screenshot_20231011_105925](https://github.com/tier4/scenario_simulator_v2/assets/8416175/0c813135-7d5b-4800-9a11-967ccc78775e)

So far, when EGO is on lanelet 3314 and NPC on lanelet 3313, the NPC starts the `YieldAction` (in case if `isBlind` parameter is `false`). In YieldAction the yield stop distance cannot be calculated and `target_speed` is taken from lanelet (code [here](https://github.com/tier4/scenario_simulator_v2/blob/master/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/yield_action.cpp#L119-L123)). For that reason, NPC accelerates to 60km/h (speed limit for lanelet 3300)


### Issue solutions
1.  I think when lanelets 3301 and 3300 have the same right of way, the NPC on lanelet 3313 shouldn't start the `YieldAction`, but should continue `FollowLaneAction`. Fix applied in commit https://github.com/tier4/scenario_simulator_v2/pull/1104/commits/af8cd266f04df50579bd059b315945ae57fcf881

2. In case when only lanelet 3301 has right of way (modified lanelet in picture below), then the NPC should start the `YieldAction`. When `YieldAction` is executing the NPC should be stopped until EGO leaves lanelet 3301. Due to the bug in `getYieldStopDistance()`, the distance cannot be calculated, and NPC accelerates to 60km/h (speed limit for lanelet 3300). The commit 5b25abe8849e35a01bbb20698df82755673630e3 fixes the calculation of yield stop distance in `getYieldStopDistance()`.

    ![Screenshot_20231011_123911](https://github.com/tier4/scenario_simulator_v2/assets/8416175/ffba02df-155f-4018-ae4a-0b797be5eff1)



## How to review this PR.
In order to verify
- the solution 1. run `scenario_rjd_645.yaml`
- the solution 2. run `scenario_rjd_645_yield_action.yaml`

from [here](https://drive.google.com/drive/folders/1F_Osx82WK9OKLHT16mH4-0wZFsfhnunq?usp=drive_link)

## Others
