### PR TITLE
Optimize `EntityManager::broadcastEntityTransform` to Execute Only Once

### DIFF
--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -40,8 +40,11 @@ namespace entity
 void EntityManager::broadcastEntityTransform()
 {
   static bool isSend;
-  if(isSend){return;}
-  else{isSend = true;}
+  if (isSend) {
+    return;
+  } else {
+    isSend = true;
+  }
 
   using math::geometry::operator/;
   using math::geometry::operator*;

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -39,6 +39,10 @@ namespace entity
 {
 void EntityManager::broadcastEntityTransform()
 {
+  static bool isSend;
+  if(isSend){return;}
+  else{isSend = true;}
+
   using math::geometry::operator/;
   using math::geometry::operator*;
   using math::geometry::operator+=;


### PR DESCRIPTION
# Description

## Abstract

This pull request modifies the `EntityManager::broadcastEntityTransform()` function to ensure it is called only once.

## Background

The function `broadcastEntityTransform` was previously being called multiple times, causing unnecessary resource usage. This change ensures the function is executed only once, improving efficiency.

## Details

The function `EntityManager::broadcastEntityTransform()` has been modified by introducing a static boolean variable `isSend` to control its execution. Once the function is called, `isSend` is set to true, preventing subsequent calls.

```cpp
void EntityManager::broadcastEntityTransform() {
  static bool isSend;
  if (isSend) {
    return;
  } else {
    isSend = true;
  }

  using math::geometry::operator/;
  using math::geometry::operator*;
  using math::geometry::operator+=;

```

## References

#1276 

# Destructive Changes

N/A

# Known Limitations

N/A