### PR TITLE
Fix workflow trigger for CheckLabel.yaml

### DIFF
--- a/.github/workflows/CheckLabel.yaml
+++ b/.github/workflows/CheckLabel.yaml
@@ -3,10 +3,7 @@ on:
   pull_request:
     branches:
       - master
-  label:
     types:
-      - created
-      - edited
       - labeled
       - unlabeled
 


### PR DESCRIPTION
# Description

## Abstract

To realize a trigger that fires when label is added or removed from pull-request, you should use `pull_request` trigger with `labeled` and `unlabeled` types instead of `label` trigger.

## Background

N/A

## Details

N/A

## References

- [About label trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#label)
- [About pull_request trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)

# Destructive Changes

N/A

# Known Limitations

N/A
