### PR TITLE
Feature/joblist update traveled distance

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -224,7 +224,7 @@ public:
 
   /*   */ auto updateStandStillDuration(const double step_time) -> double;
 
-  /*   */ auto updateTraveledDistance(const double step_time) -> double;
+  // /*   */ auto updateTraveledDistance(const double step_time) -> double;
 
   /*   */ bool reachPosition(
     const geometry_msgs::msg::Pose & target_pose, const double tolerance) const;

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -224,8 +224,6 @@ public:
 
   /*   */ auto updateStandStillDuration(const double step_time) -> double;
 
-  // /*   */ auto updateTraveledDistance(const double step_time) -> double;
-
   /*   */ bool reachPosition(
     const geometry_msgs::msg::Pose & target_pose, const double tolerance) const;
 

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -166,7 +166,6 @@ void EgoEntity::onUpdate(double current_time, double step_time)
   }
 
   updateStandStillDuration(step_time);
-  // updateTraveledDistance(step_time);
   updateFieldOperatorApplication();
 
   EntityBase::onPostUpdate(current_time, step_time);

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -166,7 +166,7 @@ void EgoEntity::onUpdate(double current_time, double step_time)
   }
 
   updateStandStillDuration(step_time);
-  updateTraveledDistance(step_time);
+  // updateTraveledDistance(step_time);
   updateFieldOperatorApplication();
 
   EntityBase::onPostUpdate(current_time, step_time);

--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -39,8 +39,8 @@ EntityBase::EntityBase(
   hdmap_utils_ptr_(hdmap_utils_ptr)
 {
   job_list_.append(
-    [this](double delta_time) {
-      traveled_distance_ += std::abs(getCurrentTwist().linear.x) * delta_time;
+    [this](double) {
+      traveled_distance_ += std::abs(getCurrentTwist().linear.x) * step_time_;
       return false;
     },
     [this]() {}, job::Type::TRAVELED_DISTANCE, true, job::Event::POST_UPDATE);

--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -38,6 +38,17 @@ EntityBase::EntityBase(
   status_before_update_(*status_),
   hdmap_utils_ptr_(hdmap_utils_ptr)
 {
+  job_list_.append(
+    [this](double delta_time) { 
+      traveled_distance_ += std::abs(getCurrentTwist().linear.x) * delta_time; 
+      return true;
+    },
+    [this]() { return false; },
+    job::Type::TRAVELED_DISTANCE,
+    true,
+    job::Event::POST_UPDATE
+  );
+
   if (name != static_cast<EntityStatus>(entity_status).name) {
     THROW_SIMULATION_ERROR(
       "The name of the entity does not match the name of the entity listed in entity_status.",
@@ -646,10 +657,10 @@ auto EntityBase::updateStandStillDuration(const double step_time) -> double
   }
 }
 
-auto EntityBase::updateTraveledDistance(const double step_time) -> double
-{
-  return traveled_distance_ += std::abs(getCurrentTwist().linear.x) * step_time;
-}
+// auto EntityBase::updateTraveledDistance(const double step_time) -> double
+// {
+//   return traveled_distance_ += std::abs(getCurrentTwist().linear.x) * step_time;
+// }
 
 bool EntityBase::reachPosition(const std::string & target_name, const double tolerance) const
 {

--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -41,9 +41,9 @@ EntityBase::EntityBase(
   job_list_.append(
     [this](double delta_time) {
       traveled_distance_ += std::abs(getCurrentTwist().linear.x) * delta_time;
-      return true;
+      return false;
     },
-    [this]() { return false; }, job::Type::TRAVELED_DISTANCE, true, job::Event::POST_UPDATE);
+    [this]() {}, job::Type::TRAVELED_DISTANCE, true, job::Event::POST_UPDATE);
 
   if (name != static_cast<EntityStatus>(entity_status).name) {
     THROW_SIMULATION_ERROR(

--- a/simulation/traffic_simulator/src/entity/entity_base.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_base.cpp
@@ -39,15 +39,11 @@ EntityBase::EntityBase(
   hdmap_utils_ptr_(hdmap_utils_ptr)
 {
   job_list_.append(
-    [this](double delta_time) { 
-      traveled_distance_ += std::abs(getCurrentTwist().linear.x) * delta_time; 
+    [this](double delta_time) {
+      traveled_distance_ += std::abs(getCurrentTwist().linear.x) * delta_time;
       return true;
     },
-    [this]() { return false; },
-    job::Type::TRAVELED_DISTANCE,
-    true,
-    job::Event::POST_UPDATE
-  );
+    [this]() { return false; }, job::Type::TRAVELED_DISTANCE, true, job::Event::POST_UPDATE);
 
   if (name != static_cast<EntityStatus>(entity_status).name) {
     THROW_SIMULATION_ERROR(
@@ -656,11 +652,6 @@ auto EntityBase::updateStandStillDuration(const double step_time) -> double
     return stand_still_duration_ = 0.0;
   }
 }
-
-// auto EntityBase::updateTraveledDistance(const double step_time) -> double
-// {
-//   return traveled_distance_ += std::abs(getCurrentTwist().linear.x) * step_time;
-// }
 
 bool EntityBase::reachPosition(const std::string & target_name, const double tolerance) const
 {

--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -259,12 +259,10 @@ auto PedestrianEntity::onUpdate(const double current_time, const double step_tim
     if (pose::isAtEndOfLanelets(canonicalized_lanelet_pose.value(), hdmap_utils_ptr_)) {
       stopAtCurrentPosition();
       updateStandStillDuration(step_time);
-      // updateTraveledDistance(step_time);
       return;
     }
   }
   updateStandStillDuration(step_time);
-  // updateTraveledDistance(step_time);
 
   EntityBase::onPostUpdate(current_time, step_time);
 }

--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -259,12 +259,12 @@ auto PedestrianEntity::onUpdate(const double current_time, const double step_tim
     if (pose::isAtEndOfLanelets(canonicalized_lanelet_pose.value(), hdmap_utils_ptr_)) {
       stopAtCurrentPosition();
       updateStandStillDuration(step_time);
-      updateTraveledDistance(step_time);
+      // updateTraveledDistance(step_time);
       return;
     }
   }
   updateStandStillDuration(step_time);
-  updateTraveledDistance(step_time);
+  // updateTraveledDistance(step_time);
 
   EntityBase::onPostUpdate(current_time, step_time);
 }

--- a/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
@@ -151,12 +151,10 @@ auto VehicleEntity::onUpdate(const double current_time, const double step_time) 
     if (pose::isAtEndOfLanelets(canonicalized_lanelet_pose.value(), hdmap_utils_ptr_)) {
       stopAtCurrentPosition();
       updateStandStillDuration(step_time);
-      // updateTraveledDistance(step_time);
       return;
     }
   }
   updateStandStillDuration(step_time);
-  // updateTraveledDistance(step_time);
 
   EntityBase::onPostUpdate(current_time, step_time);
 }

--- a/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
@@ -151,12 +151,12 @@ auto VehicleEntity::onUpdate(const double current_time, const double step_time) 
     if (pose::isAtEndOfLanelets(canonicalized_lanelet_pose.value(), hdmap_utils_ptr_)) {
       stopAtCurrentPosition();
       updateStandStillDuration(step_time);
-      updateTraveledDistance(step_time);
+      // updateTraveledDistance(step_time);
       return;
     }
   }
   updateStandStillDuration(step_time);
-  updateTraveledDistance(step_time);
+  // updateTraveledDistance(step_time);
 
   EntityBase::onPostUpdate(current_time, step_time);
 }

--- a/simulation/traffic_simulator/test/src/entity/test_misc_object_entity.cpp
+++ b/simulation/traffic_simulator/test/src/entity/test_misc_object_entity.cpp
@@ -450,22 +450,6 @@ TEST_F(MiscObjectEntityTest_FullObject, updateStandStillDuration_startedMoving)
 }
 
 /**
- * @note Test basic functionality; test updating traveled distance correctness
- * with NPC logic started and velocity greater than 0.
- */
-TEST_F(MiscObjectEntityTest_FullObject, updateTraveledDistance_startedMoving)
-{
-  constexpr double velocity = 3.0;
-  // constexpr double step_time = 0.1;
-  misc_object.setLinearVelocity(velocity);
-
-  // EXPECT_EQ(1.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
-  // EXPECT_EQ(2.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
-  // EXPECT_EQ(3.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
-  // EXPECT_EQ(4.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
-}
-
-/**
  * @note Test basic functionality; test stopping correctness - the goal
  * is to check whether the entity status is changed to stopped (no velocity etc.).
  */

--- a/simulation/traffic_simulator/test/src/entity/test_misc_object_entity.cpp
+++ b/simulation/traffic_simulator/test/src/entity/test_misc_object_entity.cpp
@@ -456,13 +456,13 @@ TEST_F(MiscObjectEntityTest_FullObject, updateStandStillDuration_startedMoving)
 TEST_F(MiscObjectEntityTest_FullObject, updateTraveledDistance_startedMoving)
 {
   constexpr double velocity = 3.0;
-  constexpr double step_time = 0.1;
+  // constexpr double step_time = 0.1;
   misc_object.setLinearVelocity(velocity);
 
-  EXPECT_EQ(1.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
-  EXPECT_EQ(2.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
-  EXPECT_EQ(3.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
-  EXPECT_EQ(4.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
+  // EXPECT_EQ(1.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
+  // EXPECT_EQ(2.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
+  // EXPECT_EQ(3.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
+  // EXPECT_EQ(4.0 * step_time * velocity, misc_object.updateTraveledDistance(step_time));
 }
 
 /**


### PR DESCRIPTION
# Description

## Abstract
This pull request removes the `updateTraveledDistance` function from several entity classes. The function has been integrated into the job list management system for better cleaner code.

## Background
The `updateTraveledDistance` function was previously implemented in multiple entity classes. However, a more efficient and centralized method to track traveled distance through the job list system was introduced. This refactor eliminates redundant code and ensures consistency across different entity types.

## Details
The following changes were made:
- Removed the `updateTraveledDistance` function from `EntityBase`, `EgoEntity`, `PedestrianEntity`, and `VehicleEntity`.
- The traveled distance is now updated through the job list system in `EntityBase` using a new job that calculates the traveled distance based on linear velocity.
- Updated unit tests by removing tests specifically for `updateTraveledDistance` as the functionality is now handled by the job system.

## References
N/A

# Destructive Changes
N/A

# Known Limitations
N/A