### PR TITLE
fix link error of release note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ To keep the commit hashes consistent, **please DO NOT force-push the commit to y
 If you want to force-push the commit during the review, please contact the maintainers for approval in advance.
 
 If at least one maintainer approves your pull request and all checks are passed, your pull request will be merged into the `master` branch.
-Your contribution will be recorded in the [release note](https://tier4.github.io/scenario_simulator_v2-docs/ReleaseNotes/).
+Your contribution will be recorded in the [release note](https://tier4.github.io/scenario_simulator_v2-docs/release/ReleaseNotes/).
 
 Pull requests must be labeled `bump major`, `bump minor` or `bump patch`.
 


### PR DESCRIPTION
# Description

## Abstract

Fix url of release note.

## Background

URL of the release note was changed in #1244 , so we have to fix url in documentation.

## Details

Fix url of release note from https://tier4.github.io/scenario_simulator_v2-docs/ReleaseNotes to https://tier4.github.io/scenario_simulator_v2-docs/release/ReleaseNotes

## References

#1244 

# Destructive Changes

N/A

# Known Limitations

N/A
