### PR TITLE
Delete edited trigger from release workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -5,7 +5,6 @@ on:
       - master
     types:
       - closed
-      - edited
       - labeled
       - opened
       - reopened


### PR DESCRIPTION
# Description

## Abstract

When merged pull-request is edited, the release workflow executed wrongly.
It can be avoided in operation, but the possibility of human error remains, so I remove the trigger in this pull-request.


## Background

N/A

## Details

N/A

## References

The releases that published wrongly
- https://github.com/tier4/scenario_simulator_v2/releases/tag/1.7.0
- https://github.com/tier4/scenario_simulator_v2/releases/tag/1.6.0

# Destructive Changes

N/A

# Known Limitations

N/A
