### PR TITLE
Random test runner fix

### DIFF
--- a/test_runner/random_test_runner/include/random_test_runner/file_interactions/junit_xml_reporter.hpp
+++ b/test_runner/random_test_runner/include/random_test_runner/file_interactions/junit_xml_reporter.hpp
@@ -40,6 +40,11 @@ public:
 
   void reportTimeout() { reportError("timeout", "Ego failed to reach goal within timeout"); }
 
+  void reportException(const std::string & type, const std::string & error_msg)
+  {
+    reportError(type, error_msg);
+  }
+
 private:
   void reportError(const std::string & error_type, const std::string & message)
   {

--- a/test_runner/random_test_runner/include/random_test_runner/test_executor.hpp
+++ b/test_runner/random_test_runner/include/random_test_runner/test_executor.hpp
@@ -41,6 +41,8 @@ public:
   bool scenarioCompleted();
 
 private:
+  void executeWithErrorHandling(std::function<void()> func);
+
   std::shared_ptr<traffic_simulator::API> api_;
   TestDescription test_description_;
   const std::string ego_name_ = "ego";

--- a/test_runner/random_test_runner/include/random_test_runner/test_executor.hpp
+++ b/test_runner/random_test_runner/include/random_test_runner/test_executor.hpp
@@ -36,7 +36,7 @@ public:
     ArchitectureType architecture_type, rclcpp::Logger logger);
 
   void initialize();
-  void update(double current_time);
+  void update();
   void deinitialize();
   bool scenarioCompleted();
 

--- a/test_runner/random_test_runner/include/random_test_runner/test_executor.hpp
+++ b/test_runner/random_test_runner/include/random_test_runner/test_executor.hpp
@@ -41,7 +41,7 @@ public:
   bool scenarioCompleted();
 
 private:
-  void executeWithErrorHandling(std::function<void()> func);
+  void executeWithErrorHandling(std::function<void()> && func);
 
   std::shared_ptr<traffic_simulator::API> api_;
   TestDescription test_description_;

--- a/test_runner/random_test_runner/launch/random_test.launch.py
+++ b/test_runner/random_test_runner/launch/random_test.launch.py
@@ -99,7 +99,7 @@ class RandomTestRunnerLaunch(object):
                 {"default": "/tmp",
                  "description": "Directory to which result.yaml and result.junit.xml files will be placed"},
 
-            "initialize_duration": {"default": 30, "description": "How long test runner will wait for Autoware to initialize"},
+            "initialize_duration": {"default": 35, "description": "How long test runner will wait for Autoware to initialize"},
 
             # test suite arguments #
             "test_name": {"default": "random_test",
@@ -119,7 +119,7 @@ class RandomTestRunnerLaunch(object):
                                 "ego_goal_partial_randomization_distance value. If ego_goal_lanelet_id is set to -1, "
                                 "this value is ignored"},
             "ego_goal_partial_randomization_distance":
-                {"default": 20.0,
+                {"default": 25.0,
                  "description": "Distance from goal set by ego_goal_lanelet_id and ego_goal_s, within which goal "
                                 "pose will be randomized if ego_goal_partial_randomization is set to true"},
             "npc_count": {"default": 10, "description": "Generated npc count"},

--- a/test_runner/random_test_runner/launch/random_test.launch.py
+++ b/test_runner/random_test_runner/launch/random_test.launch.py
@@ -99,6 +99,8 @@ class RandomTestRunnerLaunch(object):
                 {"default": "/tmp",
                  "description": "Directory to which result.yaml and result.junit.xml files will be placed"},
 
+            "initialize_duration": {"default": 30, "description": "How long test runner will wait for Autoware to initialize"},
+
             # test suite arguments #
             "test_name": {"default": "random_test",
                           "description": "Test name. Used for descriptive purposes only"},

--- a/test_runner/random_test_runner/src/test_executor.cpp
+++ b/test_runner/random_test_runner/src/test_executor.cpp
@@ -128,8 +128,19 @@ void TestExecutor::initialize()
   }
 }
 
-void TestExecutor::update(double current_time)
+void TestExecutor::update()
 {
+  if (!api_->isEgoSpawned() && !api_->isNpcLogicStarted()) {
+    api_->startNpcLogic();
+  }
+  if (
+    api_->isEgoSpawned() && !api_->isNpcLogicStarted() &&
+    api_->asFieldOperatorApplication(api_->getEgoName()).engageable()) {
+    api_->startNpcLogic();
+  }
+
+  auto current_time = api_->getCurrentTime();
+
   if (!std::isnan(current_time)) {
     bool timeout_reached = current_time >= test_timeout;
     if (timeout_reached) {

--- a/test_runner/random_test_runner/src/test_executor.cpp
+++ b/test_runner/random_test_runner/src/test_executor.cpp
@@ -65,129 +65,163 @@ TestExecutor::TestExecutor(
 
 void TestExecutor::initialize()
 {
-  std::string message = fmt::format("Test description: {}", test_description_);
-  RCLCPP_INFO_STREAM(logger_, message);
-  scenario_completed_ = false;
+  executeWithErrorHandling([this]() {
+    std::string message = fmt::format("Test description: {}", test_description_);
+    RCLCPP_INFO_STREAM(logger_, message);
+    scenario_completed_ = false;
 
-  api_->updateFrame();
+    api_->updateFrame();
 
-  if (simulator_type_ == SimulatorType::SIMPLE_SENSOR_SIMULATOR) {
-    api_->spawn(
-      ego_name_, api_->canonicalize(test_description_.ego_start_position), getVehicleParameters(),
-      traffic_simulator::VehicleBehavior::autoware());
-    api_->setEntityStatus(
-      ego_name_, api_->canonicalize(test_description_.ego_start_position),
-      traffic_simulator::helper::constructActionStatus());
+    if (simulator_type_ == SimulatorType::SIMPLE_SENSOR_SIMULATOR) {
+      api_->spawn(
+        ego_name_, api_->canonicalize(test_description_.ego_start_position), getVehicleParameters(),
+        traffic_simulator::VehicleBehavior::autoware());
+      api_->setEntityStatus(
+        ego_name_, api_->canonicalize(test_description_.ego_start_position),
+        traffic_simulator::helper::constructActionStatus());
 
-    if (architecture_type_ == ArchitectureType::AWF_UNIVERSE) {
-      api_->attachLidarSensor(traffic_simulator::helper::constructLidarConfiguration(
-        traffic_simulator::helper::LidarType::VLP16, ego_name_,
-        stringFromArchitectureType(architecture_type_)));
+      if (architecture_type_ == ArchitectureType::AWF_UNIVERSE) {
+        api_->attachLidarSensor(traffic_simulator::helper::constructLidarConfiguration(
+          traffic_simulator::helper::LidarType::VLP16, ego_name_,
+          stringFromArchitectureType(architecture_type_)));
 
-      double constexpr detection_update_duration = 0.1;
-      api_->attachDetectionSensor(traffic_simulator::helper::constructDetectionSensorConfiguration(
-        ego_name_, stringFromArchitectureType(architecture_type_), detection_update_duration));
+        double constexpr detection_update_duration = 0.1;
+        api_->attachDetectionSensor(
+          traffic_simulator::helper::constructDetectionSensorConfiguration(
+            ego_name_, stringFromArchitectureType(architecture_type_), detection_update_duration));
 
-      api_->attachOccupancyGridSensor([&]() {
-        simulation_api_schema::OccupancyGridSensorConfiguration configuration;
-        configuration.set_architecture_type(stringFromArchitectureType(architecture_type_));
-        configuration.set_entity(ego_name_);
-        configuration.set_filter_by_range(true);
-        configuration.set_height(200);
-        configuration.set_range(300);
-        configuration.set_resolution(0.5);
-        configuration.set_update_duration(0.1);
-        configuration.set_width(200);
-        return configuration;
-      }());
+        api_->attachOccupancyGridSensor([&]() {
+          simulation_api_schema::OccupancyGridSensorConfiguration configuration;
+          configuration.set_architecture_type(stringFromArchitectureType(architecture_type_));
+          configuration.set_entity(ego_name_);
+          configuration.set_filter_by_range(true);
+          configuration.set_height(200);
+          configuration.set_range(300);
+          configuration.set_resolution(0.5);
+          configuration.set_update_duration(0.1);
+          configuration.set_width(200);
+          return configuration;
+        }());
 
-      api_->asFieldOperatorApplication(ego_name_).declare_parameter<bool>(
-        "allow_goal_modification", true);
+        api_->asFieldOperatorApplication(ego_name_).declare_parameter<bool>(
+          "allow_goal_modification", true);
+      }
+
+      // XXX dirty hack: wait for autoware system to launch
+      // ugly but helps for now
+      std::this_thread::sleep_for(std::chrono::milliseconds{5000});
+
+      api_->requestAssignRoute(
+        ego_name_, std::vector<traffic_simulator::CanonicalizedLaneletPose>(
+                     {api_->canonicalize(test_description_.ego_goal_position)}));
+      api_->asFieldOperatorApplication(ego_name_).engage();
+
+      goal_reached_metric_.setGoal(test_description_.ego_goal_pose);
     }
 
-    // XXX dirty hack: wait for autoware system to launch
-    // ugly but helps for now
-    std::this_thread::sleep_for(std::chrono::milliseconds{5000});
-
-    api_->requestAssignRoute(
-      ego_name_, std::vector<traffic_simulator::CanonicalizedLaneletPose>(
-                   {api_->canonicalize(test_description_.ego_goal_position)}));
-    api_->asFieldOperatorApplication(ego_name_).engage();
-
-    goal_reached_metric_.setGoal(test_description_.ego_goal_pose);
-  }
-
-  for (size_t i = 0; i < test_description_.npcs_descriptions.size(); i++) {
-    const auto & npc_descr = test_description_.npcs_descriptions[i];
-    api_->spawn(
-      npc_descr.name, api_->canonicalize(npc_descr.start_position), getVehicleParameters());
-    api_->setEntityStatus(
-      npc_descr.name, api_->canonicalize(npc_descr.start_position),
-      traffic_simulator::helper::constructActionStatus(npc_descr.speed));
-    api_->requestSpeedChange(npc_descr.name, npc_descr.speed, true);
-  }
+    for (size_t i = 0; i < test_description_.npcs_descriptions.size(); i++) {
+      const auto & npc_descr = test_description_.npcs_descriptions[i];
+      api_->spawn(
+        npc_descr.name, api_->canonicalize(npc_descr.start_position), getVehicleParameters());
+      api_->setEntityStatus(
+        npc_descr.name, api_->canonicalize(npc_descr.start_position),
+        traffic_simulator::helper::constructActionStatus(npc_descr.speed));
+      api_->requestSpeedChange(npc_descr.name, npc_descr.speed, true);
+    }
+  });
 }
 
 void TestExecutor::update()
 {
-  if (!api_->isEgoSpawned() && !api_->isNpcLogicStarted()) {
-    api_->startNpcLogic();
-  }
-  if (
-    api_->isEgoSpawned() && !api_->isNpcLogicStarted() &&
-    api_->asFieldOperatorApplication(api_->getEgoName()).engageable()) {
-    api_->startNpcLogic();
-  }
+  executeWithErrorHandling([this]() {
+    if (!api_->isEgoSpawned() && !api_->isNpcLogicStarted()) {
+      api_->startNpcLogic();
+    }
+    if (
+      api_->isEgoSpawned() && !api_->isNpcLogicStarted() &&
+      api_->asFieldOperatorApplication(api_->getEgoName()).engageable()) {
+      api_->startNpcLogic();
+    }
 
-  auto current_time = api_->getCurrentTime();
+    auto current_time = api_->getCurrentTime();
 
-  if (!std::isnan(current_time)) {
-    bool timeout_reached = current_time >= test_timeout;
-    if (timeout_reached) {
-      if (simulator_type_ == SimulatorType::SIMPLE_SENSOR_SIMULATOR) {
-        if (!goal_reached_metric_.isGoalReached(api_->getEntityStatus(ego_name_))) {
-          RCLCPP_INFO(logger_, "Timeout reached");
-          error_reporter_.reportTimeout();
+    if (!std::isnan(current_time)) {
+      bool timeout_reached = current_time >= test_timeout;
+      if (timeout_reached) {
+        if (simulator_type_ == SimulatorType::SIMPLE_SENSOR_SIMULATOR) {
+          if (!goal_reached_metric_.isGoalReached(api_->getEntityStatus(ego_name_))) {
+            RCLCPP_INFO(logger_, "Timeout reached");
+            error_reporter_.reportTimeout();
+          }
+        }
+        scenario_completed_ = true;
+        return;
+      }
+    }
+    if (simulator_type_ == SimulatorType::SIMPLE_SENSOR_SIMULATOR) {
+      for (const auto & npc : test_description_.npcs_descriptions) {
+        if (api_->entityExists(npc.name) && api_->checkCollision(ego_name_, npc.name)) {
+          if (ego_collision_metric_.isThereEgosCollisionWith(npc.name, current_time)) {
+            std::string message =
+              fmt::format("New collision occurred between ego and {}", npc.name);
+            RCLCPP_INFO_STREAM(logger_, message);
+            error_reporter_.reportCollision(npc, current_time);
+          }
         }
       }
-      scenario_completed_ = true;
-      return;
-    }
-  }
-  if (simulator_type_ == SimulatorType::SIMPLE_SENSOR_SIMULATOR) {
-    for (const auto & npc : test_description_.npcs_descriptions) {
-      if (api_->entityExists(npc.name) && api_->checkCollision(ego_name_, npc.name)) {
-        if (ego_collision_metric_.isThereEgosCollisionWith(npc.name, current_time)) {
-          std::string message = fmt::format("New collision occurred between ego and {}", npc.name);
-          RCLCPP_INFO_STREAM(logger_, message);
-          error_reporter_.reportCollision(npc, current_time);
+
+      if (almost_standstill_metric_.isAlmostStandingStill(api_->getEntityStatus(ego_name_))) {
+        RCLCPP_INFO(logger_, "Standstill duration exceeded");
+        if (goal_reached_metric_.isGoalReached(api_->getEntityStatus(ego_name_))) {
+          RCLCPP_INFO(logger_, "Goal reached, standstill expected");
+        } else {
+          error_reporter_.reportStandStill();
         }
+        scenario_completed_ = true;
       }
     }
 
-    if (almost_standstill_metric_.isAlmostStandingStill(api_->getEntityStatus(ego_name_))) {
-      RCLCPP_INFO(logger_, "Standstill duration exceeded");
-      if (goal_reached_metric_.isGoalReached(api_->getEntityStatus(ego_name_))) {
-        RCLCPP_INFO(logger_, "Goal reached, standstill expected");
-      } else {
-        error_reporter_.reportStandStill();
-      }
-      scenario_completed_ = true;
-    }
-  }
-  api_->updateFrame();
+    api_->updateFrame();
+  });
 }
 
 void TestExecutor::deinitialize()
 {
-  std::string message = fmt::format("Deinitialize: {}", test_description_);
-  RCLCPP_INFO_STREAM(logger_, message);
+  executeWithErrorHandling([this]() {
+    std::string message = fmt::format("Deinitialize: {}", test_description_);
+    RCLCPP_INFO_STREAM(logger_, message);
 
-  if (simulator_type_ == SimulatorType::SIMPLE_SENSOR_SIMULATOR) {
-    api_->despawn(ego_name_);
-  }
-  for (const auto & npc : test_description_.npcs_descriptions) {
-    api_->despawn(npc.name);
+    if (simulator_type_ == SimulatorType::SIMPLE_SENSOR_SIMULATOR) {
+      api_->despawn(ego_name_);
+    }
+    for (const auto & npc : test_description_.npcs_descriptions) {
+      api_->despawn(npc.name);
+    }
+  });
+}
+
+void TestExecutor::executeWithErrorHandling(std::function<void()> func)
+{
+  try {
+    func();
+  } catch (const common::AutowareError & error) {
+    error_reporter_.reportException("autoware error", error.what());
+    std::string message = fmt::format("common::AutowareError occurred: {}", error.what());
+    RCLCPP_ERROR_STREAM(logger_, message);
+    scenario_completed_ = true;
+  } catch (const common::scenario_simulator_exception::Error & error) {
+    error_reporter_.reportException("scenario simulator error", error.what());
+    std::string message =
+      fmt::format("common::scenario_simulator_exception::Error occurred: {}", error.what());
+    RCLCPP_ERROR_STREAM(logger_, message);
+    scenario_completed_ = true;
+  } catch (const std::runtime_error & error) {
+    std::string message = fmt::format("std::runtime_error occurred: {}", error.what());
+    RCLCPP_ERROR_STREAM(logger_, message);
+    scenario_completed_ = true;
+  } catch (...) {
+    RCLCPP_ERROR(logger_, "Unknown error occurred.");
+    scenario_completed_ = true;
   }
 }
 

--- a/test_runner/random_test_runner/src/test_executor.cpp
+++ b/test_runner/random_test_runner/src/test_executor.cpp
@@ -87,6 +87,22 @@ void TestExecutor::initialize()
       double constexpr detection_update_duration = 0.1;
       api_->attachDetectionSensor(traffic_simulator::helper::constructDetectionSensorConfiguration(
         ego_name_, stringFromArchitectureType(architecture_type_), detection_update_duration));
+
+      api_->attachOccupancyGridSensor([&]() {
+        simulation_api_schema::OccupancyGridSensorConfiguration configuration;
+        configuration.set_architecture_type(stringFromArchitectureType(architecture_type_));
+        configuration.set_entity(ego_name_);
+        configuration.set_filter_by_range(true);
+        configuration.set_height(200);
+        configuration.set_range(300);
+        configuration.set_resolution(0.5);
+        configuration.set_update_duration(0.1);
+        configuration.set_width(200);
+        return configuration;
+      }());
+
+      api_->asFieldOperatorApplication(ego_name_).declare_parameter<bool>(
+        "allow_goal_modification", true);
     }
 
     // XXX dirty hack: wait for autoware system to launch

--- a/test_runner/random_test_runner/src/test_executor.cpp
+++ b/test_runner/random_test_runner/src/test_executor.cpp
@@ -200,7 +200,7 @@ void TestExecutor::deinitialize()
   });
 }
 
-void TestExecutor::executeWithErrorHandling(std::function<void()> func)
+void TestExecutor::executeWithErrorHandling(std::function<void()> && func)
 {
   try {
     func();


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [X] Bugfix

## Link to the issue
https://tier4.atlassian.net/browse/RJD-706

## Description
Multiple problems were fixed in this PR in order to allow performing tests with the random test runner successfully:

- The duration of Autoware initialization was not specified in the random test runner launch file. Because of that test runner was not waiting for Autoware to initialize and instead stopped immediately. The default value of the parameter is now set inside the launch file.
- `allow_goal_modification` was not declared as a parameter which made concealer crash while it was trying to use the parameter. The parameter is now declared with the usage of `traffic_simulator::API`. 
- `OccupancyGridSensor` was not attached by `TestExecutor` which blocked Autoware in planning the route. Autoware was stuck waiting for the initialization of occupancy grid map. The sensor is now attached with the usage of using `traffic_simulator::API`.
- Because all `TestExecutors` were using the same instance of `traffic_simulator::API` only the first test could be initialized properly. It was caused by the fact that `EntityManager` does not allow to set the entity status after starting the scenario. Separate `traffic_simulator::API` instances are now being attached to each `TestExecutor`.
- Exception thrown during the test ended the random test runner execution. Exceptions handling in `TestExecutor` is now added so that an exception ends only currently executed test and makes random test runner proceed to the next test.

## How to review this PR.

## Others
There is an issue which blocks random test runner from initializing the test if either initial position or goal pose exceeds the drivable area. 
- In the first case Autoware will be launched but the ego vehicle will not move waiting for Autoware to change its state to `WaitingForEngage`. After a timeout the test will finish, the error will be logged and the runner will continue with the next test.
- In the second case test will be immediately stopped after launching the Autoware and similarly as in the first case the error will be logged and the runner will continue with the next test.

This issue is not related with this PR. 
