### PR TITLE
Fix spline collision point calculation

### DIFF
--- a/common/math/geometry/include/geometry/spline/hermite_curve.hpp
+++ b/common/math/geometry/include/geometry/spline/hermite_curve.hpp
@@ -65,10 +65,10 @@ public:
     const geometry_msgs::msg::Point & point, double s, bool denormalize_s = false) const;
   std::optional<double> getCollisionPointIn2D(
     const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
-    bool search_backward = false) const;
+    bool search_backward = false, bool denormalize_s = false) const;
   std::optional<double> getCollisionPointIn2D(
     const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward = false,
-    bool close_start_end = true) const;
+    bool close_start_end = true, bool denormalize_s = false) const;
 
 private:
   std::pair<double, double> get2DMinMaxCurvatureValue() const;

--- a/common/math/geometry/src/spline/catmull_rom_spline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_spline.cpp
@@ -301,7 +301,8 @@ auto CatmullRomSpline::getCollisionPointIn2D(
     size_t n = curves_.size();
     if (search_backward) {
       for (size_t i = 0; i < n; i++) {
-        auto s = curves_[n - 1 - i].getCollisionPointIn2D(polygon, search_backward);
+        /// @note The polygon is assumed to be closed
+        auto s = curves_[n - 1 - i].getCollisionPointIn2D(polygon, search_backward, true, true);
         if (s) {
           return getSInSplineCurve(n - 1 - i, s.value());
         }
@@ -309,7 +310,8 @@ auto CatmullRomSpline::getCollisionPointIn2D(
       return std::optional<double>();
     } else {
       for (size_t i = 0; i < n; i++) {
-        auto s = curves_[i].getCollisionPointIn2D(polygon, search_backward);
+        /// @note The polygon is assumed to be closed
+        auto s = curves_[i].getCollisionPointIn2D(polygon, search_backward, true, true);
         if (s) {
           return std::optional<double>(getSInSplineCurve(i, s.value()));
         }
@@ -380,7 +382,7 @@ auto CatmullRomSpline::getCollisionPointIn2D(
   size_t n = curves_.size();
   if (search_backward) {
     for (size_t i = 0; i < n; i++) {
-      auto s = curves_[n - 1 - i].getCollisionPointIn2D(point0, point1, search_backward);
+      auto s = curves_[n - 1 - i].getCollisionPointIn2D(point0, point1, search_backward, true);
       if (s) {
         return getSInSplineCurve(n - 1 - i, s.value());
       }
@@ -388,7 +390,7 @@ auto CatmullRomSpline::getCollisionPointIn2D(
     return std::nullopt;
   } else {
     for (size_t i = 0; i < n; i++) {
-      auto s = curves_[i].getCollisionPointIn2D(point0, point1, search_backward);
+      auto s = curves_[i].getCollisionPointIn2D(point0, point1, search_backward, true);
       if (s) {
         return getSInSplineCurve(i, s.value());
       }


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
#1120 

## Description
I have fixed spline collision implementation error which caused spline to add normalized length to absolute lengths which is incorrect.

## How to review this PR.

## Others
Please note that in the `BuildAndRun` workflow the build was successful and only one test did not pass.
This test does not pass because of the floating point numbers precision. The imperfection happens in a lambda I have added, specifically in line 159 in `hermite_curve.cpp`.
The length of the spline is calculated by interpolating it with 100 points which leads to minor errors.
**I am in the process of improving `geometry` tests and these test issues will be resolved.**