### PR TITLE
Fix/lanelet matching distance

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/api/api.hpp
@@ -331,6 +331,7 @@ public:
   FORWARD_TO_ENTITY_MANAGER(getRelativePose);
   FORWARD_TO_ENTITY_MANAGER(getStandStillDuration);
   FORWARD_TO_ENTITY_MANAGER(getTraveledDistance);
+  FORWARD_TO_ENTITY_MANAGER(getDefaultMatchingDistanceForLaneletPoseCalculation);
   FORWARD_TO_ENTITY_MANAGER(getV2ITrafficLight);
   FORWARD_TO_ENTITY_MANAGER(getV2ITrafficLights);
   FORWARD_TO_ENTITY_MANAGER(isEgoSpawned);

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_manager.hpp
@@ -304,6 +304,7 @@ public:
   FORWARD_TO_ENTITY(getRouteLanelets, const);
   FORWARD_TO_ENTITY(getStandStillDuration, const);
   FORWARD_TO_ENTITY(getTraveledDistance, const);
+  FORWARD_TO_ENTITY(getDefaultMatchingDistanceForLaneletPoseCalculation, const);
   FORWARD_TO_ENTITY(laneMatchingSucceed, const);
   FORWARD_TO_ENTITY(activateOutOfRangeJob, );
   FORWARD_TO_ENTITY(cancelRequest, );

--- a/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
@@ -266,8 +266,8 @@ public:
 
   auto matchToLane(
     const geometry_msgs::msg::Pose &, const traffic_simulator_msgs::msg::BoundingBox &,
-    const bool include_crosswalk, const double reduction_ratio = 0.8) const
-    -> std::optional<lanelet::Id>;
+    const bool include_crosswalk, const double matching_distance = 1.0,
+    const double reduction_ratio = 0.8) const -> std::optional<lanelet::Id>;
 
   auto toLaneletPose(
     const geometry_msgs::msg::Pose &, const bool include_crosswalk,

--- a/simulation/traffic_simulator/src/api/api.cpp
+++ b/simulation/traffic_simulator/src/api/api.cpp
@@ -78,8 +78,8 @@ auto API::setEntityStatus(
   status.action_status = action_status;
   if (
     const auto lanelet_pose = entity_manager_ptr_->toLaneletPose(
-      status.pose, getBoundingBox(reference_entity_name), false,
-      getDefaultMatchingDistanceForLaneletPoseCalculation(reference_entity_name))) {
+      status.pose, getBoundingBox(name), false,
+      getDefaultMatchingDistanceForLaneletPoseCalculation(name))) {
     status.lanelet_pose_valid = true;
     status.lanelet_pose = lanelet_pose.value();
   } else {

--- a/simulation/traffic_simulator/src/api/api.cpp
+++ b/simulation/traffic_simulator/src/api/api.cpp
@@ -78,7 +78,8 @@ auto API::setEntityStatus(
   status.action_status = action_status;
   if (
     const auto lanelet_pose = entity_manager_ptr_->toLaneletPose(
-      status.pose, getBoundingBox(reference_entity_name), false)) {
+      status.pose, getBoundingBox(reference_entity_name), false,
+      getDefaultMatchingDistanceForLaneletPoseCalculation(reference_entity_name))) {
     status.lanelet_pose_valid = true;
     status.lanelet_pose = lanelet_pose.value();
   } else {
@@ -127,8 +128,9 @@ auto API::setEntityStatus(
   status.name = name;
   status.action_status = action_status;
   if (
-    const auto lanelet_pose =
-      entity_manager_ptr_->toLaneletPose(map_pose, getBoundingBox(name), false)) {
+    const auto lanelet_pose = entity_manager_ptr_->toLaneletPose(
+      map_pose, getBoundingBox(name), false,
+      getDefaultMatchingDistanceForLaneletPoseCalculation(name))) {
     status.lanelet_pose = lanelet_pose.value();
   } else {
     status.lanelet_pose_valid = false;

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -492,7 +492,8 @@ auto HdMapUtils::toPoint2d(const geometry_msgs::msg::Point & point) const -> lan
 
 auto HdMapUtils::matchToLane(
   const geometry_msgs::msg::Pose & pose, const traffic_simulator_msgs::msg::BoundingBox & bbox,
-  const bool include_crosswalk, const double reduction_ratio) const -> std::optional<lanelet::Id>
+  const bool include_crosswalk, const double matching_distance, const double reduction_ratio) const
+  -> std::optional<lanelet::Id>
 {
   std::optional<lanelet::Id> id;
   lanelet::matching::Object2d obj;
@@ -521,8 +522,8 @@ auto HdMapUtils::matchToLane(
     /**
      * @note Hard coded parameter. Matching threshold for lanelet.
      */
-    if (match.distance <= 1.0) {
-      auto lanelet_pose = toLaneletPose(pose, match.lanelet.id());
+    if (match.distance <= matching_distance) {
+      auto lanelet_pose = toLaneletPose(pose, match.lanelet.id(), matching_distance);
       if (lanelet_pose) {
         id_and_distance.emplace_back(lanelet_pose->lanelet_id, lanelet_pose->offset);
       }
@@ -604,7 +605,7 @@ auto HdMapUtils::toLaneletPose(
   const bool include_crosswalk, const double matching_distance) const
   -> std::optional<traffic_simulator_msgs::msg::LaneletPose>
 {
-  const auto lanelet_id = matchToLane(pose, bbox, include_crosswalk);
+  const auto lanelet_id = matchToLane(pose, bbox, include_crosswalk, matching_distance);
   if (!lanelet_id) {
     return toLaneletPose(pose, include_crosswalk, matching_distance);
   }


### PR DESCRIPTION
# Description

This fix adds the usage of default matching distance of each entity for `setEntityStatus` functions that are run by teleport action in open scenario.

## Abstract

Default lane matching distance depends on entity type and is used in various places in the code. The default distance was not used in all possible situations.

## Background

The default lane matching distance was added to the scenario simulator in PR #1194. However, the distance usage was not applied to all possible situations.

## Details

Default lane matching distance of each entity was not used in open scenario teleport action and the default distance of `1.0` was used. This fix adds the default lane matching distance to the `API::setEntityStatus` function, which is used in the open scenario teleport action.

## References

See #1194 for first default matching distance implementation.

# Destructive Changes

<!--
> [Optional] If no destructive change exists, you can skip this section.  
> Include a description of the changes and a migration guide and send the pull request with a bump major label. (Example : https://github.com/tier4/scenario_simulator_v2/pull/1139)  
> Otherwise, skip the "Destructive Changes" section and make sure this pull request is labeled `bump minor` or `bump patch`.  
-->
# Known Limitations

The same limitations to the lane matching as before apply. The difference is that the default lane matching distance in teleport action is used, so it is slightly bigger than before (which was `1.0`)
<!--
> [Optional] If there are no known limitations that you can think of, you can skip this section. If there are any limitations on the features or fixes added by this pull request, delete this sentence and clearly describe them.
> For example, the lane matching algorithm currently (1/25/2024) employed is unable to match Entity that is heavily tilted with respect to the lane, and it is difficult to throw an exception.  
> If the developer is aware of the existence of such problems or limitations, describe them in detail. The problems or limitation should be listed as an Issue on GitHub and a link to it should be provided in this section.  
-->