### PR TITLE
Customize API::getGoalPoses for goal modifications.

### DIFF
--- a/external/concealer/include/concealer/autoware_universe.hpp
+++ b/external/concealer/include/concealer/autoware_universe.hpp
@@ -22,6 +22,7 @@
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/turn_indicators_report.hpp>
 #include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <concealer/autoware.hpp>
 #include <concealer/publisher_wrapper.hpp>
 #include <concealer/subscriber_wrapper.hpp>
@@ -41,6 +42,8 @@ class AutowareUniverse : public Autoware
   SubscriberWrapper<autoware_auto_vehicle_msgs::msg::GearCommand,             ThreadSafety::safe> getGearCommandImpl;
   SubscriberWrapper<autoware_auto_vehicle_msgs::msg::TurnIndicatorsCommand,   ThreadSafety::safe> getTurnIndicatorsCommand;
   SubscriberWrapper<autoware_auto_planning_msgs::msg::PathWithLaneId,         ThreadSafety::safe> getPathWithLaneId;
+  SubscriberWrapper<autoware_planning_msgs::msg::LaneletRoute,                ThreadSafety::safe> getAWMissionRoute;
+
 
   PublisherWrapper<geometry_msgs::msg::AccelWithCovarianceStamped>        setAcceleration;
   PublisherWrapper<nav_msgs::msg::Odometry>                               setOdometry;

--- a/external/concealer/include/concealer/field_operator_application_for_autoware_universe.hpp
+++ b/external/concealer/include/concealer/field_operator_application_for_autoware_universe.hpp
@@ -108,6 +108,7 @@ protected:
 
 public:
   SubscriberWrapper<autoware_auto_planning_msgs::msg::PathWithLaneId> getPathWithLaneId;
+  SubscriberWrapper<autoware_planning_msgs::msg::LaneletRoute>        getAWMissionRoute;
 
 public:
   template <typename... Ts>
@@ -123,6 +124,7 @@ public:
 #endif
     getMrmState("/api/fail_safe/mrm_state", *this, [this](const auto & v) { receiveMrmState(v); }),
     getPathWithLaneId("/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id", *this),
+    getAWMissionRoute("/planning/mission_planning/route", *this),
     getTrajectory("/api/iv_msgs/planning/scenario_planning/trajectory", *this),
     getTurnIndicatorsCommandImpl("/control/command/turn_indicators_cmd", *this),
     requestClearRoute("/api/routing/clear_route", *this),

--- a/external/concealer/package.xml
+++ b/external/concealer/package.xml
@@ -23,6 +23,7 @@
   <depend>tier4_planning_msgs</depend>
   <depend>tier4_rtc_msgs</depend>
   <depend>tier4_system_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
 
   <!-- Common -->
   <depend>ament_index_cpp</depend>

--- a/external/concealer/src/autoware_universe.cpp
+++ b/external/concealer/src/autoware_universe.cpp
@@ -22,6 +22,7 @@ AutowareUniverse::AutowareUniverse()
   getTurnIndicatorsCommand("/control/command/turn_indicators_cmd", *this),
   getPathWithLaneId(
     "/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id", *this),
+  getAWMissionRoute("/planning/mission_planning/route", *this),
   setAcceleration("/localization/acceleration", *this),
   setOdometry("/localization/kinematic_state", *this),
   setSteeringReport("/vehicle/status/steering_status", *this),

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/ego_entity.hpp
@@ -82,6 +82,8 @@ public:
 
   auto getEntityTypename() const -> const std::string & override;
 
+  auto getGoalPoses() -> std::vector<CanonicalizedLaneletPose> override;
+
   auto getObstacle() -> std::optional<traffic_simulator_msgs::msg::Obstacle> override;
 
   auto getRouteLanelets(double horizon = 100) -> lanelet::Ids override;

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -236,7 +236,7 @@ protected:
 
   CanonicalizedEntityStatus status_before_update_;
 
-  std::shared_ptr<hdmap_utils::HdMapUtils> hdmap_utils_ptr_;
+  std::shared_ptr<hdmap_utils::HdMapUtils> hdmap_utils_ptr_;//use this
   std::shared_ptr<traffic_simulator::TrafficLightManager> traffic_light_manager_;
 
   bool npc_logic_started_ = false;

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -23,6 +23,7 @@
 #include <thread>
 #include <traffic_simulator/entity/ego_entity.hpp>
 #include <traffic_simulator_msgs/msg/waypoints_array.hpp>
+#include <traffic_simulator/utils/pose.hpp>
 #include <tuple>
 #include <unordered_map>
 #include <utility>
@@ -100,6 +101,19 @@ auto EgoEntity::getEntityTypename() const -> const std::string &
 {
   static const std::string result = "EgoEntity";
   return result;
+}
+
+auto EgoEntity::getGoalPoses() -> std::vector<CanonicalizedLaneletPose>
+{
+  std::vector<CanonicalizedLaneletPose> lenlet_pose;
+
+  if (const auto universe =
+        dynamic_cast<concealer::FieldOperatorApplicationFor<concealer::AutowareUniverse> *>(
+          field_operator_application.get());
+      universe) {
+    lenlet_pose.push_back(traffic_simulator::pose::toLaneletPose(universe->getAWMissionRoute().goal_pose, false, hdmap_utils_ptr_).value());
+  }
+  return lenlet_pose;
 }
 
 auto EgoEntity::getEntityType() const -> const traffic_simulator_msgs::msg::EntityType &


### PR DESCRIPTION
# Description

## Abstract

This pull request customizes the API::getGoalPoses function for goal modifications in Autoware.

## Background

The goal position in Autoware is automatically modified by a feature called "goal modification." This PR addresses the need to retrieve the actual goal positions considering these modifications.

## Details

The `API::getGoalPoses` function has been customized to check the goal field in `/planning/mission_planning/route` and retrieve the goal positions. When `API::getGoalPoses` is called for an Ego entity, this new logic is applied to extract the correct goal positions. Currently, `VehicleEntity::getGoalPoses` is being called, which only computes the route to the goal without considering the goal modifications.

## References

N/A

# Destructive Changes

N/A

# Known Limitations

N/A
