### PR TITLE
chore: include all topic to rosbag

### DIFF
--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -201,12 +201,8 @@ auto Interpreter::on_activate(const rclcpp_lifecycle::State &) -> Result
       },
       [&]() {
         if (record) {
-          // clang-format off
           record::start(
-            "-a",
-            "-o", boost::filesystem::path(osc_path).replace_extension("").string(),
-            "-x", "/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection");
-          // clang-format on
+            "-a", "-o", boost::filesystem::path(osc_path).replace_extension("").string());
         }
 
         SimulatorCore::activate(


### PR DESCRIPTION
# Description

## Abstract

In #829, the `/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection` topic has excluded from recording target due to its so large size.
But after [autowarefoundation/autoware.universe#1483](https://github.com/autowarefoundation/autoware.universe/pull/1483),  [Internal research](https://tier4.atlassian.net/browse/RT1-1658) has confirmed that the size has improved significantly.

With this pull-request, scenario_simulator_v2 starts to recording the topic again.

## Background

N/A

## Details

N/A

## References

#829 
https://github.com/autowarefoundation/autoware.universe/pull/1483

# Destructive Changes

N/A

# Known Limitations

N/A
