### PR TITLE
Fix LineSegment initialization bug

### DIFF
--- a/common/math/geometry/src/polygon/line_segment.cpp
+++ b/common/math/geometry/src/polygon/line_segment.cpp
@@ -39,6 +39,13 @@ LineSegment::LineSegment(
 : start_point(start_point), end_point([&]() -> geometry_msgs::msg::Point {
     geometry_msgs::msg::Point ret;
     double vec_size = std::hypot(vec.x, vec.y);
+    if (vec_size == 0.0) {
+      THROW_SIMULATION_ERROR(
+        "Invalid vector is specified, while constructing LineSegment. ",
+        "The vector should have a non zero length to initialize the line segment correctly. ",
+        "This message is not originally intended to be displayed, if you see it, please "
+        "contact the developer of traffic_simulator.");
+    }
     ret.x = start_point.x + vec.x / vec_size * length;
     ret.y = start_point.y + vec.y / vec_size * length;
     ret.z = start_point.z + vec.z / vec_size * length;


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
#1116 

## Description
I have fixed a bug where the `LineSegment` class could be constructed with a `geometry_msgs::msg::Vector3` of size = 0.
This lead to initialization of `end_point` with `nan` values.

## How to review this PR.

## Others
