### PR TITLE
Fix longitudinal dintance calculation with lane-change in `HdMapUtils::getLongitudinalDistance`

### DIFF
--- a/simulation/traffic_simulator/package.xml
+++ b/simulation/traffic_simulator/package.xml
@@ -51,6 +51,7 @@
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_pep257</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>kashiwanoha_map</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -1560,9 +1560,9 @@ auto HdMapUtils::getLongitudinalDistance(
 
       /// @note "first lanelet before the lane change" case
       if (route[i] == from.lanelet_id) {
-        distance += getLaneletLength(route[i + 1]) - from.s;
+        distance -= from.s;
         if (route[i + 1] == to.lanelet_id) {
-          distance -= getLaneletLength(route[i + 1]) - to.s;
+          distance += to.s;
           return distance;
         }
       }

--- a/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
+++ b/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
@@ -109,6 +109,21 @@ protected:
 
   hdmap_utils::HdMapUtils hdmap_utils;
 };
+class HdMapUtilsTest_KashiwanohaMap : public testing::Test
+{
+protected:
+  HdMapUtilsTest_KashiwanohaMap()
+  : hdmap_utils(hdmap_utils::HdMapUtils(
+      ament_index_cpp::get_package_share_directory("kashiwanoha_map") + "/map/lanelet2_map.osm",
+      geographic_msgs::build<geographic_msgs::msg::GeoPoint>()
+        .latitude(0.0)
+        .longitude(0.0)
+        .altitude(0.0)))
+  {
+  }
+
+  hdmap_utils::HdMapUtils hdmap_utils;
+};
 /**
  * @note Test basic functionality.
  * Test initialization correctness with a correct path to a lanelet map.
@@ -2022,6 +2037,19 @@ TEST_F(HdMapUtilsTest_FourTrackHighwayMap, getLongitudinalDistance_differentLane
 
   EXPECT_FALSE(
     hdmap_utils.getLongitudinalDistance(pose_from.value(), pose_to.value(), false).has_value());
+}
+
+/**
+ * @note Test for the corner-case fixed in https://github.com/tier4/scenario_simulator_v2/pull/1348.
+ */
+TEST_F(HdMapUtilsTest_KashiwanohaMap, getLongitudinalDistance_PullRequest1348)
+{
+  auto pose_from = traffic_simulator::helper::constructLaneletPose(34468, 10.0);
+  auto pose_to = traffic_simulator::helper::constructLaneletPose(34795, 5.0);
+
+  EXPECT_NO_THROW(EXPECT_DOUBLE_EQ(
+    hdmap_utils.getLongitudinalDistance(pose_from, pose_to, true).value(),
+    54.18867466433655977198213804513216018676757812500000));
 }
 
 /**

--- a/test_runner/scenario_test_runner/scenario/ByEntityCondition.EntityCondition.DistanceCondition.Shortest.yaml
+++ b/test_runner/scenario_test_runner/scenario/ByEntityCondition.EntityCondition.DistanceCondition.Shortest.yaml
@@ -92,6 +92,17 @@ OpenSCENARIO:
                       offset: 0
                       Orientation: *DEFAULT_ORIENTATION
               - LongitudinalAction: *SPEED_ACTION_ZERO
+          - entityRef: car_4
+            PrivateAction:
+              - TeleportAction:
+                  Position: &POSITION_4
+                    LanePosition:
+                      roadId: ""
+                      laneId: 34795
+                      s: 5
+                      offset: 0
+                      Orientation: *DEFAULT_ORIENTATION
+              - LongitudinalAction: *SPEED_ACTION_ZERO
     Story:
       - name: story
         Act:
@@ -582,6 +593,24 @@ OpenSCENARIO:
                                         routingAlgorithm: shortest
                                         rule: notEqualTo
                                         value: 1.262040583529198123358128214022
+                            - Condition:
+                                - name: "corner case fixed in #1348"
+                                  delay: 0
+                                  conditionEdge: none
+                                  ByEntityCondition:
+                                    TriggeringEntities:
+                                      triggeringEntitiesRule: all
+                                      EntityRef:
+                                        - entityRef: car_1
+                                    EntityCondition:
+                                      RelativeDistanceCondition:
+                                        coordinateSystem: lane
+                                        entityRef: car_4
+                                        freespace: false
+                                        relativeDistanceType: longitudinal
+                                        routingAlgorithm: shortest
+                                        rule: notEqualTo
+                                        value: 54.18867466433655977198213804513216018676757812500000
             StartTrigger:
               ConditionGroup:
                 - Condition:


### PR DESCRIPTION
# Description

## Abstract

Fix longitudinal dintance calculation with lane-change in `HdMapUtils::getLongitudinalDistance`

## Details

In previous implementation of  `HdMapUtils::getLongitudinalDistance`, the function performed wrong longitudinal distance when the route has a lane change between first and second lanelet.

The calculation method is as [described in the documentation](https://tier4.github.io/scenario_simulator_v2-docs/developer_guide/DistanceCalculation/#appendix-first-lanelet-before-the-lane-change), but the implementation contained a miss, so I will fix it in this pull-request.

### scenario test behavior 

I added the bugged case to [ByEntityCondition.EntityCondition.DistanceCondition.Shortest.yaml](https://github.com/tier4/scenario_simulator_v2/pull/1348/files#diff-7527c01f989b824fa603f3c2fea0e1343d4b9417d30c341a1647f7b08d48009c)
Before this pull_request, the relative longitudinal distance between Npc1 and Npc4 is calculated to about 113, as executed [here](https://github.com/tier4/scenario_simulator_v2/actions/runs/10486229400/job/29044006066?pr=1348#step:14:393).
But after this pull-request, it is calculated to about 54, as defined in the test scenario. 

![image](https://github.com/user-attachments/assets/cdcb0abc-8a57-48b0-bd13-a8e2f1fab827)


## References

[Regression Test: OK](https://github.com/tier4/sim_evaluation_tools/issues/329)

# Destructive Changes

None

# Known Limitations

None