### PR TITLE
fix: Automated branch deletion is not working properly

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -130,8 +130,13 @@ jobs:
           name: ${{ steps.new_version.outputs.new_version }}
           body: ${{ steps.get_release_description.outputs.stdout }}
 
-      - name: Delete branch
+      - name: Delete branch if merged
         if: github.event.pull_request.merged == true
-        uses: SvanBoxel/delete-merged-branch@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${context.payload.pull_request.head.ref}`,
+            })


### PR DESCRIPTION
# Description

## Abstract

Fix Actions problem that automated branch deletion is not working properly

## Background

Related issues
[https://github.com/SvanBoxel/delete-merged-branch/issues/257](https://github.com/SvanBoxel/delete-merged-branch/issues/257#issuecomment-2182796423)

## Details

`SvanBoxel/delete-merged-branch` is not maintained, and causes error on Release Action.
This PR fixes error by replacing `SvanBoxel/delete-merged-branch`