### PR TITLE
Remove quaternion_operation

### DIFF
--- a/common/math/geometry/include/geometry/quaternion/euler_to_quaternion.hpp
+++ b/common/math/geometry/include/geometry/quaternion/euler_to_quaternion.hpp
@@ -1,0 +1,47 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEOMETRY__QUATERNION__EULER_TO_QUATERNION_HPP_
+#define GEOMETRY__QUATERNION__EULER_TO_QUATERNION_HPP_
+
+#include <tf2/LinearMath/Matrix3x3.h>
+
+#include <cmath>
+#include <geometry/vector3/is_like_vector3.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+
+namespace math
+{
+namespace geometry
+{
+template <
+  typename T, std::enable_if_t<std::conjunction_v<IsLikeVector3<T>>, std::nullptr_t> = nullptr>
+auto convertEulerAngleToQuaternion(const T & v)
+{
+  geometry_msgs::msg::Quaternion ret;
+  const double & roll = v.x;
+  const double & pitch = v.y;
+  const double & yaw = v.z;
+  tf2::Quaternion tf_quat;
+  tf_quat.setRPY(roll, pitch, yaw);
+  ret.x = tf_quat.x();
+  ret.y = tf_quat.y();
+  ret.z = tf_quat.z();
+  ret.w = tf_quat.w();
+  return ret;
+}
+}  // namespace geometry
+}  // namespace math
+
+#endif  // GEOMETRY__QUATERNION__EULER_TO_QUATERNION_HPP_

--- a/common/math/geometry/include/geometry/quaternion/euler_to_quaternion.hpp
+++ b/common/math/geometry/include/geometry/quaternion/euler_to_quaternion.hpp
@@ -29,17 +29,16 @@ template <
   typename T, std::enable_if_t<std::conjunction_v<IsLikeVector3<T>>, std::nullptr_t> = nullptr>
 auto convertEulerAngleToQuaternion(const T & v)
 {
-  geometry_msgs::msg::Quaternion ret;
   const double & roll = v.x;
   const double & pitch = v.y;
   const double & yaw = v.z;
   tf2::Quaternion tf_quat;
   tf_quat.setRPY(roll, pitch, yaw);
-  ret.x = tf_quat.x();
-  ret.y = tf_quat.y();
-  ret.z = tf_quat.z();
-  ret.w = tf_quat.w();
-  return ret;
+  return geometry_msgs::build<geometry_msgs::msg::Quaternion>()
+    .x(tf_quat.x())
+    .y(tf_quat.y())
+    .z(tf_quat.z())
+    .w(tf_quat.w());
 }
 }  // namespace geometry
 }  // namespace math

--- a/common/math/geometry/include/geometry/quaternion/get_rotation.hpp
+++ b/common/math/geometry/include/geometry/quaternion/get_rotation.hpp
@@ -31,7 +31,7 @@ template <
     nullptr>
 auto getRotation(T from, U to)
 {
-  // This code is inverting the sign of the coordinates (x, y, z) of the 'from' vector.
+  // This function gets the conjugate of the quaternion.
   from.x *= -1;
   from.y *= -1;
   from.z *= -1;

--- a/common/math/geometry/include/geometry/quaternion/get_rotation.hpp
+++ b/common/math/geometry/include/geometry/quaternion/get_rotation.hpp
@@ -1,0 +1,43 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEOMETRY__QUATERNION__GET_ROTATION_HPP_
+#define GEOMETRY__QUATERNION__GET_ROTATION_HPP_
+
+#include <tf2/LinearMath/Matrix3x3.h>
+
+#include <cmath>
+#include <geometry/quaternion/is_like_quaternion.hpp>
+#include <geometry/quaternion/operator.hpp>
+
+namespace math
+{
+namespace geometry
+{
+template <
+  typename T, typename U,
+  std::enable_if_t<std::conjunction_v<IsLikeQuaternion<T>, IsLikeQuaternion<U>>, std::nullptr_t> =
+    nullptr>
+auto getRotation(T from, U to)
+{
+  from.x *= -1;
+  from.y *= -1;
+  from.z *= -1;
+  auto ans = from * to;
+  return ans;
+}
+}  // namespace geometry
+}  // namespace math
+
+#endif  // GEOMETRY__QUATERNION__GET_ROTATION_HPP_

--- a/common/math/geometry/include/geometry/quaternion/get_rotation.hpp
+++ b/common/math/geometry/include/geometry/quaternion/get_rotation.hpp
@@ -31,11 +31,11 @@ template <
     nullptr>
 auto getRotation(T from, U to)
 {
+  // This code is inverting the sign of the coordinates (x, y, z) of the 'from' vector.
   from.x *= -1;
   from.y *= -1;
   from.z *= -1;
-  auto ans = from * to;
-  return ans;
+  return from * to;
 }
 }  // namespace geometry
 }  // namespace math

--- a/common/math/geometry/include/geometry/quaternion/get_rotation_matrix.hpp
+++ b/common/math/geometry/include/geometry/quaternion/get_rotation_matrix.hpp
@@ -1,0 +1,48 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEOMETRY__QUATERNION__GET_ROTATION_MATRIX_HPP_
+#define GEOMETRY__QUATERNION__GET_ROTATION_MATRIX_HPP_
+
+#include <tf2/LinearMath/Matrix3x3.h>
+
+#include <cmath>
+#include <geometry/quaternion/is_like_quaternion.hpp>
+
+#define EIGEN_MPL2_ONLY
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace math
+{
+namespace geometry
+{
+template <
+  typename T, std::enable_if_t<std::conjunction_v<IsLikeQuaternion<T>>, std::nullptr_t> = nullptr>
+auto getRotationMatrix(T quat)
+{
+  auto x = quat.x;
+  auto y = quat.y;
+  auto z = quat.z;
+  auto w = quat.w;
+  Eigen::Matrix3d ret(3, 3);
+  ret << x * x - y * y - z * z + w * w, 2 * (x * y - z * w), 2 * (z * x + w * y),
+    2 * (x * y + z * w), -x * x + y * y - z * z + w * w, 2 * (y * z - x * w), 2 * (z * x - w * y),
+    2 * (y * z + w * x), -x * x - y * y + z * z + w * w;
+  return ret;
+}
+}  // namespace geometry
+}  // namespace math
+
+#endif  // GEOMETRY__QUATERNION__GET_ROTATION_MATRIX_HPP_

--- a/common/math/geometry/include/geometry/quaternion/get_rotation_matrix.hpp
+++ b/common/math/geometry/include/geometry/quaternion/get_rotation_matrix.hpp
@@ -37,9 +37,11 @@ auto getRotationMatrix(T quat)
   auto z = quat.z;
   auto w = quat.w;
   Eigen::Matrix3d ret(3, 3);
-  ret << x * x - y * y - z * z + w * w, 2 * (x * y - z * w), 2 * (z * x + w * y),
-    2 * (x * y + z * w), -x * x + y * y - z * z + w * w, 2 * (y * z - x * w), 2 * (z * x - w * y),
-    2 * (y * z + w * x), -x * x - y * y + z * z + w * w;
+  // clang-format off
+  ret << x * x - y * y - z * z + w * w,  2 * (x * y - z * w),            2 * (z * x + w * y),
+         2 * (x * y + z * w),           -x * x + y * y - z * z + w * w,  2 * (y * z - x * w), 
+         2 * (z * x - w * y),            2 * (y * z + w * x),           -x * x - y * y + z * z + w * w;
+  // clang-format on
   return ret;
 }
 }  // namespace geometry

--- a/common/math/geometry/include/geometry/quaternion/quaternion_to_euler.hpp
+++ b/common/math/geometry/include/geometry/quaternion/quaternion_to_euler.hpp
@@ -29,15 +29,11 @@ template <
   typename T, std::enable_if_t<std::conjunction_v<IsLikeQuaternion<T>>, std::nullptr_t> = nullptr>
 auto convertQuaternionToEulerAngle(const T & q)
 {
-  geometry_msgs::msg::Vector3 ret;
   tf2::Quaternion tf_quat(q.x, q.y, q.z, q.w);
   tf2::Matrix3x3 mat(tf_quat);
   double roll, pitch, yaw;
   mat.getRPY(roll, pitch, yaw);
-  ret.x = roll;
-  ret.y = pitch;
-  ret.z = yaw;
-  return ret;
+  return geometry_msgs::build<geometry_msgs::msg::Vector3>().x(roll).y(pitch).z(yaw);
 }
 }  // namespace geometry
 }  // namespace math

--- a/common/math/geometry/include/geometry/quaternion/quaternion_to_euler.hpp
+++ b/common/math/geometry/include/geometry/quaternion/quaternion_to_euler.hpp
@@ -1,0 +1,45 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEOMETRY__QUATERNION__QUATERNION_TO_EULER_HPP_
+#define GEOMETRY__QUATERNION__QUATERNION_TO_EULER_HPP_
+
+#include <tf2/LinearMath/Matrix3x3.h>
+
+#include <cmath>
+#include <geometry/quaternion/is_like_quaternion.hpp>
+#include <geometry_msgs/msg/vector3.hpp>
+
+namespace math
+{
+namespace geometry
+{
+template <
+  typename T, std::enable_if_t<std::conjunction_v<IsLikeQuaternion<T>>, std::nullptr_t> = nullptr>
+auto convertQuaternionToEulerAngle(const T & q)
+{
+  geometry_msgs::msg::Vector3 ret;
+  tf2::Quaternion tf_quat(q.x, q.y, q.z, q.w);
+  tf2::Matrix3x3 mat(tf_quat);
+  double roll, pitch, yaw;
+  mat.getRPY(roll, pitch, yaw);
+  ret.x = roll;
+  ret.y = pitch;
+  ret.z = yaw;
+  return ret;
+}
+}  // namespace geometry
+}  // namespace math
+
+#endif  // GEOMETRY__QUATERNION__QUATERNION_TO_EULER_HPP_

--- a/common/math/geometry/include/geometry/quaternion/slerp.hpp
+++ b/common/math/geometry/include/geometry/quaternion/slerp.hpp
@@ -1,0 +1,59 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEOMETRY__QUATERNION__SLERP_HPP_
+#define GEOMETRY__QUATERNION__SLERP_HPP_
+
+#include <cmath>
+#include <geometry/quaternion/is_like_quaternion.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
+namespace math
+{
+namespace geometry
+{
+template <
+  typename T, typename U, typename V,
+  std::enable_if_t<
+    std::conjunction_v<IsLikeQuaternion<T>, IsLikeQuaternion<U>, std::is_scalar<V>>,
+    std::nullptr_t> = nullptr>
+auto slerp(T quat1, U quat2, V t)
+{
+  geometry_msgs::msg::Quaternion q;
+  double qr = quat1.w * quat2.w + quat1.x * quat2.x + quat1.y * quat2.y + quat1.z * quat2.z;
+  double ss = 1.0 - qr * qr;
+  constexpr double e = std::numeric_limits<double>::epsilon();
+  if (std::fabs(ss) <= e) {
+    q.w = quat1.w;
+    q.x = quat1.x;
+    q.y = quat1.y;
+    q.z = quat1.z;
+    return q;
+  } else {
+    double sp = std::sqrt(ss);
+    double ph = std::acos(qr);
+    double pt = ph * t;
+    double t1 = std::sin(pt) / sp;
+    double t0 = std::sin(ph - pt) / sp;
+
+    q.w = quat1.w * t0 + quat2.w * t1;
+    q.x = quat1.x * t0 + quat2.x * t1;
+    q.y = quat1.y * t0 + quat2.y * t1;
+    q.z = quat1.z * t0 + quat2.z * t1;
+    return q;
+  }
+}
+}  // namespace geometry
+}  // namespace math
+
+#endif  // GEOMETRY__QUATERNION__SLERP_HPP_

--- a/common/math/geometry/include/geometry/quaternion/slerp.hpp
+++ b/common/math/geometry/include/geometry/quaternion/slerp.hpp
@@ -29,16 +29,15 @@ template <
     std::nullptr_t> = nullptr>
 auto slerp(T quat1, U quat2, V t)
 {
-  geometry_msgs::msg::Quaternion q;
   double qr = quat1.w * quat2.w + quat1.x * quat2.x + quat1.y * quat2.y + quat1.z * quat2.z;
   double ss = 1.0 - qr * qr;
   constexpr double e = std::numeric_limits<double>::epsilon();
   if (std::fabs(ss) <= e) {
-    q.w = quat1.w;
-    q.x = quat1.x;
-    q.y = quat1.y;
-    q.z = quat1.z;
-    return q;
+    return geometry_msgs::build<geometry_msgs::msg::Quaternion>()
+      .x(quat1.x)
+      .y(quat1.y)
+      .z(quat1.z)
+      .w(quat1.w);
   } else {
     double sp = std::sqrt(ss);
     double ph = std::acos(qr);
@@ -46,11 +45,11 @@ auto slerp(T quat1, U quat2, V t)
     double t1 = std::sin(pt) / sp;
     double t0 = std::sin(ph - pt) / sp;
 
-    q.w = quat1.w * t0 + quat2.w * t1;
-    q.x = quat1.x * t0 + quat2.x * t1;
-    q.y = quat1.y * t0 + quat2.y * t1;
-    q.z = quat1.z * t0 + quat2.z * t1;
-    return q;
+    return geometry_msgs::build<geometry_msgs::msg::Quaternion>()
+      .x(quat1.x * t0 + quat2.x * t1)
+      .y(quat1.y * t0 + quat2.y * t1)
+      .z(quat1.z * t0 + quat2.z * t1)
+      .w(quat1.w * t0 + quat2.w * t1);
   }
 }
 }  // namespace geometry

--- a/common/math/geometry/include/geometry/spline/hermite_curve.hpp
+++ b/common/math/geometry/include/geometry/spline/hermite_curve.hpp
@@ -16,7 +16,6 @@
 #define GEOMETRY__SPLINE__HERMITE_CURVE_HPP_
 
 #include <gtest/gtest.h>
-#include <quaternion_operation/quaternion_operation.h>
 
 #include <geometry/solver/polynomial_solver.hpp>
 #include <geometry_msgs/msg/point.hpp>

--- a/common/math/geometry/package.xml
+++ b/common/math/geometry/package.xml
@@ -12,10 +12,10 @@
 
   <depend>boost</depend>
   <depend>geometry_msgs</depend>
-  <depend>quaternion_operation</depend>
   <depend>rclcpp</depend>
   <depend>scenario_simulator_exception</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
   <depend>traffic_simulator_msgs</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>

--- a/common/math/geometry/src/bounding_box.cpp
+++ b/common/math/geometry/src/bounding_box.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <geometry/bounding_box.hpp>
 #include <geometry/polygon/polygon.hpp>
 

--- a/common/math/geometry/src/intersection/collision.cpp
+++ b/common/math/geometry/src/intersection/collision.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <boost/assert.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/geometry.hpp>

--- a/common/math/geometry/src/polygon/line_segment.cpp
+++ b/common/math/geometry/src/polygon/line_segment.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <cmath>
 #include <geometry/polygon/line_segment.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <geometry/transform.hpp>
 #include <geometry/vector3/hypot.hpp>
 #include <geometry/vector3/operator.hpp>
@@ -104,7 +103,7 @@ auto LineSegment::getPose(const double s, const bool denormalize_s, const bool f
     .position(getPoint(s, denormalize_s))
     .orientation([this, fill_pitch]() -> geometry_msgs::msg::Quaternion {
       const auto tangent_vec = getVector();
-      return quaternion_operation::convertEulerAngleToQuaternion(
+      return math::geometry::convertEulerAngleToQuaternion(
         geometry_msgs::build<geometry_msgs::msg::Vector3>()
           .x(0.0)
           .y(

--- a/common/math/geometry/src/polygon/polygon.cpp
+++ b/common/math/geometry/src/polygon/polygon.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 #include <boost/geometry/geometries/polygon.hpp>

--- a/common/math/geometry/src/spline/hermite_curve.cpp
+++ b/common/math/geometry/src/spline/hermite_curve.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cmath>
 #include <geometry/bounding_box.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <geometry/spline/hermite_curve.hpp>
 #include <iostream>
 #include <limits>
@@ -292,7 +293,7 @@ const geometry_msgs::msg::Pose HermiteCurve::getPose(
   rpy.x = 0.0;
   rpy.y = fill_pitch ? std::atan2(-tangent_vec.z, std::hypot(tangent_vec.x, tangent_vec.y)) : 0.0;
   rpy.z = std::atan2(tangent_vec.y, tangent_vec.x);
-  pose.orientation = quaternion_operation::convertEulerAngleToQuaternion(rpy);
+  pose.orientation = math::geometry::convertEulerAngleToQuaternion(rpy);
   pose.position = getPoint(s);
   return pose;
 }

--- a/common/math/geometry/src/transform.cpp
+++ b/common/math/geometry/src/transform.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
 #include <tf2/LinearMath/Quaternion.h>
 
+#include <geometry/quaternion/get_rotation.hpp>
+#include <geometry/quaternion/get_rotation_matrix.hpp>
 #include <geometry/transform.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
@@ -64,7 +65,7 @@ const geometry_msgs::msg::Pose getRelativePose(
 const geometry_msgs::msg::Point transformPoint(
   const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Point & point)
 {
-  auto mat = quaternion_operation::getRotationMatrix(pose.orientation);
+  auto mat = math::geometry::getRotationMatrix(pose.orientation);
   Eigen::VectorXd v(3);
   v(0) = point.x;
   v(1) = point.y;
@@ -84,8 +85,8 @@ const geometry_msgs::msg::Point transformPoint(
   const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Pose & sensor_pose,
   const geometry_msgs::msg::Point & point)
 {
-  auto mat = quaternion_operation::getRotationMatrix(
-    quaternion_operation::getRotation(sensor_pose.orientation, pose.orientation));
+  auto mat = math::geometry::getRotationMatrix(
+    math::geometry::getRotation(sensor_pose.orientation, pose.orientation));
   Eigen::VectorXd v(3);
   v(0) = point.x;
   v(1) = point.y;

--- a/common/math/geometry/test/test_bounding_box.cpp
+++ b/common/math/geometry/test/test_bounding_box.cpp
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include <quaternion_operation/quaternion_operation.h>
 
 #include <geometry/bounding_box.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <scenario_simulator_exception/exception.hpp>
 
 #include "expect_eq_macros.hpp"
@@ -79,7 +79,7 @@ TEST(BoundingBox, get2DPolygonOnlyTranslation)
 TEST(BoundingBox, get2DPolygonFullPose)
 {
   geometry_msgs::msg::Pose pose = makePose(1.0, 2.0);
-  pose.orientation = quaternion_operation::convertEulerAngleToQuaternion(
+  pose.orientation = math::geometry::convertEulerAngleToQuaternion(
     geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(30.0 * M_PI / 180.0));
   traffic_simulator_msgs::msg::BoundingBox bounding_box = makeBbox(2.0, 2.0, 2.0);
   boost::geometry::model::polygon<boost::geometry::model::d2::point_xy<double>> poly =

--- a/common/math/geometry/test/test_catmull_rom_spline.cpp
+++ b/common/math/geometry/test/test_catmull_rom_spline.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <geometry/spline/catmull_rom_spline.hpp>
 #include <scenario_simulator_exception/exception.hpp>
 
@@ -470,7 +471,7 @@ TEST(CatmullRomSpline, getPoseLine)
   EXPECT_POINT_NEAR(pose.position, makePoint(1.5, 4.5), EPS);
   EXPECT_QUATERNION_NEAR(
     pose.orientation,
-    quaternion_operation::convertEulerAngleToQuaternion(makeVector(0.0, 0.0, std::atan(3.0))), EPS);
+    math::geometry::convertEulerAngleToQuaternion(makeVector(0.0, 0.0, std::atan(3.0))), EPS);
 }
 
 TEST(CatmullRomSpline, getPoseLineWithPitch)
@@ -480,7 +481,7 @@ TEST(CatmullRomSpline, getPoseLineWithPitch)
   EXPECT_POINT_NEAR(pose.position, makePoint(1.5, 4.5, 1.5), EPS);
   EXPECT_QUATERNION_NEAR(
     pose.orientation,
-    quaternion_operation::convertEulerAngleToQuaternion(
+    math::geometry::convertEulerAngleToQuaternion(
       makeVector(0.0, std::atan2(-1.0, std::sqrt(1.0 + 3.0 * 3.0)), std::atan(3.0))),
     EPS);
 }

--- a/common/math/geometry/test/test_line_segment.cpp
+++ b/common/math/geometry/test/test_line_segment.cpp
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include <quaternion_operation/quaternion_operation.h>
 
 #include <cmath>
 #include <geometry/polygon/line_segment.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <scenario_simulator_exception/exception.hpp>
 
 #include "expect_eq_macros.hpp"
@@ -310,7 +310,7 @@ TEST(LineSegment, getSValue_parallel)
   const auto s = line.getSValue(
     makePose(
       1.0, 0.0, 0.0,
-      quaternion_operation::convertEulerAngleToQuaternion(makeVector(0.0, 0.0, M_PI_4 * 3.0))),
+      math::geometry::convertEulerAngleToQuaternion(makeVector(0.0, 0.0, M_PI_4 * 3.0))),
     1000.0, false);
   EXPECT_FALSE(s);
 }
@@ -321,7 +321,7 @@ TEST(LineSegment, getSValue_parallelDenormalize)
   const auto s = line.getSValue(
     makePose(
       1.0, 0.0, 0.0,
-      quaternion_operation::convertEulerAngleToQuaternion(makeVector(0.0, 0.0, M_PI_4 * 3.0))),
+      math::geometry::convertEulerAngleToQuaternion(makeVector(0.0, 0.0, M_PI_4 * 3.0))),
     1000.0, true);
   EXPECT_FALSE(s);
 }
@@ -395,7 +395,7 @@ TEST(LineSegment, GetPose)
       line.getPose(0, false, true),
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(0).y(0).z(0))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0).y(-M_PI * 0.5).z(0))));
     // [Snippet_getPose_with_s_0]
     /// @snippet test/test_line_segment.cpp Snippet_getPose_with_s_0
@@ -412,7 +412,7 @@ TEST(LineSegment, GetPose)
       line.getPose(1, false, true),
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(0).y(0).z(1))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0).y(-M_PI * 0.5).z(0))));
     // [Snippet_getPose_with_s_1]
     /// @snippet test/test_line_segment.cpp Snippet_getPose_with_s_1

--- a/common/math/geometry/test/test_transform.cpp
+++ b/common/math/geometry/test/test_transform.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include <quaternion_operation/quaternion_operation.h>
 
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <geometry/transform.hpp>
 
 #include "expect_eq_macros.hpp"
@@ -27,7 +27,7 @@ geometry_msgs::msg::Pose getFilledPose()
   geometry_msgs::msg::Pose pose;
   pose.position = makePoint(1.0, 2.0, 3.0);
   pose.orientation =
-    quaternion_operation::convertEulerAngleToQuaternion(makeVector(90.0 * M_PI / 180.0, 0.0));
+    math::geometry::convertEulerAngleToQuaternion(makeVector(90.0 * M_PI / 180.0, 0.0));
   return pose;
 }
 
@@ -38,7 +38,7 @@ TEST(Transform, getRelativePoseDifferent)
 
   geometry_msgs::msg::Pose ans = makePose(
     2.0, -3.0, 2.0,
-    quaternion_operation::convertEulerAngleToQuaternion(makeVector(-90.0 * M_PI / 180.0, 0.0)));
+    math::geometry::convertEulerAngleToQuaternion(makeVector(-90.0 * M_PI / 180.0, 0.0)));
   EXPECT_POSE_NEAR(math::geometry::getRelativePose(pose0, pose1), ans, EPS);
 }
 

--- a/docs/developer_guide/TrafficSimulator.md
+++ b/docs/developer_guide/TrafficSimulator.md
@@ -24,7 +24,7 @@ You can also see the detailed documentation of the API classes [here](https://ti
 
 ```c++
 #include <traffic_simulator/api/api.hpp>
-#include <quaternion_operation/quaternion_operation.h>
+
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <memory>

--- a/mock/cpp_mock_scenarios/src/behavior_plugin/load_do_nothing_plugin.cpp
+++ b/mock/cpp_mock_scenarios/src/behavior_plugin/load_do_nothing_plugin.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/collision/crashing_npc.cpp
+++ b/mock/cpp_mock_scenarios/src/collision/crashing_npc.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/collision/spawn_with_offset.cpp
+++ b/mock/cpp_mock_scenarios/src/collision/spawn_with_offset.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
+++ b/mock/cpp_mock_scenarios/src/crosswalk/stop_at_crosswalk.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/follow_front_entity/accelerate_and_follow.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_front_entity/accelerate_and_follow.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/follow_front_entity/decelerate_and_follow.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_front_entity/decelerate_and_follow.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/follow_lane/acquire_position_in_world_frame.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_lane/acquire_position_in_world_frame.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/follow_lane/assign_route_in_world_frame.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_lane/assign_route_in_world_frame.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/follow_lane/cancel_request.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_lane/cancel_request.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/follow_lane/follow_with_offset.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_lane/follow_with_offset.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/follow_trajectory/follow_polyline_trajectory_with_do_nothing_plugin.cpp
+++ b/mock/cpp_mock_scenarios/src/follow_trajectory/follow_polyline_trajectory_with_do_nothing_plugin.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_left.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_left.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_left_with_id.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_left_with_id.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear_lateral_velocity.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear_lateral_velocity.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear_time.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_linear_time.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_longitudinal_distance.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_longitudinal_distance.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_right.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_right.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_right_with_id.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_right_with_id.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/lane_change/lanechange_time.cpp
+++ b/mock/cpp_mock_scenarios/src/lane_change/lanechange_time.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/measurement/get_distance_in_lane_coordinate_distance.cpp
+++ b/mock/cpp_mock_scenarios/src/measurement/get_distance_in_lane_coordinate_distance.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/measurement/get_distance_to_lane_bound.cpp
+++ b/mock/cpp_mock_scenarios/src/measurement/get_distance_to_lane_bound.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/merge/merge_left.cpp
+++ b/mock/cpp_mock_scenarios/src/merge/merge_left.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/metrics/traveled_distance.cpp
+++ b/mock/cpp_mock_scenarios/src/metrics/traveled_distance.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cmath>
 #include <cpp_mock_scenarios/catalogs.hpp>

--- a/mock/cpp_mock_scenarios/src/move_backward/move_backward.cpp
+++ b/mock/cpp_mock_scenarios/src/move_backward/move_backward.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/pedestrian/walk_straight.cpp
+++ b/mock/cpp_mock_scenarios/src/pedestrian/walk_straight.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/random_scenario/random001.cpp
+++ b/mock/cpp_mock_scenarios/src/random_scenario/random001.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_continuous_false.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_continuous_false.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_relative.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_relative.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_step.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_step.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_limit.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_limit.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint_linear.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint_linear.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint_relative.cpp
+++ b/mock/cpp_mock_scenarios/src/speed_planning/request_speed_change_with_time_constraint_relative.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/traffic_simulation_demo.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_simulation_demo.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_delay.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_delay.cpp
@@ -15,6 +15,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -22,7 +23,6 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
-#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_delay.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_delay.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
@@ -57,7 +55,7 @@ private:
         5.0, 2.0, 10.0,
         geometry_msgs::build<geometry_msgs::msg::Pose>()
           .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(3755.0).y(73692.5).z(0.0))
-          .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+          .orientation(math::geometry::convertEulerAngleToQuaternion(
             geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(0.321802))),
         // clang-format off
         {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_delay.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_delay.cpp
@@ -22,6 +22,7 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_high_rate.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_high_rate.cpp
@@ -15,6 +15,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -22,7 +23,6 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
-#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_high_rate.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_high_rate.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
@@ -78,7 +76,7 @@ private:
       5.0, 50.0, 10.0,
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(3755.0).y(73692.5).z(0.0))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(0.321802))),
       // clang-format off
       {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_high_rate.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_high_rate.cpp
@@ -22,6 +22,7 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_large.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_large.cpp
@@ -15,6 +15,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -22,7 +23,6 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
-#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_large.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_large.cpp
@@ -22,6 +22,7 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_large.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_large.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
@@ -74,7 +72,7 @@ private:
       200.0, 2.0, 10.0,
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(3764.18).y(73745.45).z(0.0))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(0.321802))),
       // clang-format off
       {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_mixed.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_mixed.cpp
@@ -15,6 +15,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -22,7 +23,6 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
-#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_mixed.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_mixed.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
@@ -91,7 +89,7 @@ private:
       5.0, 3.0, 5.0,
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(3755.0).y(73692.5).z(0.0))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(0.321802))),
       // clang-format off
       {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_mixed.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_mixed.cpp
@@ -22,6 +22,7 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_multiple.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_multiple.cpp
@@ -15,6 +15,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -22,7 +23,6 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
-#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_multiple.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_multiple.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
@@ -100,7 +98,7 @@ private:
       5.0, 2.0, 10.0,
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(3755.0).y(73692.5).z(0.0))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(0.321802))),
       // clang-format off
       {
@@ -113,7 +111,7 @@ private:
       1.0, 5.0, 3.0,
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(3757.0).y(73750.3).z(0.0))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(0.321802))),
 
       // clang-format off

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_multiple.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_multiple.cpp
@@ -22,6 +22,7 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_outside_lane.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_outside_lane.cpp
@@ -15,6 +15,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -22,7 +23,6 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
-#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_outside_lane.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_outside_lane.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
@@ -74,7 +72,7 @@ private:
       10.0, 2.0, 3.0,
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(3745.0).y(73710.0).z(0.0))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(0.0))),
 
       // clang-format off

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_outside_lane.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_outside_lane.cpp
@@ -22,6 +22,7 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_pedestrian.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_pedestrian.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
@@ -77,7 +75,7 @@ private:
       1.0, 5.0, 3.0,
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(3757.0).y(73750.3).z(0.0))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(0.321802))),
 
       // clang-format off

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_pedestrian.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_pedestrian.cpp
@@ -15,6 +15,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -22,7 +23,6 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
-#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_pedestrian.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_pedestrian.cpp
@@ -22,6 +22,7 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_vehicle.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_vehicle.cpp
@@ -15,6 +15,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -22,7 +23,6 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
-#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_vehicle.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_vehicle.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
@@ -78,7 +76,7 @@ private:
       5.0, 2.0, 10.0,
       geometry_msgs::build<geometry_msgs::msg::Pose>()
         .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(3755.0).y(73692.5).z(0.0))
-        .orientation(quaternion_operation::convertEulerAngleToQuaternion(
+        .orientation(math::geometry::convertEulerAngleToQuaternion(
           geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(0.321802))),
       // clang-format off
       {

--- a/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_vehicle.cpp
+++ b/mock/cpp_mock_scenarios/src/traffic_source/define_traffic_source_vehicle.cpp
@@ -22,6 +22,7 @@
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <vector>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 
 namespace cpp_mock_scenarios
 {

--- a/openscenario/openscenario_interpreter/CHANGELOG.rst
+++ b/openscenario/openscenario_interpreter/CHANGELOG.rst
@@ -2850,7 +2850,7 @@ Changelog for package openscenario_interpreter
 * Lipsticks
 * Add optional argument verbose (= True) to openscenario_utility
 * Rename 'step_time_ms' to 'frame-rate'
-* Fix external/quaternion_operation's commit hash
+* Fix external/math::geometry's commit hash
 * Add parameter 'real-time-factor' to openscenario_interpreter
 * enable pass colcon test
 * enable pass test case

--- a/openscenario/openscenario_interpreter/CHANGELOG.rst
+++ b/openscenario/openscenario_interpreter/CHANGELOG.rst
@@ -2857,7 +2857,7 @@ Changelog for package openscenario_interpreter
 * Lipsticks
 * Add optional argument verbose (= True) to openscenario_utility
 * Rename 'step_time_ms' to 'frame-rate'
-* Fix external/math::geometry's commit hash
+* Fix external/quaternion_operation's commit hash
 * Add parameter 'real-time-factor' to openscenario_interpreter
 * enable pass colcon test
 * enable pass test case

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -15,6 +15,7 @@
 #ifndef OPENSCENARIO_INTERPRETER__SIMULATOR_CORE_HPP_
 #define OPENSCENARIO_INTERPRETER__SIMULATOR_CORE_HPP_
 
+#include <geometry/quaternion/quaternion_to_euler.hpp>
 #include <openscenario_interpreter/error.hpp>
 #include <openscenario_interpreter/syntax/boolean.hpp>
 #include <openscenario_interpreter/syntax/double.hpp>
@@ -562,8 +563,7 @@ public:
           const auto relative_pose =
             traffic_simulator::pose::relativePose(from_map_pose, to_map_pose)) {
           return static_cast<Double>(std::abs(
-            quaternion_operation::convertQuaternionToEulerAngle(relative_pose.value().orientation)
-              .z));
+            math::geometry::convertQuaternionToEulerAngle(relative_pose.value().orientation).z));
         }
       }
       return Double::nan();

--- a/openscenario/openscenario_interpreter/src/syntax/world_position.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/world_position.cpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <openscenario_interpreter/reader/attribute.hpp>
 #include <openscenario_interpreter/simulator_core.hpp>
 #include <openscenario_interpreter/syntax/world_position.hpp>
@@ -43,7 +42,7 @@ WorldPosition::operator NativeWorldPosition() const
   native_world_position.position.x = x;
   native_world_position.position.y = y;
   native_world_position.position.z = z;
-  native_world_position.orientation = quaternion_operation::convertEulerAngleToQuaternion(
+  native_world_position.orientation = math::geometry::convertEulerAngleToQuaternion(
     geometry_msgs::build<geometry_msgs::msg::Vector3>().x(r).y(p).z(h));
   return native_world_position;
 }

--- a/simulation/behavior_tree_plugin/package.xml
+++ b/simulation/behavior_tree_plugin/package.xml
@@ -12,7 +12,6 @@
   <depend>behaviortree_cpp_v3</depend>
   <depend>geometry</depend>
   <depend>pluginlib</depend>
-  <depend>math::geometry</depend>
   <depend>rclcpp</depend>
   <depend>traffic_simulator</depend>
 

--- a/simulation/behavior_tree_plugin/package.xml
+++ b/simulation/behavior_tree_plugin/package.xml
@@ -12,7 +12,7 @@
   <depend>behaviortree_cpp_v3</depend>
   <depend>geometry</depend>
   <depend>pluginlib</depend>
-  <depend>quaternion_operation</depend>
+  <depend>math::geometry</depend>
   <depend>rclcpp</depend>
   <depend>traffic_simulator</depend>
 

--- a/simulation/behavior_tree_plugin/src/pedestrian/follow_lane_action.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/follow_lane_action.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <algorithm>
 #include <behavior_tree_plugin/pedestrian/follow_lane_action.hpp>
 #include <iostream>

--- a/simulation/do_nothing_plugin/package.xml
+++ b/simulation/do_nothing_plugin/package.xml
@@ -12,7 +12,6 @@
 
   <depend>behaviortree_cpp_v3</depend>
   <depend>pluginlib</depend>
-  <depend>math::geometry</depend>
   <depend>rclcpp</depend>
   <depend>traffic_simulator</depend>
 

--- a/simulation/do_nothing_plugin/package.xml
+++ b/simulation/do_nothing_plugin/package.xml
@@ -12,7 +12,7 @@
 
   <depend>behaviortree_cpp_v3</depend>
   <depend>pluginlib</depend>
-  <depend>quaternion_operation</depend>
+  <depend>math::geometry</depend>
   <depend>rclcpp</depend>
   <depend>traffic_simulator</depend>
 

--- a/simulation/do_nothing_plugin/src/plugin.cpp
+++ b/simulation/do_nothing_plugin/src/plugin.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <do_nothing_plugin/plugin.hpp>
+#include <geometry/quaternion/slerp.hpp>
 #include <geometry/vector3/hypot.hpp>
 #include <geometry/vector3/operator.hpp>
 
@@ -88,7 +89,7 @@ auto interpolateEntityStatusFromPolylineTrajectory(
         .position(
           v0.position.position * (1 - interpolation_ratio) +
           v1.position.position * interpolation_ratio)
-        .orientation(quaternion_operation::slerp(
+        .orientation(math::geometry::slerp(
           v0.position.orientation, v1.position.orientation, interpolation_ratio));
     const double linear_velocity =
       math::geometry::hypot(v1.position.position, v0.position.position) / (v1.time - v0.time);

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/lidar/lidar_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/lidar/lidar_sensor.hpp
@@ -17,6 +17,7 @@
 
 #include <simulation_api_schema.pb.h>
 
+#include <geometry/quaternion/get_rotation_matrix.hpp>
 #include <memory>
 #include <queue>
 #include <rclcpp/rclcpp.hpp>

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/lidar/raycaster.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/lidar/raycaster.hpp
@@ -17,8 +17,9 @@
 
 #include <embree4/rtcore.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <quaternion_operation/quaternion_operation.h>
 
+#include <geometry/quaternion/euler_to_quaternion.hpp>
+#include <geometry/quaternion/get_rotation_matrix.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <memory>
@@ -83,7 +84,7 @@ private:
   {
     auto & rotation_matrices = ref_rotation_matrices.get();
     auto & thread_detected_ids = ref_thread_detected_ids.get();
-    const auto orientation_matrix = quaternion_operation::getRotationMatrix(origin.orientation);
+    const auto orientation_matrix = math::geometry::getRotationMatrix(origin.orientation);
     for (unsigned int i = thread_id; i < rotation_matrices.size(); i += thread_count) {
       RTCRayHit rayhit = {};
       rayhit.ray.org_x = origin.position.x;

--- a/simulation/simple_sensor_simulator/package.xml
+++ b/simulation/simple_sensor_simulator/package.xml
@@ -43,7 +43,7 @@
   <depend>libpcl-all-dev</depend>
   <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
-  <depend>quaternion_operation</depend>
+  <depend>math::geometry</depend>
   <depend>rclcpp_components</depend>
   <depend>simulation_interface</depend>
   <depend>traffic_simulator_msgs</depend>

--- a/simulation/simple_sensor_simulator/package.xml
+++ b/simulation/simple_sensor_simulator/package.xml
@@ -43,7 +43,6 @@
   <depend>libpcl-all-dev</depend>
   <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
-  <depend>math::geometry</depend>
   <depend>rclcpp_components</depend>
   <depend>simulation_interface</depend>
   <depend>traffic_simulator_msgs</depend>

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <algorithm>
 #include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_auto_perception_msgs/msg/tracked_objects.hpp>
@@ -21,6 +19,7 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <geometry/quaternion/get_rotation_matrix.hpp>
 #include <geometry/vector3/hypot.hpp>
 #include <memory>
 #include <random>
@@ -117,7 +116,7 @@ auto make(const traffic_simulator_msgs::EntityStatus & status) -> geometry_msgs:
   auto center_point = geometry_msgs::msg::Point();
   simulation_interface::toMsg(status.bounding_box().center(), center_point);
 
-  Eigen::Vector3d center = quaternion_operation::getRotationMatrix(pose.orientation) *
+  Eigen::Vector3d center = math::geometry::getRotationMatrix(pose.orientation) *
                            Eigen::Vector3d(center_point.x, center_point.y, center_point.z);
 
   pose.position.x = pose.position.x + center.x();

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/lidar/lidar_sensor.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/lidar/lidar_sensor.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <memory>
 #include <optional>
 #include <simple_sensor_simulator/exception.hpp>
@@ -39,7 +37,7 @@ auto LidarSensor<sensor_msgs::msg::PointCloud2>::raycast(
     } else {
       geometry_msgs::msg::Pose pose;
       simulation_interface::toMsg(entity.pose(), pose);
-      auto rotation = quaternion_operation::getRotationMatrix(pose.orientation);
+      auto rotation = math::geometry::getRotationMatrix(pose.orientation);
       geometry_msgs::msg::Point center_point;
       simulation_interface::toMsg(entity.bounding_box().center(), center_point);
       Eigen::Vector3d center(center_point.x, center_point.y, center_point.z);

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/lidar/raycaster.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/lidar/raycaster.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <algorithm>
 #include <iostream>
 #include <simple_sensor_simulator/sensor_simulation/lidar/lidar_sensor.hpp>
@@ -61,7 +59,7 @@ void Raycaster::setDirection(
     configuration.horizontal_resolution());
   rotation_matrices_.clear();
   for (const auto & q : quat_directions) {
-    rotation_matrices_.push_back(quaternion_operation::getRotationMatrix(q));
+    rotation_matrices_.push_back(math::geometry::getRotationMatrix(q));
   }
 }
 
@@ -83,7 +81,7 @@ std::vector<geometry_msgs::msg::Quaternion> Raycaster::getDirections(
         rpy.x = 0;
         rpy.y = vertical_angle;
         rpy.z = horizontal_angle;
-        auto quat = quaternion_operation::convertEulerAngleToQuaternion(rpy);
+        auto quat = math::geometry::convertEulerAngleToQuaternion(rpy);
         directions.emplace_back(quat);
       }
     }

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/occupancy_grid/occupancy_grid_builder.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/occupancy_grid/occupancy_grid_builder.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <boost/geometry.hpp>
+#include <geometry/quaternion/get_rotation_matrix.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <simple_sensor_simulator/sensor_simulation/occupancy_grid/grid_traversal.hpp>
 #include <simple_sensor_simulator/sensor_simulation/occupancy_grid/occupancy_grid_builder.hpp>

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/occupancy_grid/occupancy_grid_sensor.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/occupancy_grid/occupancy_grid_sensor.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <algorithm>
+#include <geometry/quaternion/get_rotation_matrix.hpp>
 #include <memory>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <optional>
@@ -126,7 +125,7 @@ auto OccupancyGridSensor<nav_msgs::msg::OccupancyGrid>::getOccupancyGrid(
         simulation_interface::toMsg(s.pose(), pose);
         auto point = geometry_msgs::msg::Point();
         simulation_interface::toMsg(s.bounding_box().center(), point);
-        auto rotation = quaternion_operation::getRotationMatrix(pose.orientation);
+        auto rotation = math::geometry::getRotationMatrix(pose.orientation);
         auto center = (rotation * Eigen::Vector3d(point.x, point.y, point.z)).eval();
 
         pose.position.x += center.x();

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/primitives/primitive.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/primitives/primitive.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <algorithm>
 #include <boost/geometry.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>

--- a/simulation/simple_sensor_simulator/src/simple_sensor_simulator.cpp
+++ b/simulation/simple_sensor_simulator/src/simple_sensor_simulator.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <algorithm>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <limits>

--- a/simulation/traffic_simulator/CMakeLists.txt
+++ b/simulation/traffic_simulator/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(traffic_simulator_msgs REQUIRED)
 find_package(Boost COMPONENTS filesystem)
 find_package(lanelet2_matching REQUIRED)
 find_package(tinyxml2_vendor REQUIRED)
-find_package(quaternion_operation REQUIRED)
 find_package(pluginlib REQUIRED)
 include(FindProtobuf REQUIRED)
 

--- a/simulation/traffic_simulator/package.xml
+++ b/simulation/traffic_simulator/package.xml
@@ -27,7 +27,6 @@
   <depend>libomp-dev</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>pugixml-dev</depend>
-  <depend>quaternion_operation</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rosgraph_msgs</depend>

--- a/simulation/traffic_simulator/src/api/api.cpp
+++ b/simulation/traffic_simulator/src/api/api.cpp
@@ -14,6 +14,7 @@
 
 #include <tf2/LinearMath/Quaternion.h>
 
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -112,7 +113,7 @@ auto API::setEntityStatus(
 {
   geometry_msgs::msg::Pose relative_pose;
   relative_pose.position = relative_position;
-  relative_pose.orientation = quaternion_operation::convertEulerAngleToQuaternion(relative_rpy);
+  relative_pose.orientation = math::geometry::convertEulerAngleToQuaternion(relative_rpy);
   setEntityStatus(name, reference_entity_name, relative_pose, action_status);
 }
 

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <boost/lexical_cast.hpp>
 #include <concealer/autoware_universe.hpp>
 #include <concealer/field_operator_application_for_autoware_universe.hpp>

--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <algorithm>
 #include <memory>
 #include <string>

--- a/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <algorithm>
 #include <memory>
 #include <string>

--- a/simulation/traffic_simulator/src/helper/helper.cpp
+++ b/simulation/traffic_simulator/src/helper/helper.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <quaternion_operation/quaternion_operation.h>
-
+#include <geometry/quaternion/euler_to_quaternion.hpp>
+#include <geometry/quaternion/quaternion_to_euler.hpp>
 #include <string>
 #include <traffic_simulator/helper/helper.hpp>
 
@@ -60,7 +60,7 @@ geometry_msgs::msg::Vector3 constructRPY(double roll, double pitch, double yaw)
 
 geometry_msgs::msg::Vector3 constructRPYfromQuaternion(geometry_msgs::msg::Quaternion quaternion)
 {
-  return quaternion_operation::convertQuaternionToEulerAngle(quaternion);
+  return math::geometry::convertQuaternionToEulerAngle(quaternion);
 }
 
 geometry_msgs::msg::Pose constructPose(
@@ -70,8 +70,7 @@ geometry_msgs::msg::Pose constructPose(
   pose.position.x = x;
   pose.position.y = y;
   pose.position.z = z;
-  pose.orientation =
-    quaternion_operation::convertEulerAngleToQuaternion(constructRPY(roll, pitch, yaw));
+  pose.orientation = math::geometry::convertEulerAngleToQuaternion(constructRPY(roll, pitch, yaw));
   return pose;
 }
 

--- a/simulation/traffic_simulator/src/traffic/traffic_source.cpp
+++ b/simulation/traffic_simulator/src/traffic/traffic_source.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <geometry/intersection/collision.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <geometry/vector3/hypot.hpp>
 #include <traffic_simulator/helper/helper.hpp>
 #include <traffic_simulator/traffic/traffic_source.hpp>
@@ -83,7 +84,7 @@ auto TrafficSource::makeRandomPose(const bool random_orientation) -> geometry_ms
   random_pose.position.y += radius * std::sin(angle);
 
   if (random_orientation) {
-    random_pose.orientation = quaternion_operation::convertEulerAngleToQuaternion(
+    random_pose.orientation = math::geometry::convertEulerAngleToQuaternion(
       traffic_simulator::helper::constructRPY(0.0, 0.0, angle_distribution_(engine_)));
   }
 

--- a/simulation/traffic_simulator/src/visualization/visualization_component.cpp
+++ b/simulation/traffic_simulator/src/visualization/visualization_component.cpp
@@ -42,8 +42,6 @@
   </table>
  */
 
-#include <quaternion_operation/quaternion_operation.h>
-
 #include <algorithm>
 #include <cmath>
 #include <color_names/color_names.hpp>

--- a/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
+++ b/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <geometry/quaternion/euler_to_quaternion.hpp>
 #include <string>
 #include <traffic_simulator/hdmap_utils/hdmap_utils.hpp>
 #include <traffic_simulator/helper/helper.hpp>
@@ -52,7 +53,7 @@ auto makeSmallBoundingBox(const double center_y = 0.0) -> traffic_simulator_msgs
 
 auto makeQuaternionFromYaw(const double yaw) -> geometry_msgs::msg::Quaternion
 {
-  return quaternion_operation::convertEulerAngleToQuaternion(
+  return math::geometry::convertEulerAngleToQuaternion(
     geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0.0).y(0.0).z(yaw));
 }
 

--- a/test_runner/scenario_test_runner/CHANGELOG.rst
+++ b/test_runner/scenario_test_runner/CHANGELOG.rst
@@ -1735,7 +1735,7 @@ Changelog for package scenario_test_runner
 * Rename option 'timeout' to 'global-timeout'
 * Add optional argument verbose (= True) to openscenario_utility
 * Rename 'step_time_ms' to 'frame-rate'
-* Fix external/math::geometry's commit hash
+* Fix external/quaternion_operation's commit hash
 * Add parameter 'real-time-factor' to openscenario_interpreter
 * Rename option to '--global-real-time-factor' from 'real-time-factor'
 * Add launch argument '--real-time-factor'

--- a/test_runner/scenario_test_runner/CHANGELOG.rst
+++ b/test_runner/scenario_test_runner/CHANGELOG.rst
@@ -1728,7 +1728,7 @@ Changelog for package scenario_test_runner
 * Rename option 'timeout' to 'global-timeout'
 * Add optional argument verbose (= True) to openscenario_utility
 * Rename 'step_time_ms' to 'frame-rate'
-* Fix external/quaternion_operation's commit hash
+* Fix external/math::geometry's commit hash
 * Add parameter 'real-time-factor' to openscenario_interpreter
 * Rename option to '--global-real-time-factor' from 'real-time-factor'
 * Add launch argument '--real-time-factor'


### PR DESCRIPTION
# Description

Remove quaternion_operation.

## Abstract

This pull request removes the `quaternion_operation` that was causing bugs. All dependent areas have been updated accordingly. The functionality remains unchanged, but the namespace has been modified and template implementation has been added.

## Background

The `quaternion_operation` was identified as the source of multiple bugs within the codebase. To improve stability and maintainability, it was necessary to remove this operation and update all dependencies. This change also provided an opportunity to improve the structure by changing the namespace and implementing templates.

## Details

The pull request includes the removal of `quaternion_operation` and updates to all code sections that depended on it. The namespace has been changed to better reflect the current structure and functionality of the code. Additionally, template implementation has been incorporated to enhance flexibility and reusability. The overall functionality of the system remains intact with these modifications.

## References

https://github.com/tier4/sim_evaluation_tools/issues/299

# Destructive Changes

N/A

# Known Limitations

N/A
