### PR TITLE
Fix/minor bug fixes

### DIFF
--- a/common/math/geometry/include/geometry/linear_algebra.hpp
+++ b/common/math/geometry/include/geometry/linear_algebra.hpp
@@ -50,6 +50,4 @@ geometry_msgs::msg::Vector3 operator-(
   const geometry_msgs::msg::Vector3 & v0, const geometry_msgs::msg::Vector3 & v1);
 geometry_msgs::msg::Point operator-(
   const geometry_msgs::msg::Point & v0, const geometry_msgs::msg::Point & v1);
-bool operator==(const geometry_msgs::msg::Point & v0, const geometry_msgs::msg::Point & v1);
-bool operator==(const geometry_msgs::msg::Vector3 & v0, const geometry_msgs::msg::Vector3 & v1);
 #endif  // GEOMETRY__LINEAR_ALGEBRA_HPP_

--- a/common/math/geometry/include/geometry/spline/catmull_rom_spline.hpp
+++ b/common/math/geometry/include/geometry/spline/catmull_rom_spline.hpp
@@ -49,8 +49,9 @@ public:
     -> double;
   auto getSquaredDistanceVector(const geometry_msgs::msg::Point & point, const double s) const
     -> geometry_msgs::msg::Vector3;
-  auto getCollisionPointsIn2D(const std::vector<geometry_msgs::msg::Point> & polygon) const
-    -> std::set<double>;
+  auto getCollisionPointsIn2D(
+    const std::vector<geometry_msgs::msg::Point> & polygon,
+    const bool search_backward = false) const -> std::set<double>;
   auto getCollisionPointIn2D(
     const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
     const bool search_backward = false) const -> std::optional<double>;

--- a/common/math/geometry/include/geometry/spline/catmull_rom_spline.hpp
+++ b/common/math/geometry/include/geometry/spline/catmull_rom_spline.hpp
@@ -49,6 +49,8 @@ public:
     -> double;
   auto getSquaredDistanceVector(const geometry_msgs::msg::Point & point, const double s) const
     -> geometry_msgs::msg::Vector3;
+  auto getCollisionPointsIn2D(const std::vector<geometry_msgs::msg::Point> & polygon) const
+    -> std::set<double>;
   auto getCollisionPointIn2D(
     const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
     const bool search_backward = false) const -> std::optional<double>;

--- a/common/math/geometry/include/geometry/spline/hermite_curve.hpp
+++ b/common/math/geometry/include/geometry/spline/hermite_curve.hpp
@@ -63,9 +63,15 @@ public:
     const geometry_msgs::msg::Point & point, double s, bool denormalize_s = false) const;
   geometry_msgs::msg::Vector3 getSquaredDistanceVector(
     const geometry_msgs::msg::Point & point, double s, bool denormalize_s = false) const;
+  std::set<double> getCollisionPointsIn2D(
+    const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
+    bool search_backward = false, bool denormalize_s = false) const;
   std::optional<double> getCollisionPointIn2D(
     const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
     bool search_backward = false, bool denormalize_s = false) const;
+  std::set<double> getCollisionPointsIn2D(
+    const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward = false,
+    bool close_start_end = true, bool denormalize_s = false) const;
   std::optional<double> getCollisionPointIn2D(
     const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward = false,
     bool close_start_end = true, bool denormalize_s = false) const;

--- a/common/math/geometry/include/geometry/spline/hermite_curve.hpp
+++ b/common/math/geometry/include/geometry/spline/hermite_curve.hpp
@@ -65,10 +65,10 @@ public:
     const geometry_msgs::msg::Point & point, double s, bool denormalize_s = false) const;
   std::optional<double> getCollisionPointIn2D(
     const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
-    bool search_backward = false) const;
+    bool search_backward = false, bool denormalize_s = false) const;
   std::optional<double> getCollisionPointIn2D(
     const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward = false,
-    bool close_start_end = true) const;
+    bool close_start_end = true, bool denormalize_s = false) const;
 
 private:
   std::pair<double, double> get2DMinMaxCurvatureValue() const;

--- a/common/math/geometry/src/intersection/intersection.cpp
+++ b/common/math/geometry/src/intersection/intersection.cpp
@@ -41,8 +41,8 @@ bool isIntersect2D(const LineSegment & line0, const LineSegment & line1)
 
 bool isIntersect2D(const std::vector<LineSegment> & lines)
 {
-  for (size_t i = 0; i <= lines.size(); i++) {
-    for (size_t m = 0; m <= lines.size(); m++) {
+  for (size_t i = 0; i < lines.size(); ++i) {
+    for (size_t m = 0; m < lines.size(); ++m) {
       if (i != m && isIntersect2D(lines[i], lines[m])) {
         return true;
       }
@@ -74,8 +74,8 @@ std::optional<geometry_msgs::msg::Point> getIntersection2D(
 std::vector<geometry_msgs::msg::Point> getIntersection2D(const std::vector<LineSegment> & lines)
 {
   std::vector<geometry_msgs::msg::Point> ret;
-  for (size_t i = 0; i <= lines.size(); i++) {
-    for (size_t m = 0; m <= lines.size(); m++) {
+  for (size_t i = 0; i < lines.size(); ++i) {
+    for (size_t m = 0; m < lines.size(); ++m) {
       if (i != m) {
         const auto point = getIntersection2D(lines[i], lines[m]);
         if (point) {

--- a/common/math/geometry/src/linear_algebra.cpp
+++ b/common/math/geometry/src/linear_algebra.cpp
@@ -149,21 +149,3 @@ geometry_msgs::msg::Point operator-(
   ret.z = v0.z - v1.z;
   return ret;
 }
-
-bool operator==(const geometry_msgs::msg::Point & v0, const geometry_msgs::msg::Point & v1)
-{
-  constexpr double e = std::numeric_limits<double>::epsilon();
-  if (std::fabs(v0.x - v1.x) <= e && std::fabs(v0.y - v1.y) <= e && std::fabs(v0.z - v1.z) <= e) {
-    return true;
-  }
-  return false;
-}
-
-bool operator==(const geometry_msgs::msg::Vector3 & v0, const geometry_msgs::msg::Vector3 & v1)
-{
-  constexpr double e = std::numeric_limits<double>::epsilon();
-  if (std::fabs(v0.x - v1.x) <= e && std::fabs(v0.y - v1.y) <= e && std::fabs(v0.z - v1.z) <= e) {
-    return true;
-  }
-  return false;
-}

--- a/common/math/geometry/src/polygon/line_segment.cpp
+++ b/common/math/geometry/src/polygon/line_segment.cpp
@@ -39,6 +39,13 @@ LineSegment::LineSegment(
 : start_point(start_point), end_point([&]() -> geometry_msgs::msg::Point {
     geometry_msgs::msg::Point ret;
     double vec_size = std::hypot(vec.x, vec.y);
+    if (vec_size == 0.0) {
+      THROW_SIMULATION_ERROR(
+        "Invalid vector is specified, while constructing LineSegment. ",
+        "The vector should have a non zero length to initialize the line segment correctly. ",
+        "This message is not originally intended to be displayed, if you see it, please "
+        "contact the developer of traffic_simulator.");
+    }
     ret.x = start_point.x + vec.x / vec_size * length;
     ret.y = start_point.y + vec.y / vec_size * length;
     ret.z = start_point.z + vec.z / vec_size * length;

--- a/common/math/geometry/src/polygon/polygon.cpp
+++ b/common/math/geometry/src/polygon/polygon.cpp
@@ -19,6 +19,7 @@
 #include <boost/geometry/geometries/polygon.hpp>
 #include <geometry/polygon/polygon.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <scenario_simulator_exception/exception.hpp>
 
 namespace math
 {
@@ -51,13 +52,41 @@ std::vector<geometry_msgs::msg::Point> get2DConvexHull(
 
 double getMaxValue(const std::vector<geometry_msgs::msg::Point> & points, const Axis & axis)
 {
+  if (points.empty()) {
+    THROW_SIMULATION_ERROR(
+      "Invalid point list is specified, while getting max value on ",
+      axis == Axis::X   ? "X"
+      : axis == Axis::Y ? "Y"
+                        : "Z",
+      " axis. ",
+      "The point list in getMaxValue should have at least one point to get the max value from. "
+      "This message is not originally intended to be displayed, if you see it, please "
+      "contact the developer of traffic_simulator.");
+  }
   const auto values = filterByAxis(points, axis);
+  if (values.size() == 1) {
+    return values.front();
+  }
   return *std::max_element(values.begin(), values.end());
 }
 
 double getMinValue(const std::vector<geometry_msgs::msg::Point> & points, const Axis & axis)
 {
+  if (points.empty()) {
+    THROW_SIMULATION_ERROR(
+      "Invalid point list is specified, while getting min value on ",
+      axis == Axis::X   ? "X"
+      : axis == Axis::Y ? "Y"
+                        : "Z",
+      " axis. ",
+      "The point list in getMinValue should have at least one point to get the min value from. "
+      "This message is not originally intended to be displayed, if you see it, please "
+      "contact the developer of traffic_simulator.");
+  }
   const auto values = filterByAxis(points, axis);
+  if (values.size() == 1) {
+    return values.front();
+  }
   return *std::min_element(values.begin(), values.end());
 }
 

--- a/common/math/geometry/src/spline/catmull_rom_spline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_spline.cpp
@@ -569,7 +569,12 @@ auto CatmullRomSpline::getMaximum2DCurvature() const -> double
   if (maximum_2d_curvatures_.empty()) {
     THROW_SIMULATION_ERROR("maximum 2D curvature vector size is 0.");  // LCOV_EXCL_LINE
   }
-  return *std::max_element(maximum_2d_curvatures_.begin(), maximum_2d_curvatures_.end());
+  const auto [min, max] =
+    std::minmax_element(maximum_2d_curvatures_.begin(), maximum_2d_curvatures_.end());
+  if (std::fabs(*min) > std::fabs(*max)) {
+    return *min;
+  }
+  return *max;
 }
 
 auto CatmullRomSpline::getNormalVector(const double s) const -> geometry_msgs::msg::Vector3

--- a/common/math/geometry/src/spline/catmull_rom_spline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_spline.cpp
@@ -290,7 +290,8 @@ auto CatmullRomSpline::getCollisionPointsIn2D(
       "developer of traffic_simulator.");
   }
   /// @note If the spline has three or more control points.
-  const auto get_collision_point_2d_with_curve = [this](const auto & polygon) -> std::set<double> {
+  const auto get_collision_point_2d_with_curve =
+    [this](const auto & polygon, const auto search_backward) -> std::set<double> {
     std::set<double> s_value_candidates;
     for (size_t i = 0; i < curves_.size(); ++i) {
       /// @note The polygon is assumed to be closed
@@ -345,7 +346,7 @@ auto CatmullRomSpline::getCollisionPointsIn2D(
       return get_collision_point_2d_with_line(polygon);
     /// @note In this case, spline is interpreted as curve.
     default:
-      return get_collision_point_2d_with_curve(polygon);
+      return get_collision_point_2d_with_curve(polygon, search_backward);
   }
 }
 

--- a/common/math/geometry/src/spline/catmull_rom_spline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_spline.cpp
@@ -301,7 +301,8 @@ auto CatmullRomSpline::getCollisionPointIn2D(
     size_t n = curves_.size();
     if (search_backward) {
       for (size_t i = 0; i < n; i++) {
-        auto s = curves_[n - 1 - i].getCollisionPointIn2D(polygon, search_backward);
+        /// @note The polygon is assumed to be closed
+        auto s = curves_[n - 1 - i].getCollisionPointIn2D(polygon, search_backward, true, true);
         if (s) {
           return getSInSplineCurve(n - 1 - i, s.value());
         }
@@ -309,7 +310,8 @@ auto CatmullRomSpline::getCollisionPointIn2D(
       return std::optional<double>();
     } else {
       for (size_t i = 0; i < n; i++) {
-        auto s = curves_[i].getCollisionPointIn2D(polygon, search_backward);
+        /// @note The polygon is assumed to be closed
+        auto s = curves_[i].getCollisionPointIn2D(polygon, search_backward, true, true);
         if (s) {
           return std::optional<double>(getSInSplineCurve(i, s.value()));
         }
@@ -380,7 +382,7 @@ auto CatmullRomSpline::getCollisionPointIn2D(
   size_t n = curves_.size();
   if (search_backward) {
     for (size_t i = 0; i < n; i++) {
-      auto s = curves_[n - 1 - i].getCollisionPointIn2D(point0, point1, search_backward);
+      auto s = curves_[n - 1 - i].getCollisionPointIn2D(point0, point1, search_backward, true);
       if (s) {
         return getSInSplineCurve(n - 1 - i, s.value());
       }
@@ -388,7 +390,7 @@ auto CatmullRomSpline::getCollisionPointIn2D(
     return std::nullopt;
   } else {
     for (size_t i = 0; i < n; i++) {
-      auto s = curves_[i].getCollisionPointIn2D(point0, point1, search_backward);
+      auto s = curves_[i].getCollisionPointIn2D(point0, point1, search_backward, true);
       if (s) {
         return getSInSplineCurve(i, s.value());
       }

--- a/common/math/geometry/src/spline/catmull_rom_spline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_spline.cpp
@@ -279,7 +279,8 @@ auto CatmullRomSpline::getSInSplineCurve(const size_t curve_index, const double 
 }
 
 auto CatmullRomSpline::getCollisionPointsIn2D(
-  const std::vector<geometry_msgs::msg::Point> & polygon) const -> std::set<double>
+  const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward) const
+  -> std::set<double>
 {
   if (polygon.size() <= 1) {
     THROW_SIMULATION_ERROR(
@@ -293,9 +294,10 @@ auto CatmullRomSpline::getCollisionPointsIn2D(
     std::set<double> s_value_candidates;
     for (size_t i = 0; i < curves_.size(); ++i) {
       /// @note The polygon is assumed to be closed
-      if (const auto s = curves_[i].getCollisionPointIn2D(polygon, false, true, true)) {
-        s_value_candidates.insert(getSInSplineCurve(i, s.value()));
-      }
+      const auto s = curves_[i].getCollisionPointsIn2D(polygon, search_backward, true, true);
+      std::for_each(s.begin(), s.end(), [&s_value_candidates, i, this](const auto & s) {
+        s_value_candidates.insert(getSInSplineCurve(i, s));
+      });
     }
     return s_value_candidates;
   };
@@ -357,7 +359,7 @@ auto CatmullRomSpline::getCollisionPointIn2D(
   const std::vector<geometry_msgs::msg::Point> & polygon, const bool search_backward) const
   -> std::optional<double>
 {
-  std::set<double> s_value_candidates = getCollisionPointsIn2D(polygon);
+  std::set<double> s_value_candidates = getCollisionPointsIn2D(polygon, search_backward);
   if (s_value_candidates.empty()) {
     return std::nullopt;
   }

--- a/common/math/geometry/src/spline/hermite_curve.cpp
+++ b/common/math/geometry/src/spline/hermite_curve.cpp
@@ -223,8 +223,12 @@ const std::vector<geometry_msgs::msg::Point> HermiteCurve::getTrajectory(
 std::vector<geometry_msgs::msg::Point> HermiteCurve::getTrajectory(size_t num_points) const
 {
   std::vector<geometry_msgs::msg::Point> ret;
-  for (size_t i = 0; i <= num_points; i++) {
-    double t = static_cast<double>(i) / static_cast<double>(num_points);
+  if (num_points == 1) {  // safe check to not divide by zero in the loop
+    ret.emplace_back(getPoint(0.0, false));
+    return ret;
+  }
+  for (size_t i = 0; i < num_points; ++i) {
+    double t = static_cast<double>(i) / static_cast<double>(num_points - 1);
     ret.emplace_back(getPoint(t, false));
   }
   return ret;

--- a/common/math/geometry/src/spline/hermite_curve.cpp
+++ b/common/math/geometry/src/spline/hermite_curve.cpp
@@ -85,45 +85,47 @@ geometry_msgs::msg::Vector3 HermiteCurve::getSquaredDistanceVector(
   return ret;
 }
 
-std::optional<double> HermiteCurve::getCollisionPointIn2D(
+std::set<double> HermiteCurve::getCollisionPointsIn2D(
   const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward,
   bool close_start_end, bool denormalize_s) const
 {
   size_t n = polygon.size();
   if (n <= 1) {
-    return std::nullopt;
+    return {};
   }
-  std::vector<double> s_values;
+  std::set<double> s_values;
   for (size_t i = 0; i < (n - 1); i++) {
     const auto p0 = polygon[i];
     const auto p1 = polygon[i + 1];
-    auto s = getCollisionPointIn2D(p0, p1, search_backward, denormalize_s);
-    if (s) {
-      s_values.push_back(s.value());
-    }
+    s_values.merge(getCollisionPointsIn2D(p0, p1, search_backward, denormalize_s));
   }
   if (close_start_end) {
     const auto p0 = polygon[n - 1];
     const auto p1 = polygon[0];
-    auto s = getCollisionPointIn2D(p0, p1, search_backward, denormalize_s);
-    if (s) {
-      s_values.push_back(s.value());
-    }
+    s_values.merge(getCollisionPointsIn2D(p0, p1, search_backward, denormalize_s));
   }
+  return s_values;
+}
+
+std::optional<double> HermiteCurve::getCollisionPointIn2D(
+  const std::vector<geometry_msgs::msg::Point> & polygon, bool search_backward,
+  bool close_start_end, bool denormalize_s) const
+{
+  auto s_values = getCollisionPointsIn2D(polygon, search_backward, close_start_end, denormalize_s);
   if (s_values.empty()) {
     return std::nullopt;
   }
   if (search_backward) {
-    return *std::max_element(s_values.begin(), s_values.end());
+    return *s_values.rbegin();
   }
-  return *std::min_element(s_values.begin(), s_values.end());
+  return *s_values.begin();
 }
 
-std::optional<double> HermiteCurve::getCollisionPointIn2D(
+std::set<double> HermiteCurve::getCollisionPointsIn2D(
   const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
   bool search_backward, bool denormalize_s) const
 {
-  std::vector<double> s_values;
+  std::set<double> s_values;
   double fx = point0.x;
   double ex = (point1.x - point0.x);
   double fy = point0.y;
@@ -173,21 +175,29 @@ std::optional<double> HermiteCurve::getCollisionPointIn2D(
        * tx, ty, will be in the range [0, 1] while the other will be out of that range because of division by zero.
        */
       if ((0 <= tx && tx <= 1) || (0 <= ty && ty <= 1)) {
-        s_values.push_back(denormalize(solution));
+        s_values.insert(denormalize(solution));
       }
     } else {
       if ((0 <= tx && tx <= 1) && (0 <= ty && ty <= 1)) {
-        s_values.push_back(denormalize(solution));
+        s_values.insert(denormalize(solution));
       }
     }
   }
+  return s_values;
+}
+
+std::optional<double> HermiteCurve::getCollisionPointIn2D(
+  const geometry_msgs::msg::Point & point0, const geometry_msgs::msg::Point & point1,
+  bool search_backward, bool denormalize_s) const
+{
+  auto s_values = getCollisionPointsIn2D(point0, point1, search_backward, denormalize_s);
   if (s_values.empty()) {
     return std::nullopt;
   }
   if (search_backward) {
-    return *std::max_element(s_values.begin(), s_values.end());
+    return *s_values.rbegin();
   }
-  return *std::min_element(s_values.begin(), s_values.end());
+  return *s_values.begin();
 }
 
 std::optional<double> HermiteCurve::getSValue(

--- a/common/math/geometry/test/test_catmull_rom_spline.cpp
+++ b/common/math/geometry/test/test_catmull_rom_spline.cpp
@@ -153,20 +153,20 @@ TEST(CatmullRomSpline, GetCollisionPointIn2D)
   auto collision_s = spline.getCollisionPointIn2D(start, goal, false);
   EXPECT_TRUE(collision_s);
   if (collision_s) {
-    EXPECT_DOUBLE_EQ(collision_s.value(), 0.1);
+    EXPECT_NEAR(collision_s.value(), 0.1, 1e-6);
   }
   collision_s = spline.getCollisionPointIn2D({start, goal}, false);
   if (collision_s) {
-    EXPECT_DOUBLE_EQ(collision_s.value(), 0.1);
+    EXPECT_NEAR(collision_s.value(), 0.1, 1e-6);
   }
   collision_s = spline.getCollisionPointIn2D(start, goal, true);
   EXPECT_TRUE(collision_s);
   if (collision_s) {
-    EXPECT_DOUBLE_EQ(collision_s.value(), 0.1);
+    EXPECT_NEAR(collision_s.value(), 0.1, 1e-6);
   }
   collision_s = spline.getCollisionPointIn2D({start, goal}, true);
   if (collision_s) {
-    EXPECT_DOUBLE_EQ(collision_s.value(), 0.1);
+    EXPECT_NEAR(collision_s.value(), 0.1, 1e-6);
   }
 }
 


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue
#1114 #1115 #1116 #1117 #1118 #1119 #1120 #1123 

## Description
I have fixed all bugs that were reported in the issues linked above. 

- I have removed equal operators for `geometry_msgs::msg::Point` and `geometry_msgs::msg::Vector3`, because they were ambiguous.
- I have fixed the bug which caused the intersection functions using vector to look past the last element of the vector and return wrong results.
- I have fixed a bug where the `LineSegment` class could be constructed with a `geometry_msgs::msg::Vector3` of size = 0. This lead to initialization of `end_point` with `nan` values.
- I have fixed the `getMinValue` and `getMaxValue` bug where when an empty vector was passed the function tried to dereference `vector.end()` and the whole program crashed.
- I have fixed a `getPolygon` bug which caused the function to generate incorrect number of points.
- I have added support for negative curvature values which were already supported by `HermiteCurve`. This incompatibility lead to errors.
- I have fixed spline collision implementation error which caused spline to add normalized length to absolute lengths which is incorrect.
- I have fixed `CatmullRomSubspline` collision detection by enabling the `HermiteCurve` and `CatmullRomSpline` to have multiple collisions detected and then choosing in the subspline the collisions that occur inside the subspline.

## How to review this PR.

## Others
