### PR TITLE
fix: install add_cpp_mock_scenario_test.cmake first, or colcon build won't pass

### DIFF
--- a/mock/cpp_mock_scenarios/CMakeLists.txt
+++ b/mock/cpp_mock_scenarios/CMakeLists.txt
@@ -64,6 +64,9 @@ endif()
 install(
   DIRECTORY launch rviz
   DESTINATION share/${PROJECT_NAME})
+install(
+  FILES cmake/add_cpp_mock_scenario_test.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
# Description

This PR follows with fix/colcon_build_error.

## Abstract

There is an error in some environments due to forgetting to write install.

## Background

N/A

## Details

With a brand new workspace, **add_cpp_mock_scenario_test.cmake** needs to be installed in CMakeLists.txt first. Or you will have the error below:

```
CMake Error at /path_to_workspace/install/cpp_mock_scenarios/share/cpp_mock_scenarios/cmake/cpp_mock_scenarios_ament_cmake-extras.cmake:17 (include):
  include could not find requested file:
/path_to_workspace/install/cpp_mock_scenarios/share/cpp_mock_scenarios/cmake/add_cpp_mock_scenario_test.cmake
```


## References

N/A

# Destructive Changes

N/A

# Known Limitations

N/A
