### PR TITLE
fix(follow_trajectory): fix orientation for zero velocity vector (inactivity)

### DIFF
--- a/simulation/traffic_simulator/src/behavior/follow_trajectory.cpp
+++ b/simulation/traffic_simulator/src/behavior/follow_trajectory.cpp
@@ -498,6 +498,10 @@ auto makeUpdatedStatus(
     updated_status.pose.position += velocity * step_time;
 
     updated_status.pose.orientation = [&]() {
+      // do not change orientation if there is no velocity vector
+      if (velocity.y == 0 && velocity.x == 0) {
+        return entity_status.pose.orientation;
+      }
       geometry_msgs::msg::Vector3 direction;
       direction.x = 0;
       direction.y = 0;


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
[RJD-727](https://tier4.atlassian.net/browse/RJD-727) - to Investigate why NPC's direction becomes wrong when FollowTrajectoryAction is used , and to fix the causes
## Description
PR introduces a fix that ensures that the actor's orientation is not changed when the calculated velocity vector is zero.
## How to review this PR.

## Others


[RJD-727]: https://tier4.atlassian.net/browse/RJD-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ