### PR TITLE
Revert "Optimize `EntityManager::broadcastEntityTransform` to Execute Only Once"

### DIFF
--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -39,13 +39,6 @@ namespace entity
 {
 void EntityManager::broadcastEntityTransform()
 {
-  static bool isSend;
-  if (isSend) {
-    return;
-  } else {
-    isSend = true;
-  }
-
   using math::geometry::operator/;
   using math::geometry::operator*;
   using math::geometry::operator+=;


### PR DESCRIPTION
# Description

## Abstract

Revert #1284

## Background

A bug was observed that visualization results were not displayed in rviz before and after the #1284 merge.
Revert and fix the bug.
![Screenshot from 2024-06-18 14-51-09](https://github.com/tier4/scenario_simulator_v2/assets/10348912/1ec0c185-47a9-499e-8264-3a9fa5db0c0e)


## Details

Reverts #1284

## References

#1284

# Destructive Changes

N/A

# Known Limitations

N/A