### PR TITLE
Test for cmake RelWithDebInfo build type

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -18,6 +18,9 @@ on:
   push:
     branches:
       - master
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   job1:
     name: BuildAndRun

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: Upload Lcov result
         uses: actions/upload-artifact@v4
         with:
-          name: lcov
+          name: lcov-${{ matrix.cmake_build_type }}
           path: lcov
           retention-days: 1
 

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         rosdistro: [humble]
         runs_on: [ubuntu-22.04] # macos-14 is added for arm support. See also https://x.com/github/status/1752458943245189120?s=20
+        cmake_build_type: [Debug, RelWithDebInfo, Release]
     steps:
       - name: Suppress warnings
         run: git config --global --add safe.directory '*'
@@ -74,7 +75,7 @@ jobs:
       - name: Build packages
         run: |
           source /opt/ros/${{ matrix.rosdistro }}/setup.bash
-          colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_CPP_MOCK_SCENARIOS=ON -DBUILD_TESTING=true -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage' --packages-up-to ${{ steps.list_packages.outputs.package_list }}
+          colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} -DBUILD_CPP_MOCK_SCENARIOS=ON -DBUILD_TESTING=true -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage' --packages-up-to ${{ steps.list_packages.outputs.package_list }}
         shell: bash
 
       - name: Colcon test

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         rosdistro: [humble]
         runs_on: [ubuntu-22.04] # macos-14 is added for arm support. See also https://x.com/github/status/1752458943245189120?s=20
-        cmake_build_type: [Debug, RelWithDebInfo, Release]
+        cmake_build_type: [RelWithDebInfo, Release] # Debug build type is currently unavailable. @TODO Fix problem and add Debug build.
     steps:
       - name: Suppress warnings
         run: git config --global --add safe.directory '*'

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -50,7 +50,7 @@ jobs:
           git config --global user.name  "Release Bot"
           git config --global user.email "action@github.com"
           git config --global --add safe.directory /__w/scenario_simulator_v2/scenario_simulator_v2
-          git config --global credential.helper ${{ secrets.GITHUB_TOKEN }}
+          git config --global credential.helper ${{ secrets.BLOOM_GITHUB_TOKEN }}
           git config pull.rebase false
 
       - name: Get old version

--- a/openscenario/openscenario_interpreter/src/syntax/relative_clearance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/relative_clearance_condition.cpp
@@ -141,7 +141,7 @@ auto RelativeClearanceCondition::evaluate() -> Object
   };
 
   return asBoolean(triggering_entities.apply([&](const auto & triggering_scenario_object) {
-    assert(triggering_scenario_object.is<ScenarioObject>());
+    assert(triggering_scenario_object.template is<ScenarioObject>());
     if (not entity_refs.empty()) {
       return std::all_of(
         entity_refs.begin(), entity_refs.end(), [&](const auto & target_entity_ref) {
@@ -181,7 +181,7 @@ auto RelativeClearanceCondition::evaluate() -> Object
               bool is_included = false;
               triggering_entities.apply(
                 [target_candidate, &is_included](const auto & triggering_scenario_object) {
-                  assert(triggering_scenario_object.is<ScenarioObject>());
+                  assert(triggering_scenario_object.template is<ScenarioObject>());
                   if (triggering_scenario_object.name() == target_candidate.name) {
                     is_included = true;
                   }


### PR DESCRIPTION
# Description

## Abstract

Add Unit/Integration test for `RelWithDebInfo` build type. 

## Background

In #1402, I found that some of functions does not works valid in `RelWithDebInfo` build type.

## Details

- Add Unit/Integration test for `RelWithDebInfo` build type.
- Use `concurrency` in GitHub Actions and specify `cancel-in-progress = true`

## References

#1402 

# Destructive Changes

N/A

# Known Limitations

Something wrong when you build with `Debug` build type.