### PR TITLE
Remove incorrect comment `// headers in STL` 

### DIFF
--- a/mock/cpp_mock_scenarios/src/synchronized_action/synchronized_action.cpp
+++ b/mock/cpp_mock_scenarios/src/synchronized_action/synchronized_action.cpp
@@ -19,7 +19,6 @@
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 
-// headers in STL
 #include <memory>
 #include <string>
 #include <vector>

--- a/mock/cpp_mock_scenarios/src/synchronized_action/synchronized_action.cpp
+++ b/mock/cpp_mock_scenarios/src/synchronized_action/synchronized_action.cpp
@@ -15,12 +15,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/src/synchronized_action/synchronized_action_with_speed.cpp
+++ b/mock/cpp_mock_scenarios/src/synchronized_action/synchronized_action_with_speed.cpp
@@ -19,7 +19,6 @@
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 
-// headers in STL
 #include <memory>
 #include <string>
 #include <vector>

--- a/mock/cpp_mock_scenarios/src/synchronized_action/synchronized_action_with_speed.cpp
+++ b/mock/cpp_mock_scenarios/src/synchronized_action/synchronized_action_with_speed.cpp
@@ -15,12 +15,11 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <cpp_mock_scenarios/catalogs.hpp>
 #include <cpp_mock_scenarios/cpp_scenario_node.hpp>
+#include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <traffic_simulator/api/api.hpp>
 #include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
-
-#include <memory>
-#include <string>
 #include <vector>
 
 namespace cpp_mock_scenarios


### PR DESCRIPTION
# Description

## Abstract

#1306 

## Background

 Incorrect comment `// headers in STL` exists.

## Details

Removes the incorrect comment `// headers in STL` from two files as per the issue request.

- **File `synchronized_action_with_speed.cpp`**: Deletes the comment `// headers in STL` located above the standard library headers inclusion.
- **File `synchronized_action.cpp`**: Removes the same comment `// headers in STL` to align with the correction made in the first file.

## References

#1306

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tier4/scenario_simulator_v2/issues/1306?shareId=97f197cf-8ddd-4b4c-b52a-6e2b166e695c).

# Destructive Changes

N/A

# Known Limitations

N/A