### PR TITLE
add Run SonarCloud scan step

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -107,6 +107,12 @@ jobs:
           path: lcov
           retention-days: 1
 
+      - name: Run SonarCloud scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
 #      - name: Basic test
 #        run: |
 #          source install/setup.bash


### PR DESCRIPTION
# Description

## Abstract

add `Run SonarCloud scan` step in [build and run](https://github.com/tier4/scenario_simulator_v2/blob/master/.github/workflows/BuildAndRun.yaml) workflow.

## Background

I add SonarCloud setting file in #1398, but it in order to upload coverage, it needs GitHub Actions.

## Details

Add o[fficial action](https://github.com/SonarSource/sonarcloud-github-action) for SonarCloud.

## References

#1398 

https://github.com/SonarSource/sonarcloud-github-action

# Destructive Changes

N/A

# Known Limitations

N/A