### PR TITLE
Update custom_spell.json

### DIFF
--- a/.github/workflows/custom_spell.json
+++ b/.github/workflows/custom_spell.json
@@ -15,11 +15,8 @@
     "DWITH_INTEGRATION_TEST",
     "engageable",
     "euclidian",
-    "hakuturu",
-    "Kataoka",
     "libunwind",
     "linelint",
-    "Masaya",
     "Mersenne",
     "Monic",
     "Moszynski",
@@ -43,7 +40,6 @@
     "Tschirnhaus",
     "walltime",
     "xerces",
-    "xercesc",
-    "yamacir-kit"
+    "xercesc"
   ]
 }


### PR DESCRIPTION
# Description

## Abstract

Remove people's name of simulation team member from dictionary.

## Background

The dictionary for ignoring proper nouns related to people's names was being managed in duplicate [here](https://github.com/tier4/cspell-dicts/blob/main/people-names/words.txt) and [here](https://github.com/tier4/scenario_simulator_v2/blob/master/.github/workflows/custom_spell.json), so this was partially corrected.
The items targeted for correction in this instance were the names of TIER IV's simulation team members.

## Details

Remove people's name of simulation team member from dictionary.

## References

https://github.com/tier4/cspell-dicts/pull/114

https://github.com/tier4/cspell-dicts/pull/115

# Destructive Changes

N/A

# Known Limitations

N/A