### PR TITLE
Support for traffic light color/shape in `TrafficSignalState`

### DIFF
--- a/simulation/simulation_interface/include/simulation_interface/conversions.hpp
+++ b/simulation/simulation_interface/include/simulation_interface/conversions.hpp
@@ -203,6 +203,8 @@ auto toMsg(
         return TrafficLightBulbMessageType::GREEN;
       case TrafficLight_Color_WHITE:
         return TrafficLightBulbMessageType::WHITE;
+      case TrafficLight_Color_UNKNOWN_COLOR:
+        return TrafficLightBulbMessageType::UNKNOWN;
       default:
         return TrafficLightBulbMessageType::UNKNOWN;
     }
@@ -232,6 +234,8 @@ auto toMsg(
         return TrafficLightBulbMessageType::DOWN_RIGHT_ARROW;
       case TrafficLight_Shape_CROSS:
         return TrafficLightBulbMessageType::CROSS;
+      case TrafficLight_Shape_UNKNOWN_SHAPE:
+        return TrafficLightBulbMessageType::UNKNOWN;
       default:
         return TrafficLightBulbMessageType::UNKNOWN;
     }
@@ -246,6 +250,8 @@ auto toMsg(
         return TrafficLightBulbMessageType::SOLID_ON;
       case TrafficLight_Status_FLASHING:
         return TrafficLightBulbMessageType::FLASHING;
+      case TrafficLight_Status_UNKNOWN_STATUS:
+        return TrafficLightBulbMessageType::UNKNOWN;
       default:
         return TrafficLightBulbMessageType::UNKNOWN;
     }

--- a/simulation/traffic_simulator/include/traffic_simulator/traffic_lights/traffic_light.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/traffic_lights/traffic_light.hpp
@@ -45,13 +45,15 @@ struct TrafficLight
       yellow,
       red,
       white,
+      unknown,
     } value;
 
     // clang-format off
-    static_assert(static_cast<std::uint8_t>(green ) == 0b0000'0000);
-    static_assert(static_cast<std::uint8_t>(yellow) == 0b0000'0001);
-    static_assert(static_cast<std::uint8_t>(red   ) == 0b0000'0010);
-    static_assert(static_cast<std::uint8_t>(white ) == 0b0000'0011);
+    static_assert(static_cast<std::uint8_t>(green  ) == 0b0000'0000);
+    static_assert(static_cast<std::uint8_t>(yellow ) == 0b0000'0001);
+    static_assert(static_cast<std::uint8_t>(red    ) == 0b0000'0010);
+    static_assert(static_cast<std::uint8_t>(white  ) == 0b0000'0011);
+    static_assert(static_cast<std::uint8_t>(unknown) == 0b0000'0100);
     // clang-format on
 
     constexpr Color(const Value value = green) : value(value) {}
@@ -64,6 +66,7 @@ struct TrafficLight
       std::make_pair("red", red),
       std::make_pair("white", white),
       std::make_pair("yellow", yellow),
+      std::make_pair("unknown", unknown),
 
       // BACKWARD COMPATIBILITY
       std::make_pair("Green", green),
@@ -262,6 +265,8 @@ struct TrafficLight
             return simulation_api_schema::TrafficLight_Color_RED;
           case Color::white:
             return simulation_api_schema::TrafficLight_Color_WHITE;
+          case Color::unknown:
+            return simulation_api_schema::TrafficLight_Color_UNKNOWN_COLOR;
           default:
             throw common::SyntaxError(std::get<Color>(value), " is not supported color.");
         }

--- a/simulation/traffic_simulator/include/traffic_simulator/traffic_lights/traffic_light.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/traffic_lights/traffic_light.hpp
@@ -135,26 +135,29 @@ struct TrafficLight
       circle,
       cross,
       arrow,
+      unknown,
     };
 
     // clang-format off
-    static_assert(static_cast<std::uint8_t>(Category::circle) == 0b0000'0000);
-    static_assert(static_cast<std::uint8_t>(Category::cross ) == 0b0000'0001);
-    static_assert(static_cast<std::uint8_t>(Category::arrow ) == 0b0000'0010);
+    static_assert(static_cast<std::uint8_t>(Category::circle ) == 0b0000'0000);
+    static_assert(static_cast<std::uint8_t>(Category::cross  ) == 0b0000'0001);
+    static_assert(static_cast<std::uint8_t>(Category::arrow  ) == 0b0000'0010);
+    static_assert(static_cast<std::uint8_t>(Category::unknown) == 0b0000'0011);
     // clang-format on
 
     enum Value : std::uint16_t {
       // clang-format off
-      circle      =                      static_cast<std::uint8_t>(Category::circle),
-      cross       =                      static_cast<std::uint8_t>(Category::cross ),
-      left        = (0b0000'1000 << 8) | static_cast<std::uint8_t>(Category::arrow ),
-      down        = (0b0000'0100 << 8) | static_cast<std::uint8_t>(Category::arrow ),
-      up          = (0b0000'0010 << 8) | static_cast<std::uint8_t>(Category::arrow ),
-      right       = (0b0000'0001 << 8) | static_cast<std::uint8_t>(Category::arrow ),
-      lower_left  = (0b0000'1100 << 8) | static_cast<std::uint8_t>(Category::arrow ),
-      upper_left  = (0b0000'1010 << 8) | static_cast<std::uint8_t>(Category::arrow ),
-      lower_right = (0b0000'0101 << 8) | static_cast<std::uint8_t>(Category::arrow ),
-      upper_right = (0b0000'0011 << 8) | static_cast<std::uint8_t>(Category::arrow ),
+      circle      =                      static_cast<std::uint8_t>(Category::circle ),
+      cross       =                      static_cast<std::uint8_t>(Category::cross  ),
+      left        = (0b0000'1000 << 8) | static_cast<std::uint8_t>(Category::arrow  ),
+      down        = (0b0000'0100 << 8) | static_cast<std::uint8_t>(Category::arrow  ),
+      up          = (0b0000'0010 << 8) | static_cast<std::uint8_t>(Category::arrow  ),
+      right       = (0b0000'0001 << 8) | static_cast<std::uint8_t>(Category::arrow  ),
+      lower_left  = (0b0000'1100 << 8) | static_cast<std::uint8_t>(Category::arrow  ),
+      upper_left  = (0b0000'1010 << 8) | static_cast<std::uint8_t>(Category::arrow  ),
+      lower_right = (0b0000'0101 << 8) | static_cast<std::uint8_t>(Category::arrow  ),
+      upper_right = (0b0000'0011 << 8) | static_cast<std::uint8_t>(Category::arrow  ),
+      unknown     =                      static_cast<std::uint8_t>(Category::unknown),
       // clang-format on
     } value;
 
@@ -169,6 +172,7 @@ struct TrafficLight
     static_assert(static_cast<std::uint16_t>(upper_left ) == 0b0000'1010'0000'0010);
     static_assert(static_cast<std::uint16_t>(lower_right) == 0b0000'0101'0000'0010);
     static_assert(static_cast<std::uint16_t>(upper_right) == 0b0000'0011'0000'0010);
+    static_assert(static_cast<std::uint16_t>(unknown    ) == 0b0000'0000'0000'0011);
     // clang-format on
 
     constexpr Shape(const Value value = circle) : value(value) {}
@@ -186,6 +190,7 @@ struct TrafficLight
       std::make_pair("upperLeft", Shape::upper_left),
       std::make_pair("lowerRight", Shape::lower_right),
       std::make_pair("upperRight", Shape::upper_right),
+      std::make_pair("unknown", Shape::unknown),
 
       // BACKWARD COMPATIBILITY
       std::make_pair("straight", Shape::up),
@@ -309,6 +314,8 @@ struct TrafficLight
             return simulation_api_schema::TrafficLight_Shape_UP_LEFT_ARROW;
           case Shape::upper_right:
             return simulation_api_schema::TrafficLight_Shape_UP_RIGHT_ARROW;
+          case Shape::unknown:
+            return simulation_api_schema::TrafficLight_Shape_UNKNOWN_SHAPE;
           default:
             throw common::SyntaxError(std::get<Shape>(value), " is not supported as a shape.");
         }


### PR DESCRIPTION
# Description

## Abstract

Previously, There was no way to specify `UNKNOWN` for color/shape in traffic light state other than specifying directly to APIs in C++.
In this pull-request, scenario_simulator_v2 started to suppot specifying them in the scenarios.

## Background

To test the behavior of Autoware when the traffic light is in the UNKNOWN state.

## References

https://github.com/autowarefoundation/autoware_msgs/blob/main/autoware_perception_msgs/msg/TrafficSignalElement.msg#L2
