### PR TITLE
Fix spline maximum 2D curvature calculation

### DIFF
--- a/common/math/geometry/src/spline/catmull_rom_spline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_spline.cpp
@@ -567,7 +567,12 @@ auto CatmullRomSpline::getMaximum2DCurvature() const -> double
   if (maximum_2d_curvatures_.empty()) {
     THROW_SIMULATION_ERROR("maximum 2D curvature vector size is 0.");  // LCOV_EXCL_LINE
   }
-  return *std::max_element(maximum_2d_curvatures_.begin(), maximum_2d_curvatures_.end());
+  const auto [min, max] =
+    std::minmax_element(maximum_2d_curvatures_.begin(), maximum_2d_curvatures_.end());
+  if (std::fabs(*min) > std::fabs(*max)) {
+    return *min;
+  }
+  return *max;
 }
 
 auto CatmullRomSpline::getNormalVector(const double s) const -> geometry_msgs::msg::Vector3


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
#1119 

## Description
I have added support for negative curvature values which were already supported by `HermiteCurve`.
This incompatibility lead to errors.

## How to review this PR.

## Others
