### PR TITLE
fix(mock): hard-coded update rate

### DIFF
--- a/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
+++ b/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
@@ -64,8 +64,9 @@ void CppScenarioNode::start()
 {
   onInitialize();
   api_.startNpcLogic();
-  using namespace std::chrono_literals;
-  update_timer_ = this->create_wall_timer(50ms, std::bind(&CppScenarioNode::update, this));
+  const auto rate =
+    std::chrono::duration<double>(1.0 / get_parameter("global_frame_rate").as_double());
+  update_timer_ = this->create_wall_timer(rate, std::bind(&CppScenarioNode::update, this));
 }
 
 void CppScenarioNode::stop(Result result, const std::string & description)


### PR DESCRIPTION
# Description

Now that https://github.com/tier4/scenario_simulator_v2/pull/1368 was merged, we can change update rate for `traffic_simulator::AP`I but I found there was another hard-coded variable in `cpp_scenario_node.cpp`.

## Abstract

Use `global_frame_rate` paramter for timer in `cpp_scenario_node.cpp`.

```patch
diff --git a/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp b/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
index b9f0d72a0..4fb9bd392 100644
--- a/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
+++ b/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
@@ -64,8 +64,9 @@ void CppScenarioNode::start()
 {
   onInitialize();
   api_.startNpcLogic();
-  using namespace std::chrono_literals;
-  update_timer_ = this->create_wall_timer(50ms, std::bind(&CppScenarioNode::update, this));
+  const auto rate =
+    std::chrono::duration<double>(1.0 / get_parameter("global_frame_rate").as_double());
+  update_timer_ = this->create_wall_timer(rate, std::bind(&CppScenarioNode::update, this));
 }
```

## Background

N/A

## Details



## References

N/A

# Destructive Changes

N/A

# Known Limitations

N/A 
