### PR TITLE
Feature/ros2 parameter forwarding

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/api/configuration.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/api/configuration.hpp
@@ -16,7 +16,6 @@
 #define TRAFFIC_SIMULATOR__API__CONFIGURATION_HPP_
 
 #include <algorithm>
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/range/iterator_range.hpp>

--- a/simulation/traffic_simulator/include/traffic_simulator/api/configuration.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/api/configuration.hpp
@@ -65,10 +65,6 @@ struct Configuration
 
   Pathname scenario_path = "";
 
-  Pathname rviz_config_path =  //
-    ament_index_cpp::get_package_share_directory("traffic_simulator") +
-    "/config/scenario_simulator_v2.rviz";
-
   explicit Configuration(const Pathname & map_path)  //
   : map_path(assertMapPath(map_path)),
     lanelet2_map_file(findLexicographicallyFirstFilenameOf(map_path, ".osm")),

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -41,8 +41,6 @@ auto EgoEntity::makeFieldOperatorApplication(
   if (const auto architecture_type =
         getParameter<std::string>(node_parameters, "architecture_type", "awf/universe");
       architecture_type.find("awf/universe") != std::string::npos) {
-    auto boolalpha = [](bool value) { return std::string(value ? "true" : "false"); };
-
     auto parameters = getParameter<std::vector<std::string>>(node_parameters, "autoware.", {});
 
     // clang-format off
@@ -54,8 +52,8 @@ auto EgoEntity::makeFieldOperatorApplication(
     parameters.push_back("rviz_config:=" + getParameter<std::string>(node_parameters, "rviz_config"));
     parameters.push_back("scenario_simulation:=true");
     parameters.push_back("use_foa:=false");
-    parameters.push_back("perception/enable_traffic_light:=" + boolalpha(architecture_type >= "awf/universe/20230906"));
-    parameters.push_back("use_sim_time:=" + boolalpha(getParameter<bool>(node_parameters, "use_sim_time", false)));
+    parameters.push_back("perception/enable_traffic_light:=" + std::string(architecture_type >= "awf/universe/20230906" ? "true" : "false"));
+    parameters.push_back("use_sim_time:=" + std::string(getParameter<bool>(node_parameters, "use_sim_time", false) ? "true" : "false"));
     // clang-format on
 
     return getParameter<bool>(node_parameters, "launch_autoware", true)

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -41,8 +41,6 @@ auto EgoEntity::makeFieldOperatorApplication(
   if (const auto architecture_type =
         getParameter<std::string>(node_parameters, "architecture_type", "awf/universe");
       architecture_type.find("awf/universe") != std::string::npos) {
-    const auto rviz_config = getParameter<std::string>(node_parameters, "rviz_config", "");
-
     auto parameters = getParameter<std::vector<std::string>>(node_parameters, "autoware.", {});
 
     // clang-format off
@@ -51,7 +49,7 @@ auto EgoEntity::makeFieldOperatorApplication(
     parameters.push_back("pointcloud_map_file:=" + configuration.getPointCloudMapFile());
     parameters.push_back("sensor_model:=" + getParameter<std::string>(node_parameters, "sensor_model"));
     parameters.push_back("vehicle_model:=" + getParameter<std::string>(node_parameters, "vehicle_model"));
-    parameters.push_back("rviz_config:=" + (rviz_config.empty() ? configuration.rviz_config_path.string() : rviz_config));
+    parameters.push_back("rviz_config:=" + getParameter<std::string>(node_parameters, "rviz_config"));
     parameters.push_back("scenario_simulation:=true");
     parameters.push_back("use_foa:=false");
     parameters.push_back("perception/enable_traffic_light:=" + std::string((architecture_type >= "awf/universe/20230906") ? "true" : "false"));

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -41,6 +41,8 @@ auto EgoEntity::makeFieldOperatorApplication(
   if (const auto architecture_type =
         getParameter<std::string>(node_parameters, "architecture_type", "awf/universe");
       architecture_type.find("awf/universe") != std::string::npos) {
+    auto boolalpha = [](bool value) { return std::string(value ? "true" : "false"); };
+
     auto parameters = getParameter<std::vector<std::string>>(node_parameters, "autoware.", {});
 
     // clang-format off
@@ -52,8 +54,8 @@ auto EgoEntity::makeFieldOperatorApplication(
     parameters.push_back("rviz_config:=" + getParameter<std::string>(node_parameters, "rviz_config"));
     parameters.push_back("scenario_simulation:=true");
     parameters.push_back("use_foa:=false");
-    parameters.push_back("perception/enable_traffic_light:=" + std::string((architecture_type >= "awf/universe/20230906") ? "true" : "false"));
-    parameters.push_back("use_sim_time:=" + std::string(getParameter<bool>(node_parameters, "use_sim_time", false) ? "true" : "false"));
+    parameters.push_back("perception/enable_traffic_light:=" + boolalpha(architecture_type >= "awf/universe/20230906"));
+    parameters.push_back("use_sim_time:=" + boolalpha(getParameter<bool>(node_parameters, "use_sim_time", false)));
     // clang-format on
 
     return getParameter<bool>(node_parameters, "launch_autoware", true)

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -41,26 +41,28 @@ auto EgoEntity::makeFieldOperatorApplication(
   if (const auto architecture_type =
         getParameter<std::string>(node_parameters, "architecture_type", "awf/universe");
       architecture_type.find("awf/universe") != std::string::npos) {
-    std::string rviz_config = getParameter<std::string>(node_parameters, "rviz_config", "");
+    const auto rviz_config = getParameter<std::string>(node_parameters, "rviz_config", "");
+
+    auto parameters = getParameter<std::vector<std::string>>(node_parameters, "autoware.", {});
+
+    // clang-format off
+    parameters.push_back("map_path:=" + configuration.map_path.string());
+    parameters.push_back("lanelet2_map_file:=" + configuration.getLanelet2MapFile());
+    parameters.push_back("pointcloud_map_file:=" + configuration.getPointCloudMapFile());
+    parameters.push_back("sensor_model:=" + getParameter<std::string>(node_parameters, "sensor_model"));
+    parameters.push_back("vehicle_model:=" + getParameter<std::string>(node_parameters, "vehicle_model"));
+    parameters.push_back("rviz_config:=" + (rviz_config.empty() ? configuration.rviz_config_path.string() : rviz_config));
+    parameters.push_back("scenario_simulation:=true");
+    parameters.push_back("use_foa:=false");
+    parameters.push_back("perception/enable_traffic_light:=" + std::string((architecture_type >= "awf/universe/20230906") ? "true" : "false"));
+    parameters.push_back("use_sim_time:=" + std::string(getParameter<bool>(node_parameters, "use_sim_time", false) ? "true" : "false"));
+    // clang-format on
+
     return getParameter<bool>(node_parameters, "launch_autoware", true)
              ? std::make_unique<
                  concealer::FieldOperatorApplicationFor<concealer::AutowareUniverse>>(
                  getParameter<std::string>(node_parameters, "autoware_launch_package"),
-                 getParameter<std::string>(node_parameters, "autoware_launch_file"),
-                 "map_path:=" + configuration.map_path.string(),
-                 "lanelet2_map_file:=" + configuration.getLanelet2MapFile(),
-                 "pointcloud_map_file:=" + configuration.getPointCloudMapFile(),
-                 "sensor_model:=" + getParameter<std::string>(node_parameters, "sensor_model"),
-                 "vehicle_model:=" + getParameter<std::string>(node_parameters, "vehicle_model"),
-                 "rviz_config:=" + ((rviz_config == "")
-                                      ? configuration.rviz_config_path.string()
-                                      : Configuration::Pathname(rviz_config).string()),
-                 "scenario_simulation:=true", "use_foa:=false",
-                 "perception/enable_traffic_light:=" +
-                   std::string((architecture_type >= "awf/universe/20230906") ? "true" : "false"),
-                 "use_sim_time:=" +
-                   std::string(
-                     getParameter<bool>(node_parameters, "use_sim_time", false) ? "true" : "false"))
+                 getParameter<std::string>(node_parameters, "autoware_launch_file"), parameters)
              : std::make_unique<
                  concealer::FieldOperatorApplicationFor<concealer::AutowareUniverse>>();
   } else {

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -137,27 +137,25 @@ def launch_setup(context, *args, **kwargs):
             {"vehicle_model": vehicle_model},
         ]
 
-        parameters += make_vehicle_parameters()
+        def collect_vehicle_parameters():
+            if vehicle_model_name := vehicle_model.perform(context):
+                description = get_package_share_directory(vehicle_model_name + "_description")
+                return [
+                    description + "/config/vehicle_info.param.yaml",
+                    description + "/config/simulator_model.param.yaml",
+                ]
+            else:
+                return []
 
-        def make_prefixed_parameters():
+        if (it := collect_vehicle_parameters()) != []:
+            parameters += it
+
+        def collect_prefixed_parameters():
             return [item[0][9:] + ':=' + item[1] for item in context.launch_configurations.items() if item[0][:9] == 'autoware.']
 
-        if (it := make_prefixed_parameters()) != []:
+        if (it := collect_prefixed_parameters()) != []:
             parameters += [{"autoware.": it}]
 
-        return parameters
-
-    def make_vehicle_parameters():
-        parameters = []
-
-        def description():
-            return get_package_share_directory(
-                vehicle_model.perform(context) + "_description"
-            )
-
-        if vehicle_model.perform(context):
-            parameters.append(description() + "/config/vehicle_info.param.yaml")
-            parameters.append(description() + "/config/simulator_model.param.yaml")
         return parameters
 
     return [

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -31,8 +31,6 @@ from pathlib import Path
 
 from scenario_test_runner.shutdown_once import ShutdownOnce
 
-import re
-
 
 def architecture_types():
     return ["awf/universe", "awf/universe/20230906"]
@@ -140,18 +138,8 @@ def launch_setup(context, *args, **kwargs):
 
         parameters += make_vehicle_parameters()
 
-        list_of_string = []
-
-        pattern = re.compile("[Aa]utoware\..*")
-
-        for each in context.launch_configurations.items():
-            if (pattern.match(each[0])):
-                list_of_string.append(each[0][9:] + ":=" + each[1])
-
-        if list_of_string != []:
-            parameters += [
-                {"autoware.": list_of_string}
-            ]
+        if (it := [item[0][9:] + ':=' + item[1] for item in context.launch_configurations.items() if item[0][:9] == 'autoware.']) != []:
+            parameters += [{"autoware.": it}]
 
         return parameters
 

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -60,6 +60,10 @@ def default_autoware_launch_file_of(architecture_type):
     }[architecture_type]
 
 
+def default_rviz_config_file():
+    return Path(get_package_share_directory("traffic_simulator")) / "config/scenario_simulator_v2.rviz"
+
+
 def launch_setup(context, *args, **kwargs):
     # fmt: off
     architecture_type                   = LaunchConfiguration("architecture_type",                      default="awf/universe/20230906")
@@ -79,7 +83,7 @@ def launch_setup(context, *args, **kwargs):
     port                                = LaunchConfiguration("port",                                   default=5555)
     publish_empty_context               = LaunchConfiguration("publish_empty_context",                  default=False)
     record                              = LaunchConfiguration("record",                                 default=True)
-    rviz_config                         = LaunchConfiguration("rviz_config",                            default="")
+    rviz_config                         = LaunchConfiguration("rviz_config",                            default=default_rviz_config_file())
     scenario                            = LaunchConfiguration("scenario",                               default=Path("/dev/null"))
     sensor_model                        = LaunchConfiguration("sensor_model",                           default="")
     sigterm_timeout                     = LaunchConfiguration("sigterm_timeout",                        default=8)
@@ -144,9 +148,10 @@ def launch_setup(context, *args, **kwargs):
             if (pattern.match(each[0])):
                 list_of_string.append(each[0][9:] + ":=" + each[1])
 
-        parameters += [
-            {"autoware.": list_of_string}
-        ]
+        if list_of_string != []:
+            parameters += [
+                {"autoware.": list_of_string}
+            ]
 
         return parameters
 
@@ -245,13 +250,7 @@ def launch_setup(context, *args, **kwargs):
             name="rviz2",
             output={"stderr": "log", "stdout": "log"},
             condition=IfCondition(launch_rviz),
-            arguments=[
-                "-d",
-                str(
-                    Path(get_package_share_directory("traffic_simulator"))
-                    / "config/scenario_simulator_v2.rviz"
-                ),
-            ],
+            arguments=["-d", str(default_rviz_config_file())],
         ),
     ]
 

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -133,12 +133,16 @@ def launch_setup(context, *args, **kwargs):
             {"rviz_config": rviz_config},
             {"sensor_model": sensor_model},
             {"sigterm_timeout": sigterm_timeout},
+            {"use_sim_time": use_sim_time},
             {"vehicle_model": vehicle_model},
         ]
 
         parameters += make_vehicle_parameters()
 
-        if (it := [item[0][9:] + ':=' + item[1] for item in context.launch_configurations.items() if item[0][:9] == 'autoware.']) != []:
+        def make_prefixed_parameters():
+            return [item[0][9:] + ':=' + item[1] for item in context.launch_configurations.items() if item[0][:9] == 'autoware.']
+
+        if (it := make_prefixed_parameters()) != []:
             parameters += [{"autoware.": it}]
 
         return parameters
@@ -201,7 +205,7 @@ def launch_setup(context, *args, **kwargs):
             namespace="simulation",
             output="screen",
             on_exit=ShutdownOnce(),
-            parameters=make_parameters() + [{"use_sim_time": use_sim_time}],
+            parameters=make_parameters(),
             condition=IfCondition(launch_simple_sensor_simulator),
         ),
         # The `name` keyword overrides the name for all created nodes, so duplicated nodes appear.
@@ -214,7 +218,7 @@ def launch_setup(context, *args, **kwargs):
             executable="openscenario_interpreter_node",
             namespace="simulation",
             output="screen",
-            parameters=[{"use_sim_time": use_sim_time}]+make_parameters(),
+            parameters=make_parameters(),
             prefix=make_launch_prefix(),
             on_exit=ShutdownOnce(),
         ),

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 from scenario_test_runner.shutdown_once import ShutdownOnce
 
+import re
+
 
 def architecture_types():
     return ["awf/universe", "awf/universe/20230906"]
@@ -131,7 +133,21 @@ def launch_setup(context, *args, **kwargs):
             {"sigterm_timeout": sigterm_timeout},
             {"vehicle_model": vehicle_model},
         ]
+
         parameters += make_vehicle_parameters()
+
+        list_of_string = []
+
+        pattern = re.compile("[Aa]utoware\..*")
+
+        for each in context.launch_configurations.items():
+            if (pattern.match(each[0])):
+                list_of_string.append(each[0][9:] + ":=" + each[1])
+
+        parameters += [
+            {"autoware.": list_of_string}
+        ]
+
         return parameters
 
     def make_vehicle_parameters():


### PR DESCRIPTION
# Description

## Abstract

Added forwarding of `scenario_test_runner` launch arguments prefixed with `autoware.` to Autoware.

## Background

Previously, `scenario_test_runner` had no mechanism to pass arbitrary launch arguments to Autoware that were not directly supported by `scenario_test_runner`. This was not due to `scenario_test_runner` design or technical reasons, but simply because such functionality was not implemented. Therefore, a mechanism was implemented to forward arbitrary launch arguments from `scenario_test_runner` to Autoware.

## Details

All launch arguments given to `scenario_test_runner` with names starting with `autoware.` are collected together as a list of strings consisting of the prefix-stripped argument names and their values.
The collected arguments are passed to `openscenario_interpreter` and `simple_sensor_simulator` as a new ROS 2 parameter named `autoware.`. Finally, `openscenario_interpreter` passes the elements of the ROS 2 parameter `autoware.` together with other existing parameters to the launch argument of Autoware.

## References

- https://github.com/tier4/sim_evaluation_tools/issues/334

# Destructive Changes

None.
Some existing launch arguments should be able to be replaced with those of the `autoware.` prefix, but for backward compatibility, we will not modify the existing arguments.

# Known Limitations

None.
