### PR TITLE
Fix intersection vector lookup after the last element

### DIFF
--- a/common/math/geometry/src/intersection/intersection.cpp
+++ b/common/math/geometry/src/intersection/intersection.cpp
@@ -41,8 +41,8 @@ bool isIntersect2D(const LineSegment & line0, const LineSegment & line1)
 
 bool isIntersect2D(const std::vector<LineSegment> & lines)
 {
-  for (size_t i = 0; i <= lines.size(); i++) {
-    for (size_t m = 0; m <= lines.size(); m++) {
+  for (size_t i = 0; i < lines.size(); ++i) {
+    for (size_t m = 0; m < lines.size(); ++m) {
       if (i != m && isIntersect2D(lines[i], lines[m])) {
         return true;
       }
@@ -74,8 +74,8 @@ std::optional<geometry_msgs::msg::Point> getIntersection2D(
 std::vector<geometry_msgs::msg::Point> getIntersection2D(const std::vector<LineSegment> & lines)
 {
   std::vector<geometry_msgs::msg::Point> ret;
-  for (size_t i = 0; i <= lines.size(); i++) {
-    for (size_t m = 0; m <= lines.size(); m++) {
+  for (size_t i = 0; i < lines.size(); ++i) {
+    for (size_t m = 0; m < lines.size(); ++m) {
       if (i != m) {
         const auto point = getIntersection2D(lines[i], lines[m]);
         if (point) {


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
#1115 

## Description
I have fixed the bug which caused the intersection functions using vector to look past the last element of the vector and return wrong results.

## How to review this PR.

## Others
