### PR TITLE
Stop using ROS messages as basic types in `openscenario_interpreter`

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/double.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/double.hpp
@@ -15,16 +15,17 @@
 #ifndef OPENSCENARIO_INTERPRETER__SYNTAX__DOUBLE_HPP_
 #define OPENSCENARIO_INTERPRETER__SYNTAX__DOUBLE_HPP_
 
-#include <std_msgs/msg/float64.hpp>
 #include <string>
 
 namespace openscenario_interpreter
 {
 inline namespace syntax
 {
-struct Double : public std_msgs::msg::Float64
+struct Double
 {
-  using value_type = decltype(std_msgs::msg::Float64::data);
+  using value_type = double;
+
+  value_type data = 0.0;
 
   Double() = default;
 

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/integer.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/integer.hpp
@@ -15,18 +15,19 @@
 #ifndef OPENSCENARIO_INTERPRETER__SYNTAX__INTEGER_HPP_
 #define OPENSCENARIO_INTERPRETER__SYNTAX__INTEGER_HPP_
 
-#include <boost/lexical_cast.hpp>
 #include <openscenario_interpreter/error.hpp>
-#include <std_msgs/msg/int64.hpp>
+#include <boost/lexical_cast.hpp>
 #include <string>
 
 namespace openscenario_interpreter
 {
 inline namespace syntax
 {
-struct Integer : public std_msgs::msg::Int64
+struct Integer
 {
-  using value_type = decltype(std_msgs::msg::Int64::data);
+  using value_type = std::int64_t;
+
+  value_type data = 0;
 
   explicit Integer() = default;
 

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/unsigned_integer.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/unsigned_integer.hpp
@@ -17,16 +17,17 @@
 
 #include <boost/lexical_cast.hpp>
 #include <openscenario_interpreter/error.hpp>
-#include <std_msgs/msg/u_int64.hpp>
 #include <string>
 
 namespace openscenario_interpreter
 {
 inline namespace syntax
 {
-struct UnsignedInteger : public std_msgs::msg::UInt64
+struct UnsignedInteger
 {
-  using value_type = decltype(std_msgs::msg::UInt64::data);
+  using value_type = std::uint64_t;
+
+  value_type data;
 
   explicit UnsignedInteger(value_type value = {});
 

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/unsigned_short.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/unsigned_short.hpp
@@ -16,16 +16,17 @@
 #define OPENSCENARIO_INTERPRETER__SYNTAX__UNSIGNED_SHORT_HPP_
 
 #include <iostream>
-#include <std_msgs/msg/u_int16.hpp>
 #include <string>
 
 namespace openscenario_interpreter
 {
 inline namespace syntax
 {
-struct UnsignedShort : public std_msgs::msg::UInt16
+struct UnsignedShort
 {
-  using value_type = decltype(std_msgs::msg::UInt16::data);
+  using value_type = std::uint16_t;
+
+  value_type data = 0U;
 
   explicit UnsignedShort() = default;
 


### PR DESCRIPTION
# Description

## Abstract

This pull-request stops using ROS messages as basic types in `openscenario_interpreter`.
Previously, this ROS message inheritance was introduced to make it easier to output to ROS messages, but now it only adds unnecessary dependencies.
