### PR TITLE
remove // headers in STL comment

### DIFF
--- a/docs/developer_guide/TrafficSimulator.md
+++ b/docs/developer_guide/TrafficSimulator.md
@@ -26,10 +26,7 @@ You can also see the detailed documentation of the API classes [here](https://ti
 #include <traffic_simulator/api/api.hpp>
 #include <quaternion_operation/quaternion_operation.h>
 #include <ament_index_cpp/get_package_share_directory.hpp>
-
 #include <rclcpp/rclcpp.hpp>
-
-// headers in STL
 #include <memory>
 #include <vector>
 #include <string>

--- a/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
+++ b/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
@@ -15,14 +15,12 @@
 #ifndef CPP_MOCK_SCENARIOS__CPP_SCENARIO_NODE_HPP_
 #define CPP_MOCK_SCENARIOS__CPP_SCENARIO_NODE_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-#include <simple_junit/junit5.hpp>
-#include <traffic_simulator/api/api.hpp>
-
-// headers in STL
 #include <limits>
 #include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <simple_junit/junit5.hpp>
 #include <string>
+#include <traffic_simulator/api/api.hpp>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/behavior_plugin/load_do_nothing_plugin.cpp
+++ b/mock/cpp_mock_scenarios/src/behavior_plugin/load_do_nothing_plugin.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/collision/crashing_npc.cpp
+++ b/mock/cpp_mock_scenarios/src/collision/crashing_npc.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/collision/spawn_with_offset.cpp
+++ b/mock/cpp_mock_scenarios/src/collision/spawn_with_offset.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
+++ b/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/follow_front_entity/accelerate_and_follow.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_front_entity/accelerate_and_follow.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/follow_front_entity/decelerate_and_follow.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_front_entity/decelerate_and_follow.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/follow_lane/acquire_position_in_world_frame.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_lane/acquire_position_in_world_frame.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/follow_lane/assign_route_in_world_frame.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_lane/assign_route_in_world_frame.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/follow_lane/cancel_request.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_lane/cancel_request.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/follow_lane/follow_with_offset.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_lane/follow_with_offset.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_left.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_left.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_left_with_id.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_left_with_id.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear_lateral_velocity.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear_lateral_velocity.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear_time.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear_time.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_longitudinal_distance.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_longitudinal_distance.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_right.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_right.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_right_with_id.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_right_with_id.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_time.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_time.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/measurement/get_distance_in_lane_coordinate_distance.cpp
+++ b/mock/cpp_mock_scenarios/src/measurement/get_distance_in_lane_coordinate_distance.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/measurement/get_distance_to_lane_bound.cpp
+++ b/mock/cpp_mock_scenarios/src/measurement/get_distance_to_lane_bound.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/merge/merge_left.cpp
+++ b/mock/cpp_mock_scenarios/src/merge/merge_left.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/metrics/traveled_distance.cpp
+++ b/mock/cpp_mock_scenarios/src/metrics/traveled_distance.cpp
@@ -15,21 +15,19 @@
 #include <quaternion_operation/quaternion_operation.h>
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <cmath>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <limits>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
+#include <vector>
 
 #include "rclcpp/logger.hpp"
 #include "rclcpp/logging.hpp"
-
-// headers in STL
-#include <cmath>
-#include <limits>
-#include <memory>
-#include <string>
-#include <vector>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/move_backward/move_backward.cpp
+++ b/mock/cpp_mock_scenarios/src/move_backward/move_backward.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/pedestrian/walk_straight.cpp
+++ b/mock/cpp_mock_scenarios/src/pedestrian/walk_straight.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/random_scenario/random001.cpp
+++ b/mock/cpp_mock_scenarios/src/random_scenario/random001.cpp
@@ -17,15 +17,13 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <random001_parameters.hpp>
+#include <random>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <random>
-#include <string>
 #include <vector>
 
 class RandomScenario : public cpp_mock_scenarios::CppScenarioNode

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_continuous_false.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_continuous_false.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_relative.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_relative.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_step.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_step.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_limit.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_limit.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint_linear.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint_linear.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint_relative.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint_relative.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/traffic_simulation_demo.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_simulation_demo.cpp
@@ -17,13 +17,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-// headers in STL
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios


### PR DESCRIPTION
# Description

## Abstract

Remove wrong comment `// headers in STL`

## Background

As pointed out in [this comment](https://github.com/tier4/scenario_simulator_v2/pull/1217#discussion_r1550525398), an inappropriate description was left as a comment.

## Details

This pull request was created to remove inappropriate descriptions.

## References

#1217 

# Destructive Changes

N/A

# Known Limitations

N/A
