### PR TITLE
fix CONFIG_EXTRAS argument of ament_auto_package macro

### DIFF
--- a/mock/cpp_mock_scenarios/CMakeLists.txt
+++ b/mock/cpp_mock_scenarios/CMakeLists.txt
@@ -73,4 +73,4 @@ if(BUILD_TESTING)
   # add_cpp_mock_scenario_test(${PROJECT_NAME} "traffic_simulation_demo" "70")
 endif()
 
-ament_auto_package(CONFIG_EXTRAS "${PROJECT_NAME}-extras.cmake")
+ament_auto_package(CONFIG_EXTRAS "${PROJECT_NAME}_ament_cmake-extras.cmake")


### PR DESCRIPTION
# Description

## Abstract

Fix cmake error.

## Background

When setting up the environment for scenario_simulator_v2 on a new work PC, the following error occurred:

```bash
--- stderr: cpp_mock_scenarios                                                                                                                                                                                           
CMake Error at /opt/ros/humble/share/ament_cmake_core/cmake/core/assert_file_exists.cmake:20 (message):
  ament_package() called with extra file 'cpp_mock_scenarios-extras.cmake'
  which does not exist
Call Stack (most recent call first):
  /opt/ros/humble/share/ament_cmake_core/cmake/core/ament_package.cmake:98 (assert_file_exists)
  /opt/ros/humble/share/ament_cmake_core/cmake/core/ament_package.cmake:68 (_ament_package)
  /opt/ros/humble/share/ament_cmake_auto/cmake/ament_auto_package.cmake:102 (ament_package)
  CMakeLists.txt:76 (ament_auto_package)
---
```

## Details

I found that the filename `cpp_mock_scenarios-extras.cmake` is wrong.
`cpp_mock_scenarios_ament_cmake-extras.cmake` is right.

## References

N/A

# Destructive Changes

N/A

# Known Limitations

N/A
