### PR TITLE
Fix getMinValue and getMaxValue empty vector bug

### DIFF
--- a/common/math/geometry/src/polygon/polygon.cpp
+++ b/common/math/geometry/src/polygon/polygon.cpp
@@ -19,6 +19,7 @@
 #include <boost/geometry/geometries/polygon.hpp>
 #include <geometry/polygon/polygon.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <scenario_simulator_exception/exception.hpp>
 
 namespace math
 {
@@ -51,13 +52,41 @@ std::vector<geometry_msgs::msg::Point> get2DConvexHull(
 
 double getMaxValue(const std::vector<geometry_msgs::msg::Point> & points, const Axis & axis)
 {
+  if (points.empty()) {
+    THROW_SIMULATION_ERROR(
+      "Invalid point list is specified, while getting max value on ",
+      axis == Axis::X   ? "X"
+      : axis == Axis::Y ? "Y"
+                        : "Z",
+      " axis. ",
+      "The point list in getMaxValue should have at least one point to get the max value from. "
+      "This message is not originally intended to be displayed, if you see it, please "
+      "contact the developer of traffic_simulator.");
+  }
   const auto values = filterByAxis(points, axis);
+  if (values.size() == 1) {
+    return values.front();
+  }
   return *std::max_element(values.begin(), values.end());
 }
 
 double getMinValue(const std::vector<geometry_msgs::msg::Point> & points, const Axis & axis)
 {
+  if (points.empty()) {
+    THROW_SIMULATION_ERROR(
+      "Invalid point list is specified, while getting min value on ",
+      axis == Axis::X   ? "X"
+      : axis == Axis::Y ? "Y"
+                        : "Z",
+      " axis. ",
+      "The point list in getMinValue should have at least one point to get the min value from. "
+      "This message is not originally intended to be displayed, if you see it, please "
+      "contact the developer of traffic_simulator.");
+  }
   const auto values = filterByAxis(points, axis);
+  if (values.size() == 1) {
+    return values.front();
+  }
   return *std::min_element(values.begin(), values.end());
 }
 


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
#1117 

## Description
I have fixed the `getMinValue` and `getMaxValue` bug where when an empty vector was passed the function tried to dereference `vector.end()` and the whole program crashed. 

## How to review this PR.

## Others
