### PR TITLE
Rjd 1278/traffic simulator update

### DIFF
--- a/simulation/traffic_simulator/test/src/helper/test_helper.cpp
+++ b/simulation/traffic_simulator/test/src/helper/test_helper.cpp
@@ -14,83 +14,125 @@
 
 #include <gtest/gtest.h>
 
+#include <geometry/vector3/vector3.hpp>
 #include <regex>
 #include <scenario_simulator_exception/exception.hpp>
 #include <traffic_simulator/helper/helper.hpp>
 
 #include "../expect_eq_macros.hpp"
 
-TEST(HELPER, RPY)
+/**
+ * @note Test basic functionality. Test construction correctness of an action status.
+ */
+TEST(helper, constructActionStatus)
 {
-  const auto rpy = traffic_simulator::helper::constructRPY(1, 2, 1);
-  geometry_msgs::msg::Vector3 vec;
-  vec.x = 1.0;
-  vec.y = 2.0;
-  vec.z = 1.0;
+  traffic_simulator_msgs::msg::ActionStatus actual_action_status;
+  actual_action_status.twist.linear.x = 2.0;
+  actual_action_status.twist.angular.z = 3.0;
+  actual_action_status.accel.linear.x = 5.0;
+  actual_action_status.accel.angular.z = 7.0;
+
+  const auto result_action_status =
+    traffic_simulator::helper::constructActionStatus(2.0, 3.0, 5.0, 7.0);
+
+  EXPECT_ACTION_STATUS_EQ(result_action_status, actual_action_status);
+}
+
+/**
+ * @note Test basic functionality. Test construction correctness of a lanelet pose.
+ */
+TEST(helper, constructLaneletPose)
+{
+  const auto actual_lanelet_pose =
+    traffic_simulator_msgs::build<traffic_simulator::LaneletPose>()
+      .lanelet_id(11LL)
+      .s(13.0)
+      .offset(17.0)
+      .rpy(geometry_msgs::build<geometry_msgs::msg::Vector3>().x(19.0).y(23.0).z(29.0));
+
+  const auto result_lanelet_pose =
+    traffic_simulator::helper::constructLaneletPose(11LL, 13.0, 17.0, 19.0, 23.0, 29.0);
+
+  std::stringstream ss;
+  ss << result_lanelet_pose;
+  EXPECT_LANELET_POSE_EQ(result_lanelet_pose, actual_lanelet_pose);
+  EXPECT_STREQ(ss.str().c_str(), "lanelet id : 11\ns : 13");
+}
+
+/**
+ * @note Test basic functionality. Test construction correctness of RPY vector.
+ */
+TEST(helper, constructRPY)
+{
+  const auto vec = geometry_msgs::build<geometry_msgs::msg::Vector3>().x(31.0).y(37.0).z(41.0);
+  const auto rpy = traffic_simulator::helper::constructRPY(31.0, 37.0, 41.0);
   EXPECT_VECTOR3_EQ(rpy, vec);
 }
 
-TEST(HELPER, QUATERNION)
+/**
+ * @note Test basic functionality. Test construction correctness of a quaternion.
+ */
+TEST(helper, constructRPYfromQuaternion)
 {
-  const auto rpy =
-    traffic_simulator::helper::constructRPYfromQuaternion(geometry_msgs::msg::Quaternion());
-  EXPECT_VECTOR3_EQ(rpy, geometry_msgs::msg::Vector3());
+  {
+    const auto default_vec = geometry_msgs::msg::Vector3();
+    const auto default_rpy =
+      traffic_simulator::helper::constructRPYfromQuaternion(geometry_msgs::msg::Quaternion());
+    EXPECT_VECTOR3_EQ(default_rpy, default_vec);
+  }
+  {
+    const auto vec =
+      geometry_msgs::build<geometry_msgs::msg::Vector3>().x(-M_PI / 3.0).y(-M_PI / 6.0).z(M_PI / 2);
+    const auto rpy = traffic_simulator::helper::constructRPYfromQuaternion(
+      geometry_msgs::build<geometry_msgs::msg::Quaternion>().x(-0.183).y(-0.5).z(0.5).w(0.683));
+    EXPECT_VECTOR3_NEAR(rpy, vec, 1.0e-3);
+  }
 }
 
-TEST(HELPER, POSE)
+/**
+ * @note Test basic functionality. Test construction correctness of a pose.
+ */
+TEST(helper, constructPose)
 {
-  const auto pose = traffic_simulator::helper::constructPose(1, 1, 1, 0, 0, 0);
-  geometry_msgs::msg::Pose expect_pose;
-  expect_pose.position.x = 1;
-  expect_pose.position.y = 1;
-  expect_pose.position.z = 1;
-  EXPECT_POSE_EQ(pose, expect_pose);
+  const auto actual_pose =
+    geometry_msgs::build<geometry_msgs::msg::Pose>()
+      .position(geometry_msgs::build<geometry_msgs::msg::Point>().x(43.0).y(47.0).z(53.0))
+      .orientation(
+        geometry_msgs::build<geometry_msgs::msg::Quaternion>().x(-0.183).y(-0.5).z(0.5).w(0.683));
+
+  const auto result_pose =
+    traffic_simulator::helper::constructPose(43.0, 47.0, 53.0, -M_PI / 3.0, -M_PI / 6.0, M_PI / 2);
+
+  EXPECT_POSE_NEAR(result_pose, actual_pose, 1.0e-3);
 }
 
-TEST(HELPER, LANELET_POSE)
-{
-  const auto lanelet_pose = traffic_simulator::helper::constructLaneletPose(5, 10, 2, 0, 0, 0);
-  traffic_simulator::LaneletPose expected_pose;
-  expected_pose.lanelet_id = 5;
-  expected_pose.s = 10.0;
-  expected_pose.offset = 2.0;
-  expected_pose.rpy.x = 0;
-  expected_pose.rpy.y = 0;
-  expected_pose.rpy.z = 0;
-  EXPECT_LANELET_POSE_EQ(lanelet_pose, expected_pose);
-  std::stringstream ss;
-  ss << lanelet_pose;
-  EXPECT_STREQ(ss.str().c_str(), "lanelet id : 5\ns : 10");
-}
-
-TEST(HELPER, ACTION_STATUS)
-{
-  const auto action_status = traffic_simulator::helper::constructActionStatus(3, 4, 5, 1);
-  traffic_simulator_msgs::msg::ActionStatus expect_action_status;
-  expect_action_status.twist.linear.x = 3;
-  expect_action_status.twist.angular.z = 4;
-  expect_action_status.accel.linear.x = 5;
-  expect_action_status.accel.angular.z = 1;
-  EXPECT_ACTION_STATUS_EQ(action_status, expect_action_status);
-}
-
-TEST(HELPER, DETECTION_SENSOR_CONFIGURATION)
-{
-  const auto configuration =
-    traffic_simulator::helper::constructDetectionSensorConfiguration("ego", "test", 3);
-  simulation_api_schema::DetectionSensorConfiguration expect_configuration;
-  expect_configuration.set_architecture_type("test");
-  expect_configuration.set_entity("ego");
-  expect_configuration.set_update_duration(3.0);
-  EXPECT_DETECTION_SENSOR_CONFIGURATION_EQ(configuration, expect_configuration);
-}
-
-TEST(HELPER, LIDAR_SENSOR_CONFIGURATION)
+/**
+ * @note Test basic functionality. Test construction correctness of
+ * a lidar sensor with both VLP16 and VLP32 configurations.
+ */
+TEST(helper, constructLidarConfiguration)
 {
   EXPECT_NO_THROW(traffic_simulator::helper::constructLidarConfiguration(
     traffic_simulator::helper::LidarType::VLP16, "ego", "test"));
   EXPECT_NO_THROW(traffic_simulator::helper::constructLidarConfiguration(
     traffic_simulator::helper::LidarType::VLP32, "ego", "test"));
+}
+
+/**
+ * @note Test basic functionality. Test construction correctness of 
+ * a detection sensor with a given configuration.
+ */
+TEST(helper, constructDetectionSensorConfiguration)
+{
+  simulation_api_schema::DetectionSensorConfiguration actual_configuration;
+  actual_configuration.set_architecture_type("test");
+  actual_configuration.set_entity("ego");
+  actual_configuration.set_update_duration(3.0);
+
+  const auto result_configuration =
+    traffic_simulator::helper::constructDetectionSensorConfiguration("ego", "test", 3);
+
+  EXPECT_DETECTION_SENSOR_CONFIGURATION_EQ(result_configuration, actual_configuration);
 }
 
 int main(int argc, char ** argv)

--- a/simulation/traffic_simulator/test/src/helper/test_helper.cpp
+++ b/simulation/traffic_simulator/test/src/helper/test_helper.cpp
@@ -81,8 +81,10 @@ TEST(helper, constructRPYfromQuaternion)
     EXPECT_VECTOR3_EQ(default_rpy, default_vec);
   }
   {
-    const auto vec =
-      geometry_msgs::build<geometry_msgs::msg::Vector3>().x(-M_PI / 3.0).y(-M_PI / 6.0).z(M_PI / 2);
+    const auto vec = geometry_msgs::build<geometry_msgs::msg::Vector3>()
+                       .x(-M_PI / 3.0)
+                       .y(-M_PI / 6.0)
+                       .z(M_PI / 2.0);
     const auto rpy = traffic_simulator::helper::constructRPYfromQuaternion(
       geometry_msgs::build<geometry_msgs::msg::Quaternion>().x(-0.183).y(-0.5).z(0.5).w(0.683));
     EXPECT_VECTOR3_NEAR(rpy, vec, 1.0e-3);
@@ -100,8 +102,8 @@ TEST(helper, constructPose)
       .orientation(
         geometry_msgs::build<geometry_msgs::msg::Quaternion>().x(-0.183).y(-0.5).z(0.5).w(0.683));
 
-  const auto result_pose =
-    traffic_simulator::helper::constructPose(43.0, 47.0, 53.0, -M_PI / 3.0, -M_PI / 6.0, M_PI / 2);
+  const auto result_pose = traffic_simulator::helper::constructPose(
+    43.0, 47.0, 53.0, -M_PI / 3.0, -M_PI / 6.0, M_PI / 2.0);
 
   EXPECT_POSE_NEAR(result_pose, actual_pose, 1.0e-3);
 }
@@ -130,7 +132,7 @@ TEST(helper, constructDetectionSensorConfiguration)
   actual_configuration.set_update_duration(3.0);
 
   const auto result_configuration =
-    traffic_simulator::helper::constructDetectionSensorConfiguration("ego", "test", 3);
+    traffic_simulator::helper::constructDetectionSensorConfiguration("ego", "test", 3.0);
 
   EXPECT_DETECTION_SENSOR_CONFIGURATION_EQ(result_configuration, actual_configuration);
 }

--- a/simulation/traffic_simulator/test/src/simulation_clock/test_simulation_clock.cpp
+++ b/simulation/traffic_simulator/test/src/simulation_clock/test_simulation_clock.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <scenario_simulator_exception/exception.hpp>
 #include <traffic_simulator/simulation_clock/simulation_clock.hpp>
 
 /**
@@ -21,7 +22,7 @@
  * Test initialization logic by calling update without initialized clock
  * - the goal is to verify that mandatory initialization works.
  */
-TEST(SimulationClock, Initialize)
+TEST(SimulationClock, SimulationClock)
 {
   auto simulation_clock = traffic_simulator::SimulationClock(true, 1.0, 10.0);
 
@@ -31,7 +32,7 @@ TEST(SimulationClock, Initialize)
 
   EXPECT_TRUE(simulation_clock.started());
   simulation_clock.update();
-  EXPECT_THROW(simulation_clock.start(), std::runtime_error);
+  EXPECT_THROW(simulation_clock.start(), common::SimulationError);
 }
 
 /**

--- a/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light.cpp
+++ b/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light.cpp
@@ -33,7 +33,7 @@ int main(int argc, char ** argv)
 }
 
 /**
- * @note Test object creation correcness.
+ * @note Test object creation correctness.
  */
 TEST(Color, Color)
 {
@@ -144,7 +144,7 @@ TEST(Color, make_wrong)
 }
 
 /**
- * @note Test object creation correcness.
+ * @note Test object creation correctness.
  */
 TEST(Status, Status)
 {
@@ -236,7 +236,7 @@ TEST(Status, make_wrong)
 }
 
 /**
- * @note Test object creation correcness.
+ * @note Test object creation correctness.
  */
 TEST(Shape, Shape)
 {

--- a/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light.cpp
+++ b/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light.cpp
@@ -20,6 +20,12 @@
 #include <scenario_simulator_exception/exception.hpp>
 #include <traffic_simulator/traffic_lights/traffic_light.hpp>
 
+using TrafficLight = traffic_simulator::TrafficLight;
+using Color = TrafficLight::Color;
+using Status = TrafficLight::Status;
+using Shape = TrafficLight::Shape;
+using Bulb = TrafficLight::Bulb;
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
@@ -31,8 +37,6 @@ int main(int argc, char ** argv)
  */
 TEST(Color, Color)
 {
-  using Color = traffic_simulator::TrafficLight::Color;
-
   {
     const auto color = Color("green");
 
@@ -85,13 +89,12 @@ TEST(Color, Color)
  */
 TEST(Color, make)
 {
-  using Color = traffic_simulator::TrafficLight::Color;
   {
     const auto color = Color::make("green");
 
     EXPECT_TRUE(color == Color::green);
     EXPECT_TRUE(color.is(Color::green));
-    EXPECT_TRUE(boost::lexical_cast<Color>("green") == Color::green);
+    EXPECT_TRUE(boost::lexical_cast<Color>(color) == Color::green);
     EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "green");
   }
 
@@ -100,7 +103,7 @@ TEST(Color, make)
 
     EXPECT_TRUE(color == Color::yellow);
     EXPECT_TRUE(color.is(Color::yellow));
-    EXPECT_TRUE(boost::lexical_cast<Color>("yellow") == Color::yellow);
+    EXPECT_TRUE(boost::lexical_cast<Color>(color) == Color::yellow);
     EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "yellow");
   }
 
@@ -109,7 +112,7 @@ TEST(Color, make)
 
     EXPECT_TRUE(color == Color::red);
     EXPECT_TRUE(color.is(Color::red));
-    EXPECT_TRUE(boost::lexical_cast<Color>("red") == Color::red);
+    EXPECT_TRUE(boost::lexical_cast<Color>(color) == Color::red);
     EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "red");
   }
 
@@ -118,7 +121,7 @@ TEST(Color, make)
 
     EXPECT_TRUE(color == Color::white);
     EXPECT_TRUE(color.is(Color::white));
-    EXPECT_TRUE(boost::lexical_cast<Color>("white") == Color::white);
+    EXPECT_TRUE(boost::lexical_cast<Color>(color) == Color::white);
     EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "white");
   }
 
@@ -127,7 +130,7 @@ TEST(Color, make)
 
     EXPECT_TRUE(color == Color::yellow);
     EXPECT_TRUE(color.is(Color::yellow));
-    EXPECT_TRUE(boost::lexical_cast<Color>("amber") == Color::yellow);
+    EXPECT_TRUE(boost::lexical_cast<Color>(color) == Color::yellow);
     EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "yellow");
   }
 }
@@ -145,8 +148,6 @@ TEST(Color, make_wrong)
  */
 TEST(Status, Status)
 {
-  using Status = traffic_simulator::TrafficLight::Status;
-
   {
     const auto status = Status("solidOn");
 
@@ -189,14 +190,12 @@ TEST(Status, Status)
  */
 TEST(Status, make)
 {
-  using Status = traffic_simulator::TrafficLight::Status;
-
   {
     const auto status = Status::make("solidOn");
 
     EXPECT_TRUE(status == Status::solid_on);
     EXPECT_TRUE(status.is(Status::solid_on));
-    EXPECT_TRUE(boost::lexical_cast<Status>("solidOn") == Status::solid_on);
+    EXPECT_TRUE(boost::lexical_cast<Status>(status) == Status::solid_on);
     EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "solidOn");
   }
 
@@ -205,7 +204,7 @@ TEST(Status, make)
 
     EXPECT_TRUE(status == Status::solid_off);
     EXPECT_TRUE(status.is(Status::solid_off));
-    EXPECT_TRUE(boost::lexical_cast<Status>("solidOff") == Status::solid_off);
+    EXPECT_TRUE(boost::lexical_cast<Status>(status) == Status::solid_off);
     EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "solidOff");
   }
 
@@ -214,7 +213,7 @@ TEST(Status, make)
 
     EXPECT_TRUE(status == Status::flashing);
     EXPECT_TRUE(status.is(Status::flashing));
-    EXPECT_TRUE(boost::lexical_cast<Status>("flashing") == Status::flashing);
+    EXPECT_TRUE(boost::lexical_cast<Status>(status) == Status::flashing);
     EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "flashing");
   }
 
@@ -223,7 +222,7 @@ TEST(Status, make)
 
     EXPECT_TRUE(status == Status::unknown);
     EXPECT_TRUE(status.is(Status::unknown));
-    EXPECT_TRUE(boost::lexical_cast<Status>("unknown") == Status::unknown);
+    EXPECT_TRUE(boost::lexical_cast<Status>(status) == Status::unknown);
     EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "unknown");
   }
 }
@@ -241,8 +240,6 @@ TEST(Status, make_wrong)
  */
 TEST(Shape, Shape)
 {
-  using Shape = traffic_simulator::TrafficLight::Shape;
-
   {
     const auto shape = Shape("circle");
 
@@ -359,8 +356,6 @@ TEST(Shape, Shape)
  */
 TEST(Shape, make)
 {
-  using Shape = traffic_simulator::TrafficLight::Shape;
-
   {
     const auto shape = Shape::make("circle");
 
@@ -481,16 +476,10 @@ TEST(Shape, make_wrong)
 }
 
 /**
- * @note Test object creation correcness.
+ * @note Test hashing function. An object must be assigned the same hash every time.
  */
-TEST(Bulb, Bulb)
+TEST(Bulb, hash)
 {
-  using TrafficLight = traffic_simulator::TrafficLight;
-  using Color = TrafficLight::Color;
-  using Status = TrafficLight::Status;
-  using Shape = TrafficLight::Shape;
-  using Bulb = TrafficLight::Bulb;
-
   // clang-format off
   static_assert(Bulb(Color::green,  Status::solid_on,  Shape::circle     ).hash() == 0b0000'0000'0000'0000'0000'0000'0000'0000);
   static_assert(Bulb(Color::yellow, Status::solid_on,  Shape::circle     ).hash() == 0b0000'0001'0000'0000'0000'0000'0000'0000);
@@ -513,7 +502,13 @@ TEST(Bulb, Bulb)
   static_assert(Bulb(Color::green,  Status::solid_on,  Shape::lower_right).hash() == 0b0000'0000'0000'0000'0000'0101'0000'0010);
   static_assert(Bulb(Color::green,  Status::solid_on,  Shape::upper_right).hash() == 0b0000'0000'0000'0000'0000'0011'0000'0010);
   // clang-format on
+}
 
+/**
+ * @note Test basic functionality. Test Bulb comparisons with different configurations.
+ */
+TEST(Bulb, is)
+{
   {
     constexpr auto bulb = Bulb(Color::red, Status::flashing, Shape::circle);
 
@@ -583,11 +578,6 @@ TEST(Bulb, Bulb)
  */
 TEST(Bulb, make)
 {
-  using TrafficLight = traffic_simulator::TrafficLight;
-  using Color = TrafficLight::Color;
-  using Status = TrafficLight::Status;
-  using Shape = TrafficLight::Shape;
-  using Bulb = TrafficLight::Bulb;
   {
     constexpr auto bulb = Bulb(Color::red, Status::flashing, Shape::circle);
 
@@ -657,8 +647,6 @@ TEST(Bulb, make)
  */
 TEST(Bulb, make_wrong)
 {
-  using Bulb = traffic_simulator::TrafficLight::Bulb;
-
   EXPECT_THROW(Bulb("red flashing wrong_shape"), common::SyntaxError);
   EXPECT_THROW(Bulb("red wrong_status circle"), common::SyntaxError);
   EXPECT_THROW(Bulb("wrong_color flashing circle"), common::SyntaxError);
@@ -671,11 +659,6 @@ TEST(Bulb, make_wrong)
  */
 TEST(Bulb, operator_TrafficLight)
 {
-  using Color = traffic_simulator::TrafficLight::Color;
-  using Status = traffic_simulator::TrafficLight::Status;
-  using Shape = traffic_simulator::TrafficLight::Shape;
-  using Bulb = traffic_simulator::TrafficLight::Bulb;
-
   {
     constexpr auto bulb = Bulb(Color::red, Status::flashing, Shape::circle);
     std::ostringstream oss;
@@ -747,11 +730,6 @@ protected:
  */
 TEST_F(TrafficLightTest, contains_colorStatusShape)
 {
-  using TrafficLight = traffic_simulator::TrafficLight;
-  using Color = TrafficLight::Color;
-  using Status = TrafficLight::Status;
-  using Shape = TrafficLight::Shape;
-
   {
     auto traffic_light = TrafficLight(34802, map_manager);
 
@@ -779,11 +757,6 @@ TEST_F(TrafficLightTest, contains_colorStatusShape)
  */
 TEST_F(TrafficLightTest, set_valid)
 {
-  using TrafficLight = traffic_simulator::TrafficLight;
-  using Color = TrafficLight::Color;
-  using Status = TrafficLight::Status;
-  using Shape = TrafficLight::Shape;
-
   auto traffic_light = TrafficLight(34802, map_manager);
 
   traffic_light.set("red flashing circle, green solidOn right");

--- a/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light.cpp
+++ b/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light.cpp
@@ -26,7 +26,10 @@ int main(int argc, char ** argv)
   return RUN_ALL_TESTS();
 }
 
-TEST(TrafficLight, Color)
+/**
+ * @note Test object creation correcness.
+ */
+TEST(Color, Color)
 {
   using Color = traffic_simulator::TrafficLight::Color;
 
@@ -76,7 +79,71 @@ TEST(TrafficLight, Color)
   }
 }
 
-TEST(TrafficLight, Status)
+/**
+ * @note Test basic functionality. Test whether the function
+ * creates Color object appropriate to the argument.
+ */
+TEST(Color, make)
+{
+  using Color = traffic_simulator::TrafficLight::Color;
+  {
+    const auto color = Color::make("green");
+
+    EXPECT_TRUE(color == Color::green);
+    EXPECT_TRUE(color.is(Color::green));
+    EXPECT_TRUE(boost::lexical_cast<Color>("green") == Color::green);
+    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "green");
+  }
+
+  {
+    const auto color = Color::make("yellow");
+
+    EXPECT_TRUE(color == Color::yellow);
+    EXPECT_TRUE(color.is(Color::yellow));
+    EXPECT_TRUE(boost::lexical_cast<Color>("yellow") == Color::yellow);
+    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "yellow");
+  }
+
+  {
+    const auto color = Color::make("red");
+
+    EXPECT_TRUE(color == Color::red);
+    EXPECT_TRUE(color.is(Color::red));
+    EXPECT_TRUE(boost::lexical_cast<Color>("red") == Color::red);
+    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "red");
+  }
+
+  {
+    const auto color = Color::make("white");
+
+    EXPECT_TRUE(color == Color::white);
+    EXPECT_TRUE(color.is(Color::white));
+    EXPECT_TRUE(boost::lexical_cast<Color>("white") == Color::white);
+    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "white");
+  }
+
+  {
+    const auto color = Color::make("amber");
+
+    EXPECT_TRUE(color == Color::yellow);
+    EXPECT_TRUE(color.is(Color::yellow));
+    EXPECT_TRUE(boost::lexical_cast<Color>("amber") == Color::yellow);
+    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "yellow");
+  }
+}
+
+/**
+ * @note Test basic functionality. Test function behavior when called with invalid name.
+ */
+TEST(Color, make_wrong)
+{
+  EXPECT_THROW(traffic_simulator::TrafficLight::Color::make("wrong_color"), common::SyntaxError);
+}
+
+/**
+ * @note Test object creation correcness.
+ */
+TEST(Status, Status)
 {
   using Status = traffic_simulator::TrafficLight::Status;
 
@@ -117,7 +184,62 @@ TEST(TrafficLight, Status)
   }
 }
 
-TEST(TrafficLight, Shape)
+/**
+ * @note Test basic functionality. Test whether the function creates Status object appropriate to the argument.
+ */
+TEST(Status, make)
+{
+  using Status = traffic_simulator::TrafficLight::Status;
+
+  {
+    const auto status = Status::make("solidOn");
+
+    EXPECT_TRUE(status == Status::solid_on);
+    EXPECT_TRUE(status.is(Status::solid_on));
+    EXPECT_TRUE(boost::lexical_cast<Status>("solidOn") == Status::solid_on);
+    EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "solidOn");
+  }
+
+  {
+    const auto status = Status::make("solidOff");
+
+    EXPECT_TRUE(status == Status::solid_off);
+    EXPECT_TRUE(status.is(Status::solid_off));
+    EXPECT_TRUE(boost::lexical_cast<Status>("solidOff") == Status::solid_off);
+    EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "solidOff");
+  }
+
+  {
+    const auto status = Status::make("flashing");
+
+    EXPECT_TRUE(status == Status::flashing);
+    EXPECT_TRUE(status.is(Status::flashing));
+    EXPECT_TRUE(boost::lexical_cast<Status>("flashing") == Status::flashing);
+    EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "flashing");
+  }
+
+  {
+    const auto status = Status::make("unknown");
+
+    EXPECT_TRUE(status == Status::unknown);
+    EXPECT_TRUE(status.is(Status::unknown));
+    EXPECT_TRUE(boost::lexical_cast<Status>("unknown") == Status::unknown);
+    EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "unknown");
+  }
+}
+
+/**
+ * @note Test basic functionality. Test function behavior when called with invalid name.
+ */
+TEST(Status, make_wrong)
+{
+  EXPECT_THROW(traffic_simulator::TrafficLight::Status::make("wrong_status"), common::SyntaxError);
+}
+
+/**
+ * @note Test object creation correcness.
+ */
+TEST(Shape, Shape)
 {
   using Shape = traffic_simulator::TrafficLight::Shape;
 
@@ -232,204 +354,10 @@ TEST(TrafficLight, Shape)
   }
 }
 
-TEST(TrafficLight, Bulb)
-{
-  using TrafficLight = traffic_simulator::TrafficLight;
-  using Color = TrafficLight::Color;
-  using Status = TrafficLight::Status;
-  using Shape = TrafficLight::Shape;
-  using Bulb = TrafficLight::Bulb;
-
-  // clang-format off
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::circle     ).hash() == 0b0000'0000'0000'0000'0000'0000'0000'0000);
-  static_assert(Bulb(Color::yellow, Status::solid_on,  Shape::circle     ).hash() == 0b0000'0001'0000'0000'0000'0000'0000'0000);
-  static_assert(Bulb(Color::red,    Status::solid_on,  Shape::circle     ).hash() == 0b0000'0010'0000'0000'0000'0000'0000'0000);
-  static_assert(Bulb(Color::white,  Status::solid_on,  Shape::circle     ).hash() == 0b0000'0011'0000'0000'0000'0000'0000'0000);
-
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::circle     ).hash() == 0b0000'0000'0000'0000'0000'0000'0000'0000);
-  static_assert(Bulb(Color::green,  Status::solid_off, Shape::circle     ).hash() == 0b0000'0000'0000'0001'0000'0000'0000'0000);
-  static_assert(Bulb(Color::green,  Status::flashing,  Shape::circle     ).hash() == 0b0000'0000'0000'0010'0000'0000'0000'0000);
-  static_assert(Bulb(Color::green,  Status::unknown,   Shape::circle     ).hash() == 0b0000'0000'0000'0011'0000'0000'0000'0000);
-
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::circle     ).hash() == 0b0000'0000'0000'0000'0000'0000'0000'0000);
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::cross      ).hash() == 0b0000'0000'0000'0000'0000'0000'0000'0001);
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::left       ).hash() == 0b0000'0000'0000'0000'0000'1000'0000'0010);
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::down       ).hash() == 0b0000'0000'0000'0000'0000'0100'0000'0010);
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::up         ).hash() == 0b0000'0000'0000'0000'0000'0010'0000'0010);
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::right      ).hash() == 0b0000'0000'0000'0000'0000'0001'0000'0010);
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::lower_left ).hash() == 0b0000'0000'0000'0000'0000'1100'0000'0010);
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::upper_left ).hash() == 0b0000'0000'0000'0000'0000'1010'0000'0010);
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::lower_right).hash() == 0b0000'0000'0000'0000'0000'0101'0000'0010);
-  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::upper_right).hash() == 0b0000'0000'0000'0000'0000'0011'0000'0010);
-  // clang-format on
-
-  {
-    constexpr auto bulb = Bulb(Color::red, Status::flashing, Shape::circle);
-
-    EXPECT_TRUE(bulb.is(Color::red));
-    EXPECT_TRUE(bulb.is(Status::flashing));
-    EXPECT_TRUE(bulb.is(Shape::circle));
-    EXPECT_TRUE(bulb.is(Shape::Category::circle));
-  }
-
-  {
-    constexpr auto bulb = Bulb(Color::green, Status::solid_on, Shape::right);
-
-    EXPECT_TRUE(bulb.is(Color::green));
-    EXPECT_TRUE(bulb.is(Status::solid_on));
-    EXPECT_TRUE(bulb.is(Shape::right));
-    EXPECT_TRUE(bulb.is(Shape::Category::arrow));
-  }
-
-  {
-    const auto bulb = Bulb("red flashing circle");
-
-    EXPECT_TRUE(bulb.is(Color::red));
-    EXPECT_TRUE(bulb.is(Status::flashing));
-    EXPECT_TRUE(bulb.is(Shape::circle));
-    EXPECT_TRUE(bulb.is(Shape::Category::circle));
-  }
-
-  {
-    const auto bulb = Bulb("red flashing");
-
-    EXPECT_TRUE(bulb.is(Color::red));
-    EXPECT_TRUE(bulb.is(Status::flashing));
-    EXPECT_TRUE(bulb.is(Shape::circle));
-    EXPECT_TRUE(bulb.is(Shape::Category::circle));
-  }
-
-  {
-    const auto bulb = Bulb("red");
-
-    EXPECT_TRUE(bulb.is(Color::red));
-    EXPECT_TRUE(bulb.is(Status::solid_on));
-    EXPECT_TRUE(bulb.is(Shape::circle));
-    EXPECT_TRUE(bulb.is(Shape::Category::circle));
-  }
-
-  {
-    const auto bulb = Bulb("green solidOn right");
-
-    EXPECT_TRUE(bulb.is(Color::green));
-    EXPECT_TRUE(bulb.is(Status::solid_on));
-    EXPECT_TRUE(bulb.is(Shape::right));
-    EXPECT_TRUE(bulb.is(Shape::Category::arrow));
-  }
-
-  {
-    const auto bulb = Bulb("green right");
-
-    EXPECT_TRUE(bulb.is(Color::green));
-    EXPECT_TRUE(bulb.is(Status::solid_on));
-    EXPECT_TRUE(bulb.is(Shape::right));
-    EXPECT_TRUE(bulb.is(Shape::Category::arrow));
-  }
-}
-
-TEST(TrafficLight, TrafficLight)
-{
-  using TrafficLight = traffic_simulator::TrafficLight;
-  using Color = TrafficLight::Color;
-  using Status = TrafficLight::Status;
-  using Shape = TrafficLight::Shape;
-
-  hdmap_utils::HdMapUtils map_manager(
-    ament_index_cpp::get_package_share_directory("traffic_simulator") + "/map/lanelet2_map.osm",
-    []() {
-      geographic_msgs::msg::GeoPoint geo_point;
-      geo_point.latitude = 35.61836750154;
-      geo_point.longitude = 139.78066608243;
-      return geo_point;
-    }());
-
-  {
-    auto traffic_light = TrafficLight(34802, map_manager);
-
-    traffic_light.emplace(Color::red, Status::flashing, Shape::circle);
-    traffic_light.emplace(Color::green, Status::solid_on, Shape::right);
-
-    EXPECT_TRUE(traffic_light.contains(Color::red, Status::flashing, Shape::circle));
-    EXPECT_TRUE(traffic_light.contains(Color::green, Status::solid_on, Shape::right));
-  }
-
-  {
-    auto traffic_light = TrafficLight(34802, map_manager);
-
-    traffic_light.emplace("red flashing circle");
-    traffic_light.emplace("green solidOn right");
-
-    EXPECT_TRUE(traffic_light.contains(Color::red, Status::flashing, Shape::circle));
-    EXPECT_TRUE(traffic_light.contains(Color::green, Status::solid_on, Shape::right));
-  }
-
-  {
-    auto traffic_light = TrafficLight(34802, map_manager);
-
-    traffic_light.set("red flashing circle, green solidOn right");
-
-    EXPECT_TRUE(traffic_light.contains(Color::red, Status::flashing, Shape::circle));
-    EXPECT_TRUE(traffic_light.contains(Color::green, Status::solid_on, Shape::right));
-  }
-}
-
 /**
- * @note Test basic functionality. Test whether the function
- * creates Color object appropriate to the argument.
+ * @note Test basic functionality. Test whether the function creates Shape object appropriate to the argument.
  */
-TEST(TrafficLight, Color_make)
-{
-  using Color = traffic_simulator::TrafficLight::Color;
-  {
-    const auto color = Color::make("green");
-
-    EXPECT_TRUE(color == Color::green);
-    EXPECT_TRUE(color.is(Color::green));
-    EXPECT_TRUE(boost::lexical_cast<Color>("green") == Color::green);
-    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "green");
-  }
-
-  {
-    const auto color = Color::make("yellow");
-
-    EXPECT_TRUE(color == Color::yellow);
-    EXPECT_TRUE(color.is(Color::yellow));
-    EXPECT_TRUE(boost::lexical_cast<Color>("yellow") == Color::yellow);
-    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "yellow");
-  }
-
-  {
-    const auto color = Color::make("red");
-
-    EXPECT_TRUE(color == Color::red);
-    EXPECT_TRUE(color.is(Color::red));
-    EXPECT_TRUE(boost::lexical_cast<Color>("red") == Color::red);
-    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "red");
-  }
-
-  {
-    const auto color = Color::make("white");
-
-    EXPECT_TRUE(color == Color::white);
-    EXPECT_TRUE(color.is(Color::white));
-    EXPECT_TRUE(boost::lexical_cast<Color>("white") == Color::white);
-    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "white");
-  }
-
-  {
-    const auto color = Color::make("amber");
-
-    EXPECT_TRUE(color == Color::yellow);
-    EXPECT_TRUE(color.is(Color::yellow));
-    EXPECT_TRUE(boost::lexical_cast<Color>("amber") == Color::yellow);
-    EXPECT_TRUE(boost::lexical_cast<std::string>(color) == "yellow");
-  }
-}
-
-/**
- * @note Test basic functionality. Test whether the function creates Color object appropriate to the argument.
- */
-TEST(TrafficLight, Shape_make)
+TEST(Shape, make)
 {
   using Shape = traffic_simulator::TrafficLight::Shape;
 
@@ -545,53 +473,115 @@ TEST(TrafficLight, Shape_make)
 }
 
 /**
- * @note Test basic functionality. Test whether the function creates Status object appropriate to the argument.
+ * @note Test basic functionality. Test function behavior when called with invalid name. 
  */
-TEST(TrafficLight, Status_make)
+TEST(Shape, make_wrong)
 {
-  using Status = traffic_simulator::TrafficLight::Status;
+  EXPECT_THROW(traffic_simulator::TrafficLight::Shape::make("wrong_shape"), common::SyntaxError);
+}
+
+/**
+ * @note Test object creation correcness.
+ */
+TEST(Bulb, Bulb)
+{
+  using TrafficLight = traffic_simulator::TrafficLight;
+  using Color = TrafficLight::Color;
+  using Status = TrafficLight::Status;
+  using Shape = TrafficLight::Shape;
+  using Bulb = TrafficLight::Bulb;
+
+  // clang-format off
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::circle     ).hash() == 0b0000'0000'0000'0000'0000'0000'0000'0000);
+  static_assert(Bulb(Color::yellow, Status::solid_on,  Shape::circle     ).hash() == 0b0000'0001'0000'0000'0000'0000'0000'0000);
+  static_assert(Bulb(Color::red,    Status::solid_on,  Shape::circle     ).hash() == 0b0000'0010'0000'0000'0000'0000'0000'0000);
+  static_assert(Bulb(Color::white,  Status::solid_on,  Shape::circle     ).hash() == 0b0000'0011'0000'0000'0000'0000'0000'0000);
+
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::circle     ).hash() == 0b0000'0000'0000'0000'0000'0000'0000'0000);
+  static_assert(Bulb(Color::green,  Status::solid_off, Shape::circle     ).hash() == 0b0000'0000'0000'0001'0000'0000'0000'0000);
+  static_assert(Bulb(Color::green,  Status::flashing,  Shape::circle     ).hash() == 0b0000'0000'0000'0010'0000'0000'0000'0000);
+  static_assert(Bulb(Color::green,  Status::unknown,   Shape::circle     ).hash() == 0b0000'0000'0000'0011'0000'0000'0000'0000);
+
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::circle     ).hash() == 0b0000'0000'0000'0000'0000'0000'0000'0000);
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::cross      ).hash() == 0b0000'0000'0000'0000'0000'0000'0000'0001);
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::left       ).hash() == 0b0000'0000'0000'0000'0000'1000'0000'0010);
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::down       ).hash() == 0b0000'0000'0000'0000'0000'0100'0000'0010);
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::up         ).hash() == 0b0000'0000'0000'0000'0000'0010'0000'0010);
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::right      ).hash() == 0b0000'0000'0000'0000'0000'0001'0000'0010);
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::lower_left ).hash() == 0b0000'0000'0000'0000'0000'1100'0000'0010);
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::upper_left ).hash() == 0b0000'0000'0000'0000'0000'1010'0000'0010);
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::lower_right).hash() == 0b0000'0000'0000'0000'0000'0101'0000'0010);
+  static_assert(Bulb(Color::green,  Status::solid_on,  Shape::upper_right).hash() == 0b0000'0000'0000'0000'0000'0011'0000'0010);
+  // clang-format on
 
   {
-    const auto status = Status::make("solidOn");
+    constexpr auto bulb = Bulb(Color::red, Status::flashing, Shape::circle);
 
-    EXPECT_TRUE(status == Status::solid_on);
-    EXPECT_TRUE(status.is(Status::solid_on));
-    EXPECT_TRUE(boost::lexical_cast<Status>("solidOn") == Status::solid_on);
-    EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "solidOn");
+    EXPECT_TRUE(bulb.is(Color::red));
+    EXPECT_TRUE(bulb.is(Status::flashing));
+    EXPECT_TRUE(bulb.is(Shape::circle));
+    EXPECT_TRUE(bulb.is(Shape::Category::circle));
   }
 
   {
-    const auto status = Status::make("solidOff");
+    constexpr auto bulb = Bulb(Color::green, Status::solid_on, Shape::right);
 
-    EXPECT_TRUE(status == Status::solid_off);
-    EXPECT_TRUE(status.is(Status::solid_off));
-    EXPECT_TRUE(boost::lexical_cast<Status>("solidOff") == Status::solid_off);
-    EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "solidOff");
+    EXPECT_TRUE(bulb.is(Color::green));
+    EXPECT_TRUE(bulb.is(Status::solid_on));
+    EXPECT_TRUE(bulb.is(Shape::right));
+    EXPECT_TRUE(bulb.is(Shape::Category::arrow));
   }
 
   {
-    const auto status = Status::make("flashing");
+    const auto bulb = Bulb("red flashing circle");
 
-    EXPECT_TRUE(status == Status::flashing);
-    EXPECT_TRUE(status.is(Status::flashing));
-    EXPECT_TRUE(boost::lexical_cast<Status>("flashing") == Status::flashing);
-    EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "flashing");
+    EXPECT_TRUE(bulb.is(Color::red));
+    EXPECT_TRUE(bulb.is(Status::flashing));
+    EXPECT_TRUE(bulb.is(Shape::circle));
+    EXPECT_TRUE(bulb.is(Shape::Category::circle));
   }
 
   {
-    const auto status = Status::make("unknown");
+    const auto bulb = Bulb("red flashing");
 
-    EXPECT_TRUE(status == Status::unknown);
-    EXPECT_TRUE(status.is(Status::unknown));
-    EXPECT_TRUE(boost::lexical_cast<Status>("unknown") == Status::unknown);
-    EXPECT_TRUE(boost::lexical_cast<std::string>(status) == "unknown");
+    EXPECT_TRUE(bulb.is(Color::red));
+    EXPECT_TRUE(bulb.is(Status::flashing));
+    EXPECT_TRUE(bulb.is(Shape::circle));
+    EXPECT_TRUE(bulb.is(Shape::Category::circle));
+  }
+
+  {
+    const auto bulb = Bulb("red");
+
+    EXPECT_TRUE(bulb.is(Color::red));
+    EXPECT_TRUE(bulb.is(Status::solid_on));
+    EXPECT_TRUE(bulb.is(Shape::circle));
+    EXPECT_TRUE(bulb.is(Shape::Category::circle));
+  }
+
+  {
+    const auto bulb = Bulb("green solidOn right");
+
+    EXPECT_TRUE(bulb.is(Color::green));
+    EXPECT_TRUE(bulb.is(Status::solid_on));
+    EXPECT_TRUE(bulb.is(Shape::right));
+    EXPECT_TRUE(bulb.is(Shape::Category::arrow));
+  }
+
+  {
+    const auto bulb = Bulb("green right");
+
+    EXPECT_TRUE(bulb.is(Color::green));
+    EXPECT_TRUE(bulb.is(Status::solid_on));
+    EXPECT_TRUE(bulb.is(Shape::right));
+    EXPECT_TRUE(bulb.is(Shape::Category::arrow));
   }
 }
 
 /**
- * @note Test basic functionality. Test whether the function creates Color object appropriate to the argument.
+ * @note Test basic functionality. Test whether the function creates Bulb object appropriate to the argument.
  */
-TEST(TrafficLight, Bulb_make)
+TEST(Bulb, make)
 {
   using TrafficLight = traffic_simulator::TrafficLight;
   using Color = TrafficLight::Color;
@@ -663,10 +653,23 @@ TEST(TrafficLight, Bulb_make)
 }
 
 /**
+ * @note Test basic functionality. Test function behavior when called with invalid name.
+ */
+TEST(Bulb, make_wrong)
+{
+  using Bulb = traffic_simulator::TrafficLight::Bulb;
+
+  EXPECT_THROW(Bulb("red flashing wrong_shape"), common::SyntaxError);
+  EXPECT_THROW(Bulb("red wrong_status circle"), common::SyntaxError);
+  EXPECT_THROW(Bulb("wrong_color flashing circle"), common::SyntaxError);
+  EXPECT_THROW(Bulb("wrong_color wrong_status wrong_shape"), common::SyntaxError);
+}
+
+/**
  * @note Test basic functionality. Test whether the TrafficLight message
  * is constructed configured according to the Bulb object.
  */
-TEST(TrafficLight, Bulb_trafficLightMessageConversion)
+TEST(Bulb, operator_TrafficLight)
 {
   using Color = traffic_simulator::TrafficLight::Color;
   using Status = traffic_simulator::TrafficLight::Status;
@@ -723,39 +726,68 @@ TEST(TrafficLight, Bulb_trafficLightMessageConversion)
   }
 }
 
-/**
- * @note Test basic functionality. Test function behavior when called with invalid name.
- */
-TEST(TrafficLight, Color_make_wrong)
+class TrafficLightTest : public testing::Test
 {
-  EXPECT_THROW(traffic_simulator::TrafficLight::Color::make("wrong_color"), common::SyntaxError);
+protected:
+  TrafficLightTest()
+  : map_manager(
+      ament_index_cpp::get_package_share_directory("traffic_simulator") + "/map/lanelet2_map.osm",
+      geographic_msgs::build<geographic_msgs::msg::GeoPoint>()
+        .latitude(35.61836750154)
+        .longitude(139.78066608243)
+        .altitude(0.0))
+  {
+  }
+  hdmap_utils::HdMapUtils map_manager;
+};
+
+/**
+ * @note test if function correctly determines if a given bulb
+ * is in the bulbs vector given a Color, Status, Shape triple.
+ */
+TEST_F(TrafficLightTest, contains_colorStatusShape)
+{
+  using TrafficLight = traffic_simulator::TrafficLight;
+  using Color = TrafficLight::Color;
+  using Status = TrafficLight::Status;
+  using Shape = TrafficLight::Shape;
+
+  {
+    auto traffic_light = TrafficLight(34802, map_manager);
+
+    traffic_light.bulbs.emplace(Color::red, Status::flashing, Shape::circle);
+    traffic_light.bulbs.emplace(Color::green, Status::solid_on, Shape::right);
+
+    ASSERT_TRUE(traffic_light.bulbs.size() == static_cast<std::size_t>(2));
+    EXPECT_TRUE(traffic_light.contains(Color::red, Status::flashing, Shape::circle));
+    EXPECT_TRUE(traffic_light.contains(Color::green, Status::solid_on, Shape::right));
+  }
+
+  {
+    auto traffic_light = TrafficLight(34802, map_manager);
+
+    traffic_light.bulbs.emplace("red flashing circle");
+    traffic_light.bulbs.emplace("green solidOn right");
+
+    EXPECT_TRUE(traffic_light.contains(Color::red, Status::flashing, Shape::circle));
+    EXPECT_TRUE(traffic_light.contains(Color::green, Status::solid_on, Shape::right));
+  }
 }
 
 /**
- * @note Test basic functionality. Test function behavior when called with invalid name. 
+ * @note Test function behavior with a valid string.
  */
-TEST(TrafficLight, Shape_make_wrong)
+TEST_F(TrafficLightTest, set_valid)
 {
-  EXPECT_THROW(traffic_simulator::TrafficLight::Shape::make("wrong_shape"), common::SyntaxError);
-}
+  using TrafficLight = traffic_simulator::TrafficLight;
+  using Color = TrafficLight::Color;
+  using Status = TrafficLight::Status;
+  using Shape = TrafficLight::Shape;
 
-/**
- * @note Test basic functionality. Test function behavior when called with invalid name.
- */
-TEST(TrafficLight, Status_make_wrong)
-{
-  EXPECT_THROW(traffic_simulator::TrafficLight::Status::make("wrong_status"), common::SyntaxError);
-}
+  auto traffic_light = TrafficLight(34802, map_manager);
 
-/**
- * @note Test basic functionality. Test function behavior when called with invalid name.
- */
-TEST(TrafficLight, Bulb_make_wrong)
-{
-  using Bulb = traffic_simulator::TrafficLight::Bulb;
+  traffic_light.set("red flashing circle, green solidOn right");
 
-  EXPECT_THROW(Bulb("red flashing wrong_shape"), common::SyntaxError);
-  EXPECT_THROW(Bulb("red wrong_status circle"), common::SyntaxError);
-  EXPECT_THROW(Bulb("wrong_color flashing circle"), common::SyntaxError);
-  EXPECT_THROW(Bulb("wrong_color wrong_status wrong_shape"), common::SyntaxError);
+  EXPECT_TRUE(traffic_light.contains(Color::red, Status::flashing, Shape::circle));
+  EXPECT_TRUE(traffic_light.contains(Color::green, Status::solid_on, Shape::right));
 }

--- a/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light_manager.cpp
+++ b/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light_manager.cpp
@@ -18,15 +18,33 @@
 #include <scenario_simulator_exception/exception.hpp>
 #include <traffic_simulator/traffic_lights/traffic_light_manager.hpp>
 
-TEST(TrafficLightManager, getIds)
+class TrafficLightManagerTest : public testing::Test
 {
-  std::string path =
-    ament_index_cpp::get_package_share_directory("traffic_simulator") + "/map/lanelet2_map.osm";
-  geographic_msgs::msg::GeoPoint origin;
-  origin.latitude = 35.61836750154;
-  origin.longitude = 139.78066608243;
-  const auto hdmap_utils_ptr = std::make_shared<hdmap_utils::HdMapUtils>(path, origin);
-  traffic_simulator::TrafficLightManager manager(hdmap_utils_ptr);
+protected:
+  TrafficLightManagerTest()
+  : manager(std::make_shared<hdmap_utils::HdMapUtils>(
+      ament_index_cpp::get_package_share_directory("traffic_simulator") + "/map/lanelet2_map.osm",
+      geographic_msgs::build<geographic_msgs::msg::GeoPoint>()
+        .latitude(35.61836750154)
+        .longitude(139.78066608243)
+        .altitude(0.0)))
+  {
+  }
+  traffic_simulator::TrafficLightManager manager;
+};
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+/**
+ * @note Test basic functionality. Test obtaining traffic light functionality
+ * with a non-existant laneletId. A traffic light should be created.
+ */
+TEST_F(TrafficLightManagerTest, getTrafficLight)
+{
   manager.getTrafficLight(34836);
   EXPECT_FALSE(manager.getTrafficLights().find(34836) == std::end(manager.getTrafficLights()));
   manager.getTrafficLight(34802);
@@ -34,19 +52,15 @@ TEST(TrafficLightManager, getIds)
   EXPECT_EQ(manager.getTrafficLights().size(), static_cast<std::size_t>(2));
 }
 
-TEST(TrafficLightManager, setColor)
+/**
+ * @note Test basic functionality. Test adding a bulb to a specific traffic light with only a color specified.
+ */
+TEST_F(TrafficLightManagerTest, getTrafficLights_setColor)
 {
-  std::string path =
-    ament_index_cpp::get_package_share_directory("traffic_simulator") + "/map/lanelet2_map.osm";
-  geographic_msgs::msg::GeoPoint origin;
-  origin.latitude = 35.61836750154;
-  origin.longitude = 139.78066608243;
-  const auto hdmap_utils_ptr = std::make_shared<hdmap_utils::HdMapUtils>(path, origin);
-  traffic_simulator::TrafficLightManager manager(hdmap_utils_ptr);
+  using Color = traffic_simulator::TrafficLight::Color;
+  using Status = traffic_simulator::TrafficLight::Status;
+  using Shape = traffic_simulator::TrafficLight::Shape;
   for (const auto & [id, traffic_light] : manager.getTrafficLights()) {
-    using Color = traffic_simulator::TrafficLight::Color;
-    using Status = traffic_simulator::TrafficLight::Status;
-    using Shape = traffic_simulator::TrafficLight::Shape;
     manager.getTrafficLight(id).clear();
     manager.getTrafficLight(id).emplace(Color::green);
     EXPECT_TRUE(
@@ -61,19 +75,15 @@ TEST(TrafficLightManager, setColor)
   }
 }
 
-TEST(TrafficLightManager, setArrow)
+/**
+ * @note Test basic functionality. Test adding a bulb to a specific traffic light with all parameters specified.
+ */
+TEST_F(TrafficLightManagerTest, getTrafficLights_setArrow)
 {
-  std::string path =
-    ament_index_cpp::get_package_share_directory("traffic_simulator") + "/map/lanelet2_map.osm";
-  geographic_msgs::msg::GeoPoint origin;
-  origin.latitude = 35.61836750154;
-  origin.longitude = 139.78066608243;
-  const auto hdmap_utils_ptr = std::make_shared<hdmap_utils::HdMapUtils>(path, origin);
-  traffic_simulator::TrafficLightManager manager(hdmap_utils_ptr);
+  using Color = traffic_simulator::TrafficLight::Color;
+  using Status = traffic_simulator::TrafficLight::Status;
+  using Shape = traffic_simulator::TrafficLight::Shape;
   for (const auto & [id, traffic_light] : manager.getTrafficLights()) {
-    using Color = traffic_simulator::TrafficLight::Color;
-    using Status = traffic_simulator::TrafficLight::Status;
-    using Shape = traffic_simulator::TrafficLight::Shape;
     manager.getTrafficLight(id).clear();
     manager.getTrafficLight(id).emplace(Color::green, Status::solid_on, Shape::left);
     EXPECT_TRUE(manager.getTrafficLight(id).contains(Color::green, Status::solid_on, Shape::left));
@@ -85,10 +95,4 @@ TEST(TrafficLightManager, setArrow)
     manager.getTrafficLight(id).emplace(Color::green, Status::solid_on, Shape::up);
     EXPECT_TRUE(manager.getTrafficLight(id).contains(Color::green, Status::solid_on, Shape::up));
   }
-}
-
-int main(int argc, char ** argv)
-{
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
 }

--- a/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light_manager.cpp
+++ b/simulation/traffic_simulator/test/src/traffic_lights/test_traffic_light_manager.cpp
@@ -20,7 +20,6 @@
 
 TEST(TrafficLightManager, getIds)
 {
-  const auto node = std::make_shared<rclcpp::Node>("getIds");
   std::string path =
     ament_index_cpp::get_package_share_directory("traffic_simulator") + "/map/lanelet2_map.osm";
   geographic_msgs::msg::GeoPoint origin;
@@ -37,7 +36,6 @@ TEST(TrafficLightManager, getIds)
 
 TEST(TrafficLightManager, setColor)
 {
-  const auto node = std::make_shared<rclcpp::Node>("setColor");
   std::string path =
     ament_index_cpp::get_package_share_directory("traffic_simulator") + "/map/lanelet2_map.osm";
   geographic_msgs::msg::GeoPoint origin;
@@ -65,7 +63,6 @@ TEST(TrafficLightManager, setColor)
 
 TEST(TrafficLightManager, setArrow)
 {
-  const auto node = std::make_shared<rclcpp::Node>("setArrow");
   std::string path =
     ament_index_cpp::get_package_share_directory("traffic_simulator") + "/map/lanelet2_map.osm";
   geographic_msgs::msg::GeoPoint origin;
@@ -93,6 +90,5 @@ TEST(TrafficLightManager, setArrow)
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  rclcpp::init(argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
# Description

## Abstract

This PR contains revisions of the traffic_simulator package unit tests.

## Details
Changes are minimal, their main purpose is to unify the source code with previously adopted rules.
Tests have been sorted.
Tests that have been refactored, now contain descriptions.

List of tests updated in this PR:
1. helper.constructActionStatus
2. helper.constructLaneletPose
3. helper.constructRPY
4. helper.constructRPYfromQuaternion
5. helper.constructPose
6. helper.constructLidarConfiguration
7. helper.constructDetectionSensorConfiguration
8. SimulationClock.SimulationClock
9. TrafficLightManager.getTrafficLight
10. TrafficLightManager.getTrafficLights_setColor
11. TrafficLightManager.getTrafficLights_setArrow
12. Color.Color
13. Color.make
14. Color.make_wrong
15. Status.Status
16. Status.make
17. Status.make_wrong
18. Shape.Shape
19. Shape.make
20. Shape.make_wrong
21. Bulb.Bulb
22. Bulb.make
23. Bulb.make_wrong
24. Bulb.operator_TrafficLight
25. TrafficLight.contains_colorStatusShape
26. TrafficLight.set_valid



## References
Jira ticket: [internal link](https://tier4.atlassian.net/browse/RJD-1278)

# Destructive Changes

There are no destructive changes.