### PR TITLE
Remove Point & Vector3 equal operators

### DIFF
--- a/common/math/geometry/include/geometry/linear_algebra.hpp
+++ b/common/math/geometry/include/geometry/linear_algebra.hpp
@@ -50,6 +50,4 @@ geometry_msgs::msg::Vector3 operator-(
   const geometry_msgs::msg::Vector3 & v0, const geometry_msgs::msg::Vector3 & v1);
 geometry_msgs::msg::Point operator-(
   const geometry_msgs::msg::Point & v0, const geometry_msgs::msg::Point & v1);
-bool operator==(const geometry_msgs::msg::Point & v0, const geometry_msgs::msg::Point & v1);
-bool operator==(const geometry_msgs::msg::Vector3 & v0, const geometry_msgs::msg::Vector3 & v1);
 #endif  // GEOMETRY__LINEAR_ALGEBRA_HPP_

--- a/common/math/geometry/src/linear_algebra.cpp
+++ b/common/math/geometry/src/linear_algebra.cpp
@@ -149,21 +149,3 @@ geometry_msgs::msg::Point operator-(
   ret.z = v0.z - v1.z;
   return ret;
 }
-
-bool operator==(const geometry_msgs::msg::Point & v0, const geometry_msgs::msg::Point & v1)
-{
-  constexpr double e = std::numeric_limits<double>::epsilon();
-  if (std::fabs(v0.x - v1.x) <= e && std::fabs(v0.y - v1.y) <= e && std::fabs(v0.z - v1.z) <= e) {
-    return true;
-  }
-  return false;
-}
-
-bool operator==(const geometry_msgs::msg::Vector3 & v0, const geometry_msgs::msg::Vector3 & v1)
-{
-  constexpr double e = std::numeric_limits<double>::epsilon();
-  if (std::fabs(v0.x - v1.x) <= e && std::fabs(v0.y - v1.y) <= e && std::fabs(v0.z - v1.z) <= e) {
-    return true;
-  }
-  return false;
-}


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
#1114 

## Description
I have removed equal operators for `geometry_msgs::msg::Point` and `geometry_msgs::msg::Vector3`, because they were ambiguous.
this is explained in more detail in the issue #1114.

## How to review this PR.

## Others
