### PR TITLE
Fix getTrajectory wrong number of points

### DIFF
--- a/common/math/geometry/src/spline/hermite_curve.cpp
+++ b/common/math/geometry/src/spline/hermite_curve.cpp
@@ -223,8 +223,12 @@ const std::vector<geometry_msgs::msg::Point> HermiteCurve::getTrajectory(
 std::vector<geometry_msgs::msg::Point> HermiteCurve::getTrajectory(size_t num_points) const
 {
   std::vector<geometry_msgs::msg::Point> ret;
-  for (size_t i = 0; i <= num_points; i++) {
-    double t = static_cast<double>(i) / static_cast<double>(num_points);
+  if (num_points == 1) {  // safe check to not divide by zero in the loop
+    ret.emplace_back(getPoint(0.0, false));
+    return ret;
+  }
+  for (size_t i = 0; i < num_points; ++i) {
+    double t = static_cast<double>(i) / static_cast<double>(num_points - 1);
     ret.emplace_back(getPoint(t, false));
   }
   return ret;


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
#1118 

## Description
I have fixed a `getPolygon` bug which caused the function to generate incorrect number of points.

## How to review this PR.

## Others
Please see the safe check I have added in order to prevent division by 0.
If the number of points on the trajectory to generate is 1, should the one point be on the beginning of the `HermiteCurve` (like it is implemented right now) or maybe in the middle?