### PR TITLE
fix -Wreorder warnings in test extcutor class

### DIFF
--- a/test_runner/random_test_runner/include/random_test_runner/test_executor.hpp
+++ b/test_runner/random_test_runner/include/random_test_runner/test_executor.hpp
@@ -243,8 +243,8 @@ private:
   EgoCollisionMetric ego_collision_metric_;
   JunitXmlReporterTestCase error_reporter_;
 
-  ArchitectureType architecture_type_;
   double test_timeout_;
+  ArchitectureType architecture_type_;
 
   bool scenario_completed_ = false;
 


### PR DESCRIPTION
# Description

## Abstract

remove `-Wreorder` warning from random_test_runner package.

## Background

There was a problem with the initialization order of variables, causing a `-Wreorder` warning.

## Details

Fixed initialization order and fixed `Wreorder` warning inside random_test_runner package.

## References

N/A

# Destructive Changes

N/A

# Known Limitations

N/A
