### PR TITLE
Use fmt library for string formatting

### DIFF
--- a/openscenario/openscenario_interpreter/package.xml
+++ b/openscenario/openscenario_interpreter/package.xml
@@ -11,6 +11,7 @@
 
   <depend>concealer</depend>
   <depend>geometry_msgs</depend>
+  <depend>fmt</depend>
   <depend>libboost-dev</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>lifecycle_msgs</depend>

--- a/openscenario/openscenario_interpreter/src/syntax/double.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/double.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fmt/format.h>
+
 #include <boost/lexical_cast.hpp>
 #include <iomanip>
 #include <limits>
@@ -97,7 +99,7 @@ auto operator>>(std::istream & is, Double & datum) -> std::istream &
 
 auto operator<<(std::ostream & os, const Double & datum) -> std::ostream &
 {
-  return os << std::fixed << std::setprecision(30) << datum.data;
+  return os << fmt::format("{:.30f}", datum.data);
 }
 }  // namespace syntax
 }  // namespace openscenario_interpreter


### PR DESCRIPTION
# Description

## Abstract

In this PR, I will introduce `fmt` formatting library instead.
This will make JSON serialization faster.

## Background

Currently, we use `stringstream` to format string, which is used to be a part of Context JSON.
However, `stringstream` is known as "slower" implementation, and this is one of bottleneck in JSON serialization.

> ![image](https://github.com/user-attachments/assets/4d58da0e-f902-402f-bf48-6a8c4ba1e455)
> Cite from [fmt](https://github.com/fmtlib/fmt)