### PR TITLE
doc: fix mkdocs.yml to delete unavailable page setting

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,7 +64,6 @@ nav:
       - Scenario Writing Tips: user_guide/ScenarioTips.md
       - Scenario Editor:
           - Overview: user_guide/scenario_editor/ScenarioEditorUserGuide.md
-          - Place an entity to relative position: user_guide/scenario_editor/RelativePosition.md
       - Scenario Test Runner:
           - Overview: user_guide/scenario_test_runner/ScenarioTestRunner.md
           - user_guide/scenario_test_runner/ScenarioFormatConversion.md


### PR DESCRIPTION
## Types of PR

- [ ] New Features
- [ ] Upgrade of existing features
- [x] Bugfix

## Link to the issue

## Description

In [this commit](https://github.com/tier4/scenario_simulator_v2/commit/b91bbf9a1ecdaf40a4bd4f5e21d1a1a6bc5aefbc), `user_guide/scenario_editor/RelativePosition.md` was deleted but page setting was not deleted.

As a result, [invalid page](https://tier4.github.io/scenario_simulator_v2-docs/user_guide/scenario_editor/RelativePosition.md) exists on the documentation site.

This pull-request is deleting the remained setting.

## How to review this PR.

Chek the setting file or build mkdocs site locally. 

## Others
