### PR TITLE
Avoid false detection of newline character literals by spell check.

### DIFF
--- a/test_runner/random_test_runner/include/random_test_runner/data_types.hpp
+++ b/test_runner/random_test_runner/include/random_test_runner/data_types.hpp
@@ -166,7 +166,7 @@ struct fmt::formatter<TestDescription>
     fmt::format_to(
       ctx.out(),
       "ego_start_position: {} ego_goal_position: {} "
-      "ego_goal_pose: {}\n"  // The spell checker detects the string "\nnpc" as an illegal word "nnpc", so it is necessary to split the string like this.
+      "ego_goal_pose: {}\n"  // The spell checker detects the string as an illegal word, so it is necessary to split the string like this.
       "npc_descriptions:",
       v.ego_start_position, v.ego_goal_position, v.ego_goal_pose);
     for (size_t idx = 0; idx < v.npcs_descriptions.size(); idx++) {

--- a/test_runner/random_test_runner/include/random_test_runner/data_types.hpp
+++ b/test_runner/random_test_runner/include/random_test_runner/data_types.hpp
@@ -166,7 +166,7 @@ struct fmt::formatter<TestDescription>
     fmt::format_to(
       ctx.out(),
       "ego_start_position: {} ego_goal_position: {} "
-      "ego_goal_pose: {}\n"  //
+      "ego_goal_pose: {}\n"  // The spell checker detects the string "\nnpc" as an illegal word "nnpc", so it is necessary to split the string like this.
       "npc_descriptions:",
       v.ego_start_position, v.ego_goal_position, v.ego_goal_pose);
     for (size_t idx = 0; idx < v.npcs_descriptions.size(); idx++) {

--- a/test_runner/random_test_runner/include/random_test_runner/data_types.hpp
+++ b/test_runner/random_test_runner/include/random_test_runner/data_types.hpp
@@ -166,7 +166,8 @@ struct fmt::formatter<TestDescription>
     fmt::format_to(
       ctx.out(),
       "ego_start_position: {} ego_goal_position: {} "
-      "ego_goal_pose: {}\nnpc_descriptions:",
+      "ego_goal_pose: {}\n"  //
+      "npc_descriptions:",
       v.ego_start_position, v.ego_goal_position, v.ego_goal_pose);
     for (size_t idx = 0; idx < v.npcs_descriptions.size(); idx++) {
       fmt::format_to(ctx.out(), "[{}]: {}\n", idx, v.npcs_descriptions[idx]);


### PR DESCRIPTION
# Description

## Abstract

Split the string “\nnpc” into “\n” and “npc”.

## Background

The spell checker detects the string “\nnpc” as an unknown word “nnpc”.

## Details

None.

## References

[Example of false positives.](https://github.com/tier4/scenario_simulator_v2/actions/runs/10449153262/job/28930899503?pr=1335)

# Destructive Changes

None.

# Known Limitations

None.
