### PR TITLE
Feature/consider tread in ego entity

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -4,8 +4,9 @@
 
 Major Changes :race_car: :red_car: :blue_car:
 
-| Feature | Brief summary | Category | Pull request | Contributor |
-| ------- | ------------- | -------- | ------------ | ----------- |
+| Feature                 | Brief summary                                                        | Category            | Pull request                                                      | Contributor                                   |
+| ----------------------- | -------------------------------------------------------------------- | ------------------- | ----------------------------------------------------------------- | --------------------------------------------- |
+| Extend matching length. | Enable consider tread when calculating matching length of EgoEntity. | `traffic_simulator` | [#1181](https://github.com/tier4/scenario_simulator_v2/pull/1181) | [hakuturu583](https://github.com/hakuturu583) |
 
 Bug Fixes:bug:
 

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/sensor_simulation.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/sensor_simulation.hpp
@@ -92,7 +92,7 @@ public:
   }
 
   auto attachPseudoTrafficLightsDetector(
-    const double current_simulation_time,
+    const double /*current_simulation_time*/,
     const simulation_api_schema::PseudoTrafficLightDetectorConfiguration & configuration,
     rclcpp::Node & node, std::shared_ptr<hdmap_utils::HdMapUtils> hdmap_utils) -> void
   {

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/vehicle_simulation/ego_entity_simulation.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/vehicle_simulation/ego_entity_simulation.hpp
@@ -62,6 +62,7 @@ private:
 
 public:
   const std::shared_ptr<hdmap_utils::HdMapUtils> hdmap_utils_ptr_;
+  const traffic_simulator_msgs::msg::VehicleParameters vehicle_parameters;
 
 private:
   auto getCurrentPose() const -> geometry_msgs::msg::Pose;

--- a/simulation/simple_sensor_simulator/src/vehicle_simulation/ego_entity_simulation.cpp
+++ b/simulation/simple_sensor_simulator/src/vehicle_simulation/ego_entity_simulation.cpp
@@ -38,7 +38,8 @@ EgoEntitySimulation::EgoEntitySimulation(
 : autoware(std::make_unique<concealer::AutowareUniverse>()),
   vehicle_model_type_(getVehicleModelType()),
   vehicle_model_ptr_(makeSimulationModel(vehicle_model_type_, step_time, parameters)),
-  hdmap_utils_ptr_(hdmap_utils)
+  hdmap_utils_ptr_(hdmap_utils),
+  vehicle_parameters(parameters)
 {
 }
 
@@ -395,12 +396,23 @@ auto EgoEntitySimulation::fillLaneletDataAndSnapZToLanelet(
     traffic_simulator::helper::getUniqueValues(autoware->getRouteLanelets());
   std::optional<traffic_simulator_msgs::msg::LaneletPose> lanelet_pose;
 
+  const auto get_matching_length = [&] {
+    return std::max(
+             vehicle_parameters.axles.front_axle.track_width,
+             vehicle_parameters.axles.rear_axle.track_width) *
+             0.5 +
+           1.0;
+  };
+
   if (unique_route_lanelets.empty()) {
-    lanelet_pose = hdmap_utils_ptr_->toLaneletPose(status.pose, status.bounding_box, false, 1.0);
+    lanelet_pose = hdmap_utils_ptr_->toLaneletPose(
+      status.pose, status.bounding_box, false, get_matching_length());
   } else {
-    lanelet_pose = hdmap_utils_ptr_->toLaneletPose(status.pose, unique_route_lanelets, 1.0);
+    lanelet_pose =
+      hdmap_utils_ptr_->toLaneletPose(status.pose, unique_route_lanelets, get_matching_length());
     if (!lanelet_pose) {
-      lanelet_pose = hdmap_utils_ptr_->toLaneletPose(status.pose, status.bounding_box, false, 1.0);
+      lanelet_pose = hdmap_utils_ptr_->toLaneletPose(
+        status.pose, status.bounding_box, false, get_matching_length());
     }
   }
   if (lanelet_pose) {

--- a/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
+++ b/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
@@ -6,8 +6,9 @@ Panels:
       Expanded:
         - /Map1/Lanelet2VectorMap1
         - /Sensing1/LiDAR1/ConcatenatePointCloud1/Autocompute Value Bounds1
+        - /TF1
       Splitter Ratio: 0.557669460773468
-    Tree Height: 914
+    Tree Height: 1281
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -132,6 +133,11 @@ Visualization Manager:
                 Expand Link Details: false
                 Expand Tree: false
                 Link Tree Style: Links in Alphabetic Order
+                ars408_front_center:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
                 base_link:
                   Alpha: 1
                   Show Axes: false
@@ -373,29 +379,11 @@ Visualization Manager:
           Namespaces:
             center_lane_line: false
             center_line_arrows: false
-            crosswalk_lanelets: true
             lane_start_bound: false
-            lanelet direction: true
             lanelet_id: false
             left_lane_bound: true
-            no_stopping_area: true
-            parking_lots: true
-            partitions: true
-            pedestrian_marking: true
             right_lane_bound: true
             road_lanelets: false
-            shoulder_center_lane_line: true
-            shoulder_center_line_arrows: true
-            shoulder_lane_start_bound: true
-            shoulder_lanelet direction: true
-            shoulder_left_lane_bound: true
-            shoulder_right_lane_bound: true
-            shoulder_road_lanelets: false
-            stop_lines: true
-            traffic_light: true
-            traffic_light_id: false
-            traffic_light_triangle: true
-            walkway_lanelets: true
           Topic:
             Depth: 5
             Durability Policy: Transient Local
@@ -749,14 +737,20 @@ Visualization Manager:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
                   Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+                  Confidence Interval: 95%
                   Display Acceleration: true
+                  Display Existence Probability: false
                   Display Label: true
-                  Display PoseWithCovariance: true
+                  Display Pose Covariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
+                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
+                  Display Yaw Covariance: false
+                  Display Yaw Rate: false
+                  Display Yaw Rate Covariance: false
                   Enabled: true
                   Line Width: 0.029999999329447746
                   MOTORCYCLE:
@@ -800,14 +794,21 @@ Visualization Manager:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
                   Class: autoware_auto_perception_rviz_plugin/TrackedObjects
+                  Confidence Interval: 95%
                   Display Acceleration: true
+                  Display Existence Probability: false
                   Display Label: true
-                  Display PoseWithCovariance: true
+                  Display Pose Covariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
+                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
+                  Display Yaw Covariance: false
+                  Display Yaw Rate: false
+                  Display Yaw Rate Covariance: false
+                  Dynamic Status: All
                   Enabled: true
                   Line Width: 0.029999999329447746
                   MOTORCYCLE:
@@ -851,14 +852,20 @@ Visualization Manager:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
                   Class: autoware_auto_perception_rviz_plugin/PredictedObjects
+                  Confidence Interval: 95%
                   Display Acceleration: true
+                  Display Existence Probability: false
                   Display Label: true
-                  Display PoseWithCovariance: false
+                  Display Pose Covariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
+                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
+                  Display Yaw Covariance: false
+                  Display Yaw Rate: false
+                  Display Yaw Rate Covariance: false
                   Enabled: true
                   Line Width: 0.5
                   MOTORCYCLE:
@@ -866,7 +873,15 @@ Visualization Manager:
                     Color: 119; 11; 32
                   Name: PredictedObjects
                   Namespaces:
-                    {}
+                    acceleration: true
+                    label: true
+                    path: true
+                    path confidence: true
+                    position covariance: true
+                    shape: true
+                    twist: true
+                    uuid: true
+                    velocity: true
                   PEDESTRIAN:
                     Alpha: 0.9990000128746033
                     Color: 255; 192; 203
@@ -969,7 +984,6 @@ Visualization Manager:
               Enabled: true
               Name: RouteArea
               Namespaces:
-                end_lanelets: true
                 goal_lanelets: true
                 lane_start_bound: false
                 left_lane_bound: false
@@ -1022,10 +1036,10 @@ Visualization Manager:
                 Alpha: 1
                 Color: 230; 230; 50
                 Offset from BaseLink: 0
-                Rear Overhang: 1.0299999713897705
+                Rear Overhang: 1.100000023841858
                 Value: false
-                Vehicle Length: 4.769999980926514
-                Vehicle Width: 1.8300000429153442
+                Vehicle Length: 4.889999866485596
+                Vehicle Width: 1.8960000276565552
               View Path:
                 Alpha: 0.9990000128746033
                 Color: 0; 0; 0
@@ -1038,6 +1052,9 @@ Visualization Manager:
                 Color: 0; 60; 255
                 Offset: 0
                 Radius: 0.10000000149011612
+                Value: false
+              View Text Slope:
+                Scale: 0.30000001192092896
                 Value: false
               View Text Velocity:
                 Scale: 0.30000001192092896
@@ -1073,10 +1090,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.4000000059604645
                         Color: 0; 0; 0
@@ -1089,6 +1106,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1137,6 +1157,9 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1183,6 +1206,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1231,6 +1257,9 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1277,6 +1306,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1325,6 +1357,9 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1372,6 +1407,9 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1402,10 +1440,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1418,6 +1456,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1466,6 +1507,9 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1496,10 +1540,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1512,6 +1556,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1543,10 +1590,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1559,6 +1606,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1607,6 +1657,9 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1654,6 +1707,9 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1684,10 +1740,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1700,6 +1756,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1731,10 +1790,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1747,6 +1806,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1778,10 +1840,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1794,6 +1856,9 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
+                        Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1822,7 +1887,10 @@ Visualization Manager:
                           Enabled: true
                           Name: VirtualWall (Avoidance)
                           Namespaces:
-                            {}
+                            dead_line_factor_text: true
+                            dead_line_virtual_wall: true
+                            stop_factor_text: true
+                            stop_virtual_wall: true
                           Topic:
                             Depth: 5
                             Durability Policy: Volatile
@@ -1942,8 +2010,7 @@ Visualization Manager:
                           Enabled: true
                           Name: VirtualWall (Walkway)
                           Namespaces:
-                            177703_stop_factor_text: true
-                            177703_stop_virtual_wall: true
+                            {}
                           Topic:
                             Depth: 5
                             Durability Policy: Volatile
@@ -1979,8 +2046,7 @@ Visualization Manager:
                           Enabled: true
                           Name: VirtualWall (MergeFromPrivateArea)
                           Namespaces:
-                            stop_factor_text: true
-                            stop_virtual_wall: true
+                            {}
                           Topic:
                             Depth: 5
                             Durability Policy: Volatile
@@ -2553,6 +2619,9 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
+                      View Text Slope:
+                        Scale: 0.30000001192092896
+                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -2604,7 +2673,8 @@ Visualization Manager:
                           Enabled: true
                           Name: VirtualWall (ObstacleCruise)
                           Namespaces:
-                            {}
+                            stop_factor_text: true
+                            stop_virtual_wall: true
                           Topic:
                             Depth: 5
                             Durability Policy: Volatile
@@ -2862,10 +2932,10 @@ Visualization Manager:
             Alpha: 1
             Color: 230; 230; 50
             Offset from BaseLink: 0
-            Rear Overhang: 1.0299999713897705
+            Rear Overhang: 1.100000023841858
             Value: false
-            Vehicle Length: 4.769999980926514
-            Vehicle Width: 1.8300000429153442
+            Vehicle Length: 4.889999866485596
+            Vehicle Width: 1.8960000276565552
           View Path:
             Alpha: 1
             Color: 255; 255; 255
@@ -2878,6 +2948,9 @@ Visualization Manager:
             Color: 0; 60; 255
             Offset: 0
             Radius: 0.10000000149011612
+            Value: false
+          View Text Slope:
+            Scale: 0.30000001192092896
             Value: false
           View Text Velocity:
             Scale: 0.30000001192092896
@@ -2944,6 +3017,7 @@ Visualization Manager:
           Enabled: true
           Name: Entity Marker
           Namespaces:
+            Npc1: true
             ego: true
           Topic:
             Depth: 5
@@ -2977,9 +3051,16 @@ Visualization Manager:
             Value: /simulation/traffic_light/marker
           Value: true
         - Class: openscenario_visualization/VisualizationConditionGroups
+          Enabled: true
+          Left: 0
+          Length: 2000
           Name: Condition Group
+          Text Color: 255; 255; 255
+          Top: 450
           Topic: /simulation/context
           Value: true
+          Value Scale: 35
+          Width: 2000
         - Class: rviz_default_plugins/MarkerArray
           Enabled: true
           Name: Debug Marker
@@ -2991,7 +3072,7 @@ Visualization Manager:
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /simulation/debug_marker
-          Value: false
+          Value: true
         - Class: rviz_common/Group
           Displays:
             - Alpha: 0.9990000128746033
@@ -3038,14 +3119,20 @@ Visualization Manager:
                 Alpha: 0.9990000128746033
                 Color: 119; 11; 32
               Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
               Display Acceleration: true
+              Display Existence Probability: false
               Display Label: true
-              Display PoseWithCovariance: true
+              Display Pose Covariance: true
               Display Predicted Path Confidence: true
               Display Predicted Paths: true
               Display Twist: true
+              Display Twist Covariance: false
               Display UUID: true
               Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
               Enabled: true
               Line Width: 0.029999999329447746
               MOTORCYCLE:
@@ -3098,8 +3185,152 @@ Visualization Manager:
               Value: false
           Enabled: true
           Name: Simple Sensor Simulator
-      Enabled: false
+      Enabled: true
       Name: Simulation
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        Npc1:
+          Value: true
+        ars408_front_center:
+          Value: true
+        base_link:
+          Value: true
+        camera0/camera_link:
+          Value: true
+        camera0/camera_optical_link:
+          Value: true
+        camera1/camera_link:
+          Value: true
+        camera1/camera_optical_link:
+          Value: true
+        camera2/camera_link:
+          Value: true
+        camera2/camera_optical_link:
+          Value: true
+        camera3/camera_link:
+          Value: true
+        camera3/camera_optical_link:
+          Value: true
+        camera4/camera_link:
+          Value: true
+        camera4/camera_optical_link:
+          Value: true
+        camera5/camera_link:
+          Value: true
+        camera5/camera_optical_link:
+          Value: true
+        camera6/camera_link:
+          Value: true
+        camera6/camera_optical_link:
+          Value: true
+        camera7/camera_link:
+          Value: true
+        camera7/camera_optical_link:
+          Value: true
+        ego:
+          Value: true
+        gnss_link:
+          Value: true
+        livox_front_left:
+          Value: true
+        livox_front_left_base_link:
+          Value: true
+        livox_front_right:
+          Value: true
+        livox_front_right_base_link:
+          Value: true
+        map:
+          Value: true
+        sensor_kit_base_link:
+          Value: true
+        tamagawa/imu_link:
+          Value: true
+        velodyne_left:
+          Value: true
+        velodyne_left_base_link:
+          Value: true
+        velodyne_rear:
+          Value: true
+        velodyne_rear_base_link:
+          Value: true
+        velodyne_right:
+          Value: true
+        velodyne_right_base_link:
+          Value: true
+        velodyne_top:
+          Value: true
+        velodyne_top_base_link:
+          Value: true
+        viewer:
+          Value: true
+      Marker Scale: 10
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        map:
+          Npc1:
+            {}
+          base_link:
+            ars408_front_center:
+              {}
+            livox_front_left_base_link:
+              livox_front_left:
+                {}
+            livox_front_right_base_link:
+              livox_front_right:
+                {}
+            sensor_kit_base_link:
+              camera0/camera_link:
+                camera0/camera_optical_link:
+                  {}
+              camera1/camera_link:
+                camera1/camera_optical_link:
+                  {}
+              camera2/camera_link:
+                camera2/camera_optical_link:
+                  {}
+              camera3/camera_link:
+                camera3/camera_optical_link:
+                  {}
+              camera4/camera_link:
+                camera4/camera_optical_link:
+                  {}
+              camera5/camera_link:
+                camera5/camera_optical_link:
+                  {}
+              camera6/camera_link:
+                camera6/camera_optical_link:
+                  {}
+              camera7/camera_link:
+                camera7/camera_optical_link:
+                  {}
+              gnss_link:
+                {}
+              tamagawa/imu_link:
+                {}
+              velodyne_left_base_link:
+                velodyne_left:
+                  {}
+              velodyne_right_base_link:
+                velodyne_right:
+                  {}
+              velodyne_top_base_link:
+                velodyne_top:
+                  {}
+            velodyne_rear_base_link:
+              velodyne_rear:
+                {}
+          ego:
+            {}
+          viewer:
+            {}
+      Update Interval: 0
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 10; 10; 10
@@ -3197,21 +3428,26 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Angle: 0
-      Class: rviz_default_plugins/TopDownOrtho
+      Class: rviz_default_plugins/ThirdPersonFollower
+      Distance: 278.631103515625
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 19.597293853759766
+      Pitch: 0.070398710668087
       Target Frame: ego
-      Value: TopDownOrtho (rviz_default_plugins)
-      X: 0
-      Y: 0
+      Value: ThirdPersonFollower (rviz_default_plugins)
+      Yaw: 3.0053985118865967
     Saved:
       - Class: rviz_default_plugins/ThirdPersonFollower
         Distance: 18
@@ -3255,12 +3491,12 @@ Window Geometry:
     collapsed: false
   Displays:
     collapsed: false
-  Height: 2083
+  Height: 2096
   Hide Left Dock: false
   Hide Right Dock: false
   InitialPoseButtonPanel:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000002d5000007a8fc020000000ffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007901000003fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000050000003e30000010101000003fc00000434000003c4000000f90100001dfa000000000100000002fb0000000a0056006900650077007301000000000000033c0000011b01000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000000ffffffff000000c401000003fb00000024004100750074006f00770061007200650053007400610074006500500061006e0065006c00000003e000000330000001c801000003fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d0065007200610100000682000000eb0000000000000000fb0000000a0049006d0061006700650100000505000002680000000000000000fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000009a01000003fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb00000030005200650063006f0067006e006900740069006f006e0052006500730075006c0074004f006e0049006d006100670065000000066c0000008f0000002e01000003fb0000002a004100750074006f0077006100720065004400610074006500540069006d006500500061006e0065006c00000006e8000001100000005201000003000000010000015f000006fffc0200000002fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000e7a0000005afc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e7a0000005afc0100000002fb0000000800540069006d0065010000000000000e7a0000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000be8000007a800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000002d5000007d6fc020000000ffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000053e000000c900fffffffc0000058100000292000000c10100001cfa000000010100000002fb0000000a0056006900650077007301000000000000033c0000010000fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000000ffffffff0000009d00fffffffb00000024004100750074006f00770061007200650053007400610074006500500061006e0065006c00000003e0000003300000017200fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d0065007200610100000682000000eb0000000000000000fb0000000a0049006d0061006700650100000505000002680000000000000000fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000006e00fffffffb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb00000030005200650063006f0067006e006900740069006f006e0052006500730075006c0074004f006e0049006d006100670065000000066c0000008f0000002800fffffffb0000002a004100750074006f0077006100720065004400610074006500540069006d006500500061006e0065006c00000006e8000001100000004100ffffff000000010000015f000006fffc0200000002fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000e7a0000005afc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e7a0000005afc0100000002fb0000000800540069006d0065010000000000000e7a0000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000bdf000007d600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   RecognitionResultOnImage:
     collapsed: false
   Selection:
@@ -3269,6 +3505,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 3774
-  X: 2626
-  Y: 41
+  Width: 3770
+  X: 70
+  Y: 27

--- a/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
+++ b/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
@@ -6,9 +6,8 @@ Panels:
       Expanded:
         - /Map1/Lanelet2VectorMap1
         - /Sensing1/LiDAR1/ConcatenatePointCloud1/Autocompute Value Bounds1
-        - /TF1
       Splitter Ratio: 0.557669460773468
-    Tree Height: 1281
+    Tree Height: 914
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -133,11 +132,6 @@ Visualization Manager:
                 Expand Link Details: false
                 Expand Tree: false
                 Link Tree Style: Links in Alphabetic Order
-                ars408_front_center:
-                  Alpha: 1
-                  Show Axes: false
-                  Show Trail: false
-                  Value: true
                 base_link:
                   Alpha: 1
                   Show Axes: false
@@ -379,11 +373,29 @@ Visualization Manager:
           Namespaces:
             center_lane_line: false
             center_line_arrows: false
+            crosswalk_lanelets: true
             lane_start_bound: false
+            lanelet direction: true
             lanelet_id: false
             left_lane_bound: true
+            no_stopping_area: true
+            parking_lots: true
+            partitions: true
+            pedestrian_marking: true
             right_lane_bound: true
             road_lanelets: false
+            shoulder_center_lane_line: true
+            shoulder_center_line_arrows: true
+            shoulder_lane_start_bound: true
+            shoulder_lanelet direction: true
+            shoulder_left_lane_bound: true
+            shoulder_right_lane_bound: true
+            shoulder_road_lanelets: false
+            stop_lines: true
+            traffic_light: true
+            traffic_light_id: false
+            traffic_light_triangle: true
+            walkway_lanelets: true
           Topic:
             Depth: 5
             Durability Policy: Transient Local
@@ -737,20 +749,14 @@ Visualization Manager:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
                   Class: autoware_auto_perception_rviz_plugin/DetectedObjects
-                  Confidence Interval: 95%
                   Display Acceleration: true
-                  Display Existence Probability: false
                   Display Label: true
-                  Display Pose Covariance: true
+                  Display PoseWithCovariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
-                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
-                  Display Yaw Covariance: false
-                  Display Yaw Rate: false
-                  Display Yaw Rate Covariance: false
                   Enabled: true
                   Line Width: 0.029999999329447746
                   MOTORCYCLE:
@@ -794,21 +800,14 @@ Visualization Manager:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
                   Class: autoware_auto_perception_rviz_plugin/TrackedObjects
-                  Confidence Interval: 95%
                   Display Acceleration: true
-                  Display Existence Probability: false
                   Display Label: true
-                  Display Pose Covariance: true
+                  Display PoseWithCovariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
-                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
-                  Display Yaw Covariance: false
-                  Display Yaw Rate: false
-                  Display Yaw Rate Covariance: false
-                  Dynamic Status: All
                   Enabled: true
                   Line Width: 0.029999999329447746
                   MOTORCYCLE:
@@ -852,20 +851,14 @@ Visualization Manager:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
                   Class: autoware_auto_perception_rviz_plugin/PredictedObjects
-                  Confidence Interval: 95%
                   Display Acceleration: true
-                  Display Existence Probability: false
                   Display Label: true
-                  Display Pose Covariance: true
+                  Display PoseWithCovariance: false
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
-                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
-                  Display Yaw Covariance: false
-                  Display Yaw Rate: false
-                  Display Yaw Rate Covariance: false
                   Enabled: true
                   Line Width: 0.5
                   MOTORCYCLE:
@@ -873,15 +866,7 @@ Visualization Manager:
                     Color: 119; 11; 32
                   Name: PredictedObjects
                   Namespaces:
-                    acceleration: true
-                    label: true
-                    path: true
-                    path confidence: true
-                    position covariance: true
-                    shape: true
-                    twist: true
-                    uuid: true
-                    velocity: true
+                    {}
                   PEDESTRIAN:
                     Alpha: 0.9990000128746033
                     Color: 255; 192; 203
@@ -984,6 +969,7 @@ Visualization Manager:
               Enabled: true
               Name: RouteArea
               Namespaces:
+                end_lanelets: true
                 goal_lanelets: true
                 lane_start_bound: false
                 left_lane_bound: false
@@ -1036,10 +1022,10 @@ Visualization Manager:
                 Alpha: 1
                 Color: 230; 230; 50
                 Offset from BaseLink: 0
-                Rear Overhang: 1.100000023841858
+                Rear Overhang: 1.0299999713897705
                 Value: false
-                Vehicle Length: 4.889999866485596
-                Vehicle Width: 1.8960000276565552
+                Vehicle Length: 4.769999980926514
+                Vehicle Width: 1.8300000429153442
               View Path:
                 Alpha: 0.9990000128746033
                 Color: 0; 0; 0
@@ -1052,9 +1038,6 @@ Visualization Manager:
                 Color: 0; 60; 255
                 Offset: 0
                 Radius: 0.10000000149011612
-                Value: false
-              View Text Slope:
-                Scale: 0.30000001192092896
                 Value: false
               View Text Velocity:
                 Scale: 0.30000001192092896
@@ -1090,10 +1073,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.100000023841858
+                        Rear Overhang: 1.0299999713897705
                         Value: false
-                        Vehicle Length: 4.889999866485596
-                        Vehicle Width: 1.8960000276565552
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.4000000059604645
                         Color: 0; 0; 0
@@ -1106,9 +1089,6 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
-                        Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1157,9 +1137,6 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
-                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1206,9 +1183,6 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
-                        Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1257,9 +1231,6 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
-                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1306,9 +1277,6 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
-                        Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1357,9 +1325,6 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
-                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1407,9 +1372,6 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
-                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1440,10 +1402,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.100000023841858
+                        Rear Overhang: 1.0299999713897705
                         Value: false
-                        Vehicle Length: 4.889999866485596
-                        Vehicle Width: 1.8960000276565552
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1456,9 +1418,6 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
-                        Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1507,9 +1466,6 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
-                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1540,10 +1496,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.100000023841858
+                        Rear Overhang: 1.0299999713897705
                         Value: false
-                        Vehicle Length: 4.889999866485596
-                        Vehicle Width: 1.8960000276565552
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1556,9 +1512,6 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
-                        Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1590,10 +1543,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.100000023841858
+                        Rear Overhang: 1.0299999713897705
                         Value: false
-                        Vehicle Length: 4.889999866485596
-                        Vehicle Width: 1.8960000276565552
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1606,9 +1559,6 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
-                        Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1657,9 +1607,6 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
-                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1707,9 +1654,6 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
-                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -1740,10 +1684,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.100000023841858
+                        Rear Overhang: 1.0299999713897705
                         Value: false
-                        Vehicle Length: 4.889999866485596
-                        Vehicle Width: 1.8960000276565552
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1756,9 +1700,6 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
-                        Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1790,10 +1731,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.100000023841858
+                        Rear Overhang: 1.0299999713897705
                         Value: false
-                        Vehicle Length: 4.889999866485596
-                        Vehicle Width: 1.8960000276565552
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1806,9 +1747,6 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
-                        Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1840,10 +1778,10 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.100000023841858
+                        Rear Overhang: 1.0299999713897705
                         Value: false
-                        Vehicle Length: 4.889999866485596
-                        Vehicle Width: 1.8960000276565552
+                        Vehicle Length: 4.769999980926514
+                        Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
                         Color: 115; 210; 22
@@ -1856,9 +1794,6 @@ Visualization Manager:
                         Color: 0; 60; 255
                         Offset: 0
                         Radius: 0.10000000149011612
-                        Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
                         Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
@@ -1887,10 +1822,7 @@ Visualization Manager:
                           Enabled: true
                           Name: VirtualWall (Avoidance)
                           Namespaces:
-                            dead_line_factor_text: true
-                            dead_line_virtual_wall: true
-                            stop_factor_text: true
-                            stop_virtual_wall: true
+                            {}
                           Topic:
                             Depth: 5
                             Durability Policy: Volatile
@@ -2010,7 +1942,8 @@ Visualization Manager:
                           Enabled: true
                           Name: VirtualWall (Walkway)
                           Namespaces:
-                            {}
+                            177703_stop_factor_text: true
+                            177703_stop_virtual_wall: true
                           Topic:
                             Depth: 5
                             Durability Policy: Volatile
@@ -2046,7 +1979,8 @@ Visualization Manager:
                           Enabled: true
                           Name: VirtualWall (MergeFromPrivateArea)
                           Namespaces:
-                            {}
+                            stop_factor_text: true
+                            stop_virtual_wall: true
                           Topic:
                             Depth: 5
                             Durability Policy: Volatile
@@ -2619,9 +2553,6 @@ Visualization Manager:
                         Offset: 0
                         Radius: 0.10000000149011612
                         Value: false
-                      View Text Slope:
-                        Scale: 0.30000001192092896
-                        Value: false
                       View Text Velocity:
                         Scale: 0.30000001192092896
                         Value: false
@@ -2673,8 +2604,7 @@ Visualization Manager:
                           Enabled: true
                           Name: VirtualWall (ObstacleCruise)
                           Namespaces:
-                            stop_factor_text: true
-                            stop_virtual_wall: true
+                            {}
                           Topic:
                             Depth: 5
                             Durability Policy: Volatile
@@ -2932,10 +2862,10 @@ Visualization Manager:
             Alpha: 1
             Color: 230; 230; 50
             Offset from BaseLink: 0
-            Rear Overhang: 1.100000023841858
+            Rear Overhang: 1.0299999713897705
             Value: false
-            Vehicle Length: 4.889999866485596
-            Vehicle Width: 1.8960000276565552
+            Vehicle Length: 4.769999980926514
+            Vehicle Width: 1.8300000429153442
           View Path:
             Alpha: 1
             Color: 255; 255; 255
@@ -2948,9 +2878,6 @@ Visualization Manager:
             Color: 0; 60; 255
             Offset: 0
             Radius: 0.10000000149011612
-            Value: false
-          View Text Slope:
-            Scale: 0.30000001192092896
             Value: false
           View Text Velocity:
             Scale: 0.30000001192092896
@@ -3017,7 +2944,6 @@ Visualization Manager:
           Enabled: true
           Name: Entity Marker
           Namespaces:
-            Npc1: true
             ego: true
           Topic:
             Depth: 5
@@ -3051,16 +2977,9 @@ Visualization Manager:
             Value: /simulation/traffic_light/marker
           Value: true
         - Class: openscenario_visualization/VisualizationConditionGroups
-          Enabled: true
-          Left: 0
-          Length: 2000
           Name: Condition Group
-          Text Color: 255; 255; 255
-          Top: 450
           Topic: /simulation/context
           Value: true
-          Value Scale: 35
-          Width: 2000
         - Class: rviz_default_plugins/MarkerArray
           Enabled: true
           Name: Debug Marker
@@ -3072,7 +2991,7 @@ Visualization Manager:
             History Policy: Keep Last
             Reliability Policy: Reliable
             Value: /simulation/debug_marker
-          Value: true
+          Value: false
         - Class: rviz_common/Group
           Displays:
             - Alpha: 0.9990000128746033
@@ -3119,20 +3038,14 @@ Visualization Manager:
                 Alpha: 0.9990000128746033
                 Color: 119; 11; 32
               Class: autoware_auto_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
               Display Acceleration: true
-              Display Existence Probability: false
               Display Label: true
-              Display Pose Covariance: true
+              Display PoseWithCovariance: true
               Display Predicted Path Confidence: true
               Display Predicted Paths: true
               Display Twist: true
-              Display Twist Covariance: false
               Display UUID: true
               Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
               Enabled: true
               Line Width: 0.029999999329447746
               MOTORCYCLE:
@@ -3185,152 +3098,8 @@ Visualization Manager:
               Value: false
           Enabled: true
           Name: Simple Sensor Simulator
-      Enabled: true
+      Enabled: false
       Name: Simulation
-    - Class: rviz_default_plugins/TF
-      Enabled: true
-      Frame Timeout: 15
-      Frames:
-        All Enabled: true
-        Npc1:
-          Value: true
-        ars408_front_center:
-          Value: true
-        base_link:
-          Value: true
-        camera0/camera_link:
-          Value: true
-        camera0/camera_optical_link:
-          Value: true
-        camera1/camera_link:
-          Value: true
-        camera1/camera_optical_link:
-          Value: true
-        camera2/camera_link:
-          Value: true
-        camera2/camera_optical_link:
-          Value: true
-        camera3/camera_link:
-          Value: true
-        camera3/camera_optical_link:
-          Value: true
-        camera4/camera_link:
-          Value: true
-        camera4/camera_optical_link:
-          Value: true
-        camera5/camera_link:
-          Value: true
-        camera5/camera_optical_link:
-          Value: true
-        camera6/camera_link:
-          Value: true
-        camera6/camera_optical_link:
-          Value: true
-        camera7/camera_link:
-          Value: true
-        camera7/camera_optical_link:
-          Value: true
-        ego:
-          Value: true
-        gnss_link:
-          Value: true
-        livox_front_left:
-          Value: true
-        livox_front_left_base_link:
-          Value: true
-        livox_front_right:
-          Value: true
-        livox_front_right_base_link:
-          Value: true
-        map:
-          Value: true
-        sensor_kit_base_link:
-          Value: true
-        tamagawa/imu_link:
-          Value: true
-        velodyne_left:
-          Value: true
-        velodyne_left_base_link:
-          Value: true
-        velodyne_rear:
-          Value: true
-        velodyne_rear_base_link:
-          Value: true
-        velodyne_right:
-          Value: true
-        velodyne_right_base_link:
-          Value: true
-        velodyne_top:
-          Value: true
-        velodyne_top_base_link:
-          Value: true
-        viewer:
-          Value: true
-      Marker Scale: 10
-      Name: TF
-      Show Arrows: true
-      Show Axes: true
-      Show Names: false
-      Tree:
-        map:
-          Npc1:
-            {}
-          base_link:
-            ars408_front_center:
-              {}
-            livox_front_left_base_link:
-              livox_front_left:
-                {}
-            livox_front_right_base_link:
-              livox_front_right:
-                {}
-            sensor_kit_base_link:
-              camera0/camera_link:
-                camera0/camera_optical_link:
-                  {}
-              camera1/camera_link:
-                camera1/camera_optical_link:
-                  {}
-              camera2/camera_link:
-                camera2/camera_optical_link:
-                  {}
-              camera3/camera_link:
-                camera3/camera_optical_link:
-                  {}
-              camera4/camera_link:
-                camera4/camera_optical_link:
-                  {}
-              camera5/camera_link:
-                camera5/camera_optical_link:
-                  {}
-              camera6/camera_link:
-                camera6/camera_optical_link:
-                  {}
-              camera7/camera_link:
-                camera7/camera_optical_link:
-                  {}
-              gnss_link:
-                {}
-              tamagawa/imu_link:
-                {}
-              velodyne_left_base_link:
-                velodyne_left:
-                  {}
-              velodyne_right_base_link:
-                velodyne_right:
-                  {}
-              velodyne_top_base_link:
-                velodyne_top:
-                  {}
-            velodyne_rear_base_link:
-              velodyne_rear:
-                {}
-          ego:
-            {}
-          viewer:
-            {}
-      Update Interval: 0
-      Value: true
   Enabled: true
   Global Options:
     Background Color: 10; 10; 10
@@ -3428,26 +3197,21 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Class: rviz_default_plugins/ThirdPersonFollower
-      Distance: 278.631103515625
+      Angle: 0
+      Class: rviz_default_plugins/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
-      Focal Point:
-        X: 0
-        Y: 0
-        Z: 0
-      Focal Shape Fixed Size: false
-      Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.070398710668087
+      Scale: 19.597293853759766
       Target Frame: ego
-      Value: ThirdPersonFollower (rviz_default_plugins)
-      Yaw: 3.0053985118865967
+      Value: TopDownOrtho (rviz_default_plugins)
+      X: 0
+      Y: 0
     Saved:
       - Class: rviz_default_plugins/ThirdPersonFollower
         Distance: 18
@@ -3491,12 +3255,12 @@ Window Geometry:
     collapsed: false
   Displays:
     collapsed: false
-  Height: 2096
+  Height: 2083
   Hide Left Dock: false
   Hide Right Dock: false
   InitialPoseButtonPanel:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000002d5000007d6fc020000000ffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000053e000000c900fffffffc0000058100000292000000c10100001cfa000000010100000002fb0000000a0056006900650077007301000000000000033c0000010000fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000000ffffffff0000009d00fffffffb00000024004100750074006f00770061007200650053007400610074006500500061006e0065006c00000003e0000003300000017200fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d0065007200610100000682000000eb0000000000000000fb0000000a0049006d0061006700650100000505000002680000000000000000fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000006e00fffffffb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb00000030005200650063006f0067006e006900740069006f006e0052006500730075006c0074004f006e0049006d006100670065000000066c0000008f0000002800fffffffb0000002a004100750074006f0077006100720065004400610074006500540069006d006500500061006e0065006c00000006e8000001100000004100ffffff000000010000015f000006fffc0200000002fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000e7a0000005afc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e7a0000005afc0100000002fb0000000800540069006d0065010000000000000e7a0000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000bdf000007d600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000002d5000007a8fc020000000ffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000007901000003fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000050000003e30000010101000003fc00000434000003c4000000f90100001dfa000000000100000002fb0000000a0056006900650077007301000000000000033c0000011b01000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000000ffffffff000000c401000003fb00000024004100750074006f00770061007200650053007400610074006500500061006e0065006c00000003e000000330000001c801000003fb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d0065007200610100000682000000eb0000000000000000fb0000000a0049006d0061006700650100000505000002680000000000000000fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000009a01000003fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb00000030005200650063006f0067006e006900740069006f006e0052006500730075006c0074004f006e0049006d006100670065000000066c0000008f0000002e01000003fb0000002a004100750074006f0077006100720065004400610074006500540069006d006500500061006e0065006c00000006e8000001100000005201000003000000010000015f000006fffc0200000002fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000e7a0000005afc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e7a0000005afc0100000002fb0000000800540069006d0065010000000000000e7a0000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000be8000007a800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   RecognitionResultOnImage:
     collapsed: false
   Selection:
@@ -3505,6 +3269,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 3770
-  X: 70
-  Y: 27
+  Width: 3774
+  X: 2626
+  Y: 41

--- a/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
@@ -333,6 +333,7 @@ public:
   FORWARD_TO_ENTITY_MANAGER(requestWalkStraight);
   FORWARD_TO_ENTITY_MANAGER(resetConventionalTrafficLightPublishRate);
   FORWARD_TO_ENTITY_MANAGER(resetV2ITrafficLightPublishRate);
+  FORWARD_TO_ENTITY_MANAGER(setAcceleration);
   FORWARD_TO_ENTITY_MANAGER(setAccelerationLimit);
   FORWARD_TO_ENTITY_MANAGER(setAccelerationRateLimit);
   FORWARD_TO_ENTITY_MANAGER(setBehaviorParameter);
@@ -341,6 +342,7 @@ public:
   FORWARD_TO_ENTITY_MANAGER(setDecelerationRateLimit);
   FORWARD_TO_ENTITY_MANAGER(setLinearVelocity);
   FORWARD_TO_ENTITY_MANAGER(setMapPose);
+  FORWARD_TO_ENTITY_MANAGER(setTwist);
   FORWARD_TO_ENTITY_MANAGER(setVelocityLimit);
   FORWARD_TO_ENTITY_MANAGER(toMapPose);
 

--- a/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
@@ -340,6 +340,7 @@ public:
   FORWARD_TO_ENTITY_MANAGER(setDecelerationLimit);
   FORWARD_TO_ENTITY_MANAGER(setDecelerationRateLimit);
   FORWARD_TO_ENTITY_MANAGER(setLinearVelocity);
+  FORWARD_TO_ENTITY_MANAGER(setMapPose);
   FORWARD_TO_ENTITY_MANAGER(setVelocityLimit);
   FORWARD_TO_ENTITY_MANAGER(toMapPose);
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
@@ -107,14 +107,14 @@ public:
   auto setBehaviorParameter(const traffic_simulator_msgs::msg::BehaviorParameter &)
     -> void override;
 
-  auto setStatusExternally(const CanonicalizedEntityStatus & status) -> void;
-
   void requestSpeedChange(double, bool continuous) override;
 
   void requestSpeedChange(
     const speed_change::RelativeTargetSpeed & target_speed, bool continuous) override;
 
   auto setVelocityLimit(double) -> void override;
+
+  auto setMapPose(const geometry_msgs::msg::Pose & map_pose) -> void override;
 
   auto fillLaneletPose(CanonicalizedEntityStatus & status) -> void override;
 };

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
@@ -39,8 +39,6 @@ class EgoEntity : public VehicleEntity
   static auto makeFieldOperatorApplication(const Configuration &)
     -> std::unique_ptr<concealer::FieldOperatorApplication>;
 
-  CanonicalizedEntityStatus externally_updated_status_;
-
 public:
   explicit EgoEntity() = delete;
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -221,6 +221,10 @@ public:
 
   virtual auto setMapPose(const geometry_msgs::msg::Pose & map_pose) -> void;
 
+  /*   */ auto setTwist(const geometry_msgs::msg::Twist & twist) -> void;
+
+  /*   */ auto setAcceleration(const geometry_msgs::msg::Accel & accel) -> void;
+
   virtual void startNpcLogic();
 
   /*   */ void stopAtCurrentPosition();

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -219,6 +219,8 @@ public:
 
   virtual auto setVelocityLimit(double) -> void;
 
+  virtual auto setMapPose(const geometry_msgs::msg::Pose & map_pose) -> void;
+
   virtual void startNpcLogic();
 
   /*   */ void stopAtCurrentPosition();

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
@@ -282,7 +282,7 @@ public:
   // clang-format on
 
   FORWARD_TO_ENTITY(asFieldOperatorApplication, const);
-  FORWARD_TO_ENTITY(cancelRequest, );
+  FORWARD_TO_ENTITY(fillLaneletPose, const);
   FORWARD_TO_ENTITY(get2DPolygon, const);
   FORWARD_TO_ENTITY(getBehaviorParameter, const);
   FORWARD_TO_ENTITY(getBoundingBox, const);
@@ -297,27 +297,28 @@ public:
   FORWARD_TO_ENTITY(getDistanceToRightLaneBound, const);
   FORWARD_TO_ENTITY(getEntityStatusBeforeUpdate, const);
   FORWARD_TO_ENTITY(getEntityType, const);
-  FORWARD_TO_ENTITY(fillLaneletPose, const);
   FORWARD_TO_ENTITY(getLaneletPose, const);
   FORWARD_TO_ENTITY(getLinearJerk, const);
   FORWARD_TO_ENTITY(getMapPose, const);
   FORWARD_TO_ENTITY(getMapPoseFromRelativePose, const);
-  FORWARD_TO_ENTITY(getRouteLanelets, );
+  FORWARD_TO_ENTITY(getRouteLanelets, const);
   FORWARD_TO_ENTITY(getStandStillDuration, const);
   FORWARD_TO_ENTITY(getTraveledDistance, const);
   FORWARD_TO_ENTITY(laneMatchingSucceed, const);
+  FORWARD_TO_ENTITY(activateOutOfRangeJob, );
+  FORWARD_TO_ENTITY(cancelRequest, );
   FORWARD_TO_ENTITY(requestAcquirePosition, );
   FORWARD_TO_ENTITY(requestAssignRoute, );
   FORWARD_TO_ENTITY(requestFollowTrajectory, );
   FORWARD_TO_ENTITY(requestLaneChange, );
   FORWARD_TO_ENTITY(requestWalkStraight, );
-  FORWARD_TO_ENTITY(activateOutOfRangeJob, );
   FORWARD_TO_ENTITY(setAccelerationLimit, );
   FORWARD_TO_ENTITY(setAccelerationRateLimit, );
   FORWARD_TO_ENTITY(setBehaviorParameter, );
   FORWARD_TO_ENTITY(setDecelerationLimit, );
   FORWARD_TO_ENTITY(setDecelerationRateLimit, );
   FORWARD_TO_ENTITY(setLinearVelocity, );
+  FORWARD_TO_ENTITY(setMapPose, );
   FORWARD_TO_ENTITY(setVelocityLimit, );
 
 #undef FORWARD_TO_ENTITY
@@ -472,9 +473,6 @@ public:
     const std::string & name, const traffic_simulator::lane_change::Direction & direction);
 
   auto setEntityStatus(const std::string & name, const CanonicalizedEntityStatus &) -> void;
-
-  auto setEntityStatusExternally(const std::string & name, const CanonicalizedEntityStatus &)
-    -> void;
 
   void setVerbose(const bool verbose);
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
@@ -312,6 +312,7 @@ public:
   FORWARD_TO_ENTITY(requestFollowTrajectory, );
   FORWARD_TO_ENTITY(requestLaneChange, );
   FORWARD_TO_ENTITY(requestWalkStraight, );
+  FORWARD_TO_ENTITY(setAcceleration, );
   FORWARD_TO_ENTITY(setAccelerationLimit, );
   FORWARD_TO_ENTITY(setAccelerationRateLimit, );
   FORWARD_TO_ENTITY(setBehaviorParameter, );
@@ -319,6 +320,7 @@ public:
   FORWARD_TO_ENTITY(setDecelerationRateLimit, );
   FORWARD_TO_ENTITY(setLinearVelocity, );
   FORWARD_TO_ENTITY(setMapPose, );
+  FORWARD_TO_ENTITY(setTwist, );
   FORWARD_TO_ENTITY(setVelocityLimit, );
 
 #undef FORWARD_TO_ENTITY

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
@@ -119,6 +119,8 @@ public:
 
   const std::string plugin_name;
 
+  const traffic_simulator_msgs::msg::PedestrianParameters pedestrian_parameters;
+
 private:
   pluginlib::ClassLoader<entity_behavior::BehaviorPluginBase> loader_;
   const std::shared_ptr<entity_behavior::BehaviorPluginBase> behavior_plugin_ptr_;

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
@@ -122,6 +122,8 @@ public:
 
   auto fillLaneletPose(CanonicalizedEntityStatus & status) -> void override;
 
+  const traffic_simulator_msgs::msg::VehicleParameters vehicle_parameters;
+
 private:
   pluginlib::ClassLoader<entity_behavior::BehaviorPluginBase> loader_;
 

--- a/simulation/traffic_simulator/src/api/api.cpp
+++ b/simulation/traffic_simulator/src/api/api.cpp
@@ -238,6 +238,8 @@ bool API::updateEntitiesStatusInSim()
 
       if (entity_manager_ptr_->isEgo(name)) {
         setMapPose(name, entity_status.pose);
+        setTwist(name, entity_status.action_status.twist);
+        setAcceleration(name, entity_status.action_status.accel);
       } else {
         setEntityStatus(name, canonicalize(entity_status));
       }

--- a/simulation/traffic_simulator/src/api/api.cpp
+++ b/simulation/traffic_simulator/src/api/api.cpp
@@ -237,13 +237,7 @@ bool API::updateEntitiesStatusInSim()
       simulation_interface::toMsg(res_status.action_status(), entity_status.action_status);
 
       if (entity_manager_ptr_->isEgo(name)) {
-        // temporarily deinitialize lanelet pose as it should be correctly filled from here
-        entity_status.lanelet_pose_valid = false;
-        entity_status.lanelet_pose = traffic_simulator_msgs::msg::LaneletPose();
-        auto canonicalized = canonicalize(entity_status);
-        /// @note apply additional status data (from ll2) and then set status
-        entity_manager_ptr_->fillLaneletPose(name, canonicalized);
-        entity_manager_ptr_->setEntityStatusExternally(name, canonicalized);
+        setMapPose(name, entity_status.pose);
       } else {
         setEntityStatus(name, canonicalize(entity_status));
       }

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -82,8 +82,7 @@ EgoEntity::EgoEntity(
   const traffic_simulator_msgs::msg::VehicleParameters & parameters,
   const Configuration & configuration)
 : VehicleEntity(name, entity_status, hdmap_utils_ptr, parameters),
-  field_operator_application(makeFieldOperatorApplication(configuration)),
-  externally_updated_status_(entity_status)
+  field_operator_application(makeFieldOperatorApplication(configuration))
 {
 }
 
@@ -155,7 +154,6 @@ auto EgoEntity::getWaypoints() -> const traffic_simulator_msgs::msg::WaypointsAr
 void EgoEntity::onUpdate(double current_time, double step_time)
 {
   EntityBase::onUpdate(current_time, step_time);
-  setStatus(externally_updated_status_);
 
   updateStandStillDuration(step_time);
   updateTraveledDistance(step_time);

--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -738,6 +738,20 @@ void EntityBase::setTrafficLightManager(
   traffic_light_manager_ = traffic_light_manager;
 }
 
+auto EntityBase::setTwist(const geometry_msgs::msg::Twist & twist) -> void
+{
+  auto new_status = static_cast<EntityStatus>(getStatus());
+  new_status.action_status.twist = twist;
+  status_ = CanonicalizedEntityStatus(new_status, hdmap_utils_ptr_);
+}
+
+auto EntityBase::setAcceleration(const geometry_msgs::msg::Accel & accel) -> void
+{
+  auto new_status = static_cast<EntityStatus>(getStatus());
+  new_status.action_status.accel = accel;
+  status_ = CanonicalizedEntityStatus(new_status, hdmap_utils_ptr_);
+}
+
 auto EntityBase::setMapPose(const geometry_msgs::msg::Pose &) -> void
 {
   THROW_SEMANTIC_ERROR(

--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -738,6 +738,12 @@ void EntityBase::setTrafficLightManager(
   traffic_light_manager_ = traffic_light_manager;
 }
 
+auto EntityBase::setMapPose(const geometry_msgs::msg::Pose &) -> void
+{
+  THROW_SEMANTIC_ERROR(
+    "You cannot set map pose to the vehicle other than ego named ", std::quoted(name), ".");
+}
+
 void EntityBase::activateOutOfRangeJob(
   double min_velocity, double max_velocity, double min_acceleration, double max_acceleration,
   double min_jerk, double max_jerk)

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -711,18 +711,6 @@ auto EntityManager::setEntityStatus(
   }
 }
 
-auto EntityManager::setEntityStatusExternally(
-  const std::string & name, const CanonicalizedEntityStatus & status) -> void
-{
-  if (not isEgo(name)) {
-    THROW_SEMANTIC_ERROR(
-      "You cannot set entity status externally to the vehicle other than ego named ",
-      std::quoted(name), ".");
-  } else {
-    dynamic_cast<EgoEntity *>(entities_[name].get())->setStatusExternally(status);
-  }
-}
-
 void EntityManager::setVerbose(const bool verbose)
 {
   configuration.verbose = verbose;

--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -31,6 +31,7 @@ PedestrianEntity::PedestrianEntity(
   const std::string & plugin_name)
 : EntityBase(name, entity_status, hdmap_utils_ptr),
   plugin_name(plugin_name),
+  pedestrian_parameters(parameters),
   loader_(pluginlib::ClassLoader<entity_behavior::BehaviorPluginBase>(
     "traffic_simulator", "entity_behavior::BehaviorPluginBase")),
   behavior_plugin_ptr_(loader_.createSharedInstance(plugin_name)),

--- a/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
@@ -31,6 +31,7 @@ VehicleEntity::VehicleEntity(
   const traffic_simulator_msgs::msg::VehicleParameters & parameters,
   const std::string & plugin_name)
 : EntityBase(name, entity_status, hdmap_utils_ptr),
+  vehicle_parameters(parameters),
   loader_(pluginlib::ClassLoader<entity_behavior::BehaviorPluginBase>(
     "traffic_simulator", "entity_behavior::BehaviorPluginBase")),
   behavior_plugin_ptr_(loader_.createSharedInstance(plugin_name)),


### PR DESCRIPTION
# Description

## Abstract

- Enable consider tread when calculating matching length of EgoEntity.
- Fixed a problem with distance measurement in some scenarios ([e.g](https://evaluation.tier4.jp/evaluation/reports/486681a0-3903-5a3d-a59a-8423129b7a00/tests/c127e068-5273-5eae-9a4e-d98275660129/055ec2ad-ca6d-5f54-9ca0-64a749e0e7df/3ed30ec1-c158-52ca-91b4-fe73ba32e0b7?project_id=prd_jt)) that caused lane matching to fail.
- Removed externally_updated_status_, a member variable that stores the EnttiyStatus calculated by sensor_simulator, which existed only for EgoEntity.

It is not desirable to have many changes in a single pull request, but in this case, more than one change was made in a single pull request because externally_entity_status_ had to be removed in order to modify EgoEntity's lane coordinate system calculations.

## Background

### About lane coordinate system.

The lane coordinate system calculation is performed at least twice for EgoEntity.
The [first time is used to calculate the z-coordinates inside simple_sensor_simulator](https://github.com/tier4/scenario_simulator_v2/blob/b842a1a046a47a1142dc886c7b1b06335019b1cb/simulation/simple_sensor_simulator/src/vehicle_simulation/ego_entity_simulation.cpp#L400-L407), and [the second time is used to obtain the final lane coordinate system inside traffic_simulator.
](https://github.com/tier4/scenario_simulator_v2/blob/c37bb71e6bfe99247306de41fc7605588a7f58ba/simulation/traffic_simulator/src/api/api.cpp#L240-L246)

At the two locations mentioned above, the parameter for the length of the horizontal bar used to calculate the lane coordinates was fixed at 1.0 m.
Since lane coordinates are calculated from the intersection of this horizontal bar and the spline-completed curve of the lanelet centerline, the lane coordinate system cannot be calculated unless an intersection exists.

![Screenshot from 2024-02-09 12-06-55](https://github.com/tier4/scenario_simulator_v2/assets/10348912/367b8f2d-f14a-48e0-aa6b-fcda8377546f)

In this case, the scenario involved overtaking and avoiding a parked vehicle stopped on the left side of the road, so when the vehicle moved to the right inside the lane, it moved more than 1.0 m to the right and 2 to the right, so the lane coordinate system could not be calculated, and as a result, distance measurement in the longitudinal direction was impossible.

### About externally_updated_status

The externally_updated_status_ variable is used in [this pull request](https://github.com/tier4/scenario_simulator_v2/pull/998/files#r1250118429) to specify the It existed to temporarily store the EntityStatus calculated by simple_sensor_simulator, but other Entities were writing their updated results directly to the entity_status_ variable, creating confusion for developers.

Therefore, this variable has been removed in this pull request and changed to be set directly to entity_status_.

## Details

### About lane coordinate system.

The parameter for the length of the horizontal bar used for all lane coordinate calculations in EgoEntity was fixed at 1.0 m. 

The length of the horizontal bar for calculating the lane coordinate system after this pull request is imported is calculated from the following formula.

Let $L_m$ be the length of the abscissa used in the lane coordinate system calculation and the tread of the front wheels be  $t_f$ and the tread of the rear wheels be $t_r$.

$$L_m = max(t_r, t_f) * 0.5 + 1.0$$

### About externally_updated_status

Delete `EgoEntity::externally_updated_status_` member variable and use `EgoEntity::entity_status_` value.
If this change is not introduced, there will be a difference between the EgoEntityStatus inside traffic_simulator and simple_sensor_simulator, resulting in a discrepancy where the motion model on the simple_sensor_simulator simulator moves forward correctly but the `tf` topic issued from inside traffic_simulator does not.

# Destructive Changes

### About lane coordinate system.

Because the method of calculating the lane coordinate system is changed, the distance, etc. calculated in the lane coordinate system may change when this pull request is merged.

We tested the existing scenarios and confirmed that no regression exists for the existing test scenarios.

If you want to check regression test result, please check [here.](https://github.com/tier4/sim_evaluation_tools/issues/243)

# Known Limitations

### About lane coordinate system.

This pull request is not a major change to the process in order to emphasize backward compatibility with existing scenarios.

Therefore, the problem that exists in the current version of scenario_simulator_v2, "the lane coordinate system is calculated by extending a horizontal line vertically from the entity, so it is impossible to calculate the lane coordinate system for an entity placed at a large angle to the lane", has not been solved. This problem has not been solved.
