### PR TITLE
Fix/remove warnings from sonarcloud

### DIFF
--- a/common/math/geometry/include/geometry/bounding_box.hpp
+++ b/common/math/geometry/include/geometry/bounding_box.hpp
@@ -33,8 +33,8 @@ namespace math
 namespace geometry
 {
 
-typedef boost::geometry::model::d2::point_xy<double> boost_point;
-typedef boost::geometry::model::polygon<boost_point> boost_polygon;
+using boost_point = boost::geometry::model::d2::point_xy<double>;
+using boost_polygon = boost::geometry::model::polygon<boost_point>;
 
 struct DistancesFromCenterToEdge
 {

--- a/common/math/geometry/include/geometry/polygon/line_segment.hpp
+++ b/common/math/geometry/include/geometry/polygon/line_segment.hpp
@@ -41,8 +41,6 @@ public:
   LineSegment(
     const geometry_msgs::msg::Point & start_point, const geometry_msgs::msg::Vector3 & vec,
     double length);
-  ~LineSegment();
-  LineSegment & operator=(const LineSegment &);
 
   auto isIntersect2D(const geometry_msgs::msg::Point & point) const -> bool;
   auto isIntersect2D(const LineSegment & line) const -> bool;

--- a/common/math/geometry/include/geometry/spline/hermite_curve.hpp
+++ b/common/math/geometry/include/geometry/spline/hermite_curve.hpp
@@ -32,15 +32,15 @@ class HermiteCurve
 {
 private:
   friend class HermiteCurveTest;
-  double ax_, bx_, cx_, dx_;
-  double ay_, by_, cy_, dy_;
-  double az_, bz_, cz_, dz_;
+  const double ax_, bx_, cx_, dx_;
+  const double ay_, by_, cy_, dy_;
+  const double az_, bz_, cz_, dz_;
   math::geometry::PolynomialSolver solver_;
 
 public:
   HermiteCurve(
-    geometry_msgs::msg::Pose start_pose, geometry_msgs::msg::Pose goal_pose,
-    geometry_msgs::msg::Vector3 start_vec, geometry_msgs::msg::Vector3 goal_vec);
+    const geometry_msgs::msg::Pose & start_pose, const geometry_msgs::msg::Pose & goal_pose,
+    const geometry_msgs::msg::Vector3 & start_vec, const geometry_msgs::msg::Vector3 & goal_vec);
   HermiteCurve(
     double ax, double bx, double cx, double dx, double ay, double by, double cy, double dy,
     double az, double bz, double cz, double dz);
@@ -78,7 +78,7 @@ public:
 
 private:
   std::pair<double, double> get2DMinMaxCurvatureValue() const;
-  double length_;
+  const double length_;
 };
 }  // namespace geometry
 }  // namespace math

--- a/common/math/geometry/include/geometry/spline/hermite_curve.hpp
+++ b/common/math/geometry/include/geometry/spline/hermite_curve.hpp
@@ -32,9 +32,9 @@ class HermiteCurve
 {
 private:
   friend class HermiteCurveTest;
-  const double ax_, bx_, cx_, dx_;
-  const double ay_, by_, cy_, dy_;
-  const double az_, bz_, cz_, dz_;
+  double ax_, bx_, cx_, dx_;
+  double ay_, by_, cy_, dy_;
+  double az_, bz_, cz_, dz_;
   math::geometry::PolynomialSolver solver_;
 
 public:
@@ -78,7 +78,7 @@ public:
 
 private:
   std::pair<double, double> get2DMinMaxCurvatureValue() const;
-  const double length_;
+  double length_;
 };
 }  // namespace geometry
 }  // namespace math

--- a/common/math/geometry/src/distance.cpp
+++ b/common/math/geometry/src/distance.cpp
@@ -58,8 +58,8 @@ double getDistance2D(
   const std::vector<geometry_msgs::msg::Point> & polygon0,
   const std::vector<geometry_msgs::msg::Point> & polygon1)
 {
-  typedef boost::geometry::model::d2::point_xy<double> boost_point;
-  typedef boost::geometry::model::polygon<boost_point> boost_polygon;
+  using boost_point = boost::geometry::model::d2::point_xy<double>;
+  using boost_polygon = boost::geometry::model::polygon<boost_point>;
   boost_polygon poly0;
   for (const auto & point : polygon0) {
     boost::geometry::exterior_ring(poly0).push_back(boost_point(point.x, point.y));

--- a/common/math/geometry/src/intersection/collision.cpp
+++ b/common/math/geometry/src/intersection/collision.cpp
@@ -36,7 +36,7 @@ bool checkCollision2D(
     return false;
   }
   namespace bg = boost::geometry;
-  using bg_point = bg::model::d2::point_xy<double> bg_point;
+  using bg_point = bg::model::d2::point_xy<double>;
   const bg::model::polygon<bg_point> poly0 = math::geometry::toPolygon2D(pose0, bbox0);
   const bg::model::polygon<bg_point> poly1 = math::geometry::toPolygon2D(pose1, bbox1);
   if (bg::intersects(poly0, poly1)) {

--- a/common/math/geometry/src/intersection/collision.cpp
+++ b/common/math/geometry/src/intersection/collision.cpp
@@ -26,6 +26,9 @@ namespace math
 {
 namespace geometry
 {
+using boost_point = boost::geometry::model::d2::point_xy<double>;
+using boost_polygon = boost::geometry::model::polygon<boost_point>;
+
 bool checkCollision2D(
   geometry_msgs::msg::Pose pose0, traffic_simulator_msgs::msg::BoundingBox bbox0,
   geometry_msgs::msg::Pose pose1, traffic_simulator_msgs::msg::BoundingBox bbox1)
@@ -35,14 +38,12 @@ bool checkCollision2D(
     (std::abs(bbox0.dimensions.z + bbox1.dimensions.z) * 0.5)) {
     return false;
   }
-  namespace bg = boost::geometry;
-  using bg_point = bg::model::d2::point_xy<double>;
-  const bg::model::polygon<bg_point> poly0 = math::geometry::toPolygon2D(pose0, bbox0);
-  const bg::model::polygon<bg_point> poly1 = math::geometry::toPolygon2D(pose1, bbox1);
-  if (bg::intersects(poly0, poly1)) {
+  const boost_polygon poly0 = math::geometry::toPolygon2D(pose0, bbox0);
+  const boost_polygon poly1 = math::geometry::toPolygon2D(pose1, bbox1);
+  if (boost::geometry::intersects(poly0, poly1)) {
     return true;
   }
-  if (bg::disjoint(poly0, poly1)) {
+  if (boost::geometry::disjoint(poly0, poly1)) {
     return false;
   }
   return true;
@@ -51,8 +52,6 @@ bool checkCollision2D(
 bool contains(
   const std::vector<geometry_msgs::msg::Point> & polygon, const geometry_msgs::msg::Point & point)
 {
-  using boost_point = boost::geometry::model::d2::point_xy<double>;
-  using boost_polygon = boost::geometry::model::polygon<boost_point>;
   boost_polygon poly;
   for (const auto & p : polygon) {
     boost::geometry::exterior_ring(poly).push_back(boost_point(p.x, p.y));

--- a/common/math/geometry/src/intersection/collision.cpp
+++ b/common/math/geometry/src/intersection/collision.cpp
@@ -51,8 +51,8 @@ bool checkCollision2D(
 bool contains(
   const std::vector<geometry_msgs::msg::Point> & polygon, const geometry_msgs::msg::Point & point)
 {
-  typedef boost::geometry::model::d2::point_xy<double> boost_point;
-  typedef boost::geometry::model::polygon<boost_point> boost_polygon;
+  using boost_point = boost::geometry::model::d2::point_xy<double>;
+  using boost_polygon = boost::geometry::model::polygon<boost_point>;
   boost_polygon poly;
   for (const auto & p : polygon) {
     boost::geometry::exterior_ring(poly).push_back(boost_point(p.x, p.y));

--- a/common/math/geometry/src/intersection/collision.cpp
+++ b/common/math/geometry/src/intersection/collision.cpp
@@ -30,13 +30,13 @@ bool checkCollision2D(
   geometry_msgs::msg::Pose pose0, traffic_simulator_msgs::msg::BoundingBox bbox0,
   geometry_msgs::msg::Pose pose1, traffic_simulator_msgs::msg::BoundingBox bbox1)
 {
-  double z_diff_pose =
-    std::abs((pose0.position.z + bbox0.center.z) - (pose1.position.z + bbox1.center.z));
-  if (z_diff_pose > (std::abs(bbox0.dimensions.z + bbox1.dimensions.z) * 0.5)) {
+  if (
+    std::abs((pose0.position.z + bbox0.center.z) - (pose1.position.z + bbox1.center.z)) >
+    (std::abs(bbox0.dimensions.z + bbox1.dimensions.z) * 0.5)) {
     return false;
   }
   namespace bg = boost::geometry;
-  typedef bg::model::d2::point_xy<double> bg_point;
+  using bg_point = bg::model::d2::point_xy<double> bg_point;
   const bg::model::polygon<bg_point> poly0 = math::geometry::toPolygon2D(pose0, bbox0);
   const bg::model::polygon<bg_point> poly1 = math::geometry::toPolygon2D(pose1, bbox1);
   if (bg::intersects(poly0, poly1)) {

--- a/common/math/geometry/src/polygon/line_segment.cpp
+++ b/common/math/geometry/src/polygon/line_segment.cpp
@@ -64,8 +64,6 @@ LineSegment::LineSegment(
 {
 }
 
-LineSegment::~LineSegment() {}
-
 /**
  * @brief Get point on the line segment from s value.
  * @param s Normalized s value in coordinate along line segment.
@@ -300,8 +298,6 @@ auto LineSegment::denormalize(const double s) const -> double
       "contact the developer of traffic_simulator.");
   }
 }
-
-LineSegment & LineSegment::operator=(const LineSegment &) { return *this; }
 
 /**
  * @brief Get the line segments from points. 

--- a/common/math/geometry/src/polygon/polygon.cpp
+++ b/common/math/geometry/src/polygon/polygon.cpp
@@ -26,8 +26,8 @@ namespace geometry
 std::vector<geometry_msgs::msg::Point> get2DConvexHull(
   const std::vector<geometry_msgs::msg::Point> & points)
 {
-  typedef boost::geometry::model::d2::point_xy<double> boost_point;
-  typedef boost::geometry::model::polygon<boost_point> boost_polygon;
+  using boost_point = boost::geometry::model::d2::point_xy<double>;
+  using boost_polygon = boost::geometry::model::polygon<boost_point>;
   boost_polygon poly;
   for (const auto & p : points) {
     boost::geometry::exterior_ring(poly).push_back(boost_point(p.x, p.y));

--- a/common/math/geometry/src/spline/catmull_rom_spline.cpp
+++ b/common/math/geometry/src/spline/catmull_rom_spline.cpp
@@ -171,7 +171,7 @@ CatmullRomSpline::CatmullRomSpline(const std::vector<geometry_msgs::msg::Point> 
             bz = bz * 0.5;
             cz = cz * 0.5;
             dz = dz * 0.5;
-            curves_.emplace_back(HermiteCurve(ax, bx, cx, dx, ay, by, cy, dy, az, bz, cz, dz));
+            curves_.emplace_back(ax, bx, cx, dx, ay, by, cy, dy, az, bz, cz, dz);
           } else if (i == (n - 1)) {
             double ax = 0;
             double bx = control_points[i - 1].x - 2 * control_points[i].x + control_points[i + 1].x;
@@ -197,7 +197,7 @@ CatmullRomSpline::CatmullRomSpline(const std::vector<geometry_msgs::msg::Point> 
             bz = bz * 0.5;
             cz = cz * 0.5;
             dz = dz * 0.5;
-            curves_.emplace_back(HermiteCurve(ax, bx, cx, dx, ay, by, cy, dy, az, bz, cz, dz));
+            curves_.emplace_back(ax, bx, cx, dx, ay, by, cy, dy, az, bz, cz, dz);
           } else {
             double ax = -1 * control_points[i - 1].x + 3 * control_points[i].x -
                         3 * control_points[i + 1].x + control_points[i + 2].x;
@@ -229,7 +229,7 @@ CatmullRomSpline::CatmullRomSpline(const std::vector<geometry_msgs::msg::Point> 
             bz = bz * 0.5;
             cz = cz * 0.5;
             dz = dz * 0.5;
-            curves_.emplace_back(HermiteCurve(ax, bx, cx, dx, ay, by, cy, dy, az, bz, cz, dz));
+            curves_.emplace_back(ax, bx, cx, dx, ay, by, cy, dy, az, bz, cz, dz);
           }
         }
         for (const auto & curve : curves_) {

--- a/common/math/geometry/src/spline/hermite_curve.cpp
+++ b/common/math/geometry/src/spline/hermite_curve.cpp
@@ -48,24 +48,22 @@ HermiteCurve::HermiteCurve(
 }
 
 HermiteCurve::HermiteCurve(
-  geometry_msgs::msg::Pose start_pose, geometry_msgs::msg::Pose goal_pose,
-  geometry_msgs::msg::Vector3 start_vec, geometry_msgs::msg::Vector3 goal_vec)
+  const geometry_msgs::msg::Pose & start_pose, const geometry_msgs::msg::Pose & goal_pose,
+  const geometry_msgs::msg::Vector3 & start_vec, const geometry_msgs::msg::Vector3 & goal_vec)
+: ax_(2 * start_pose.position.x - 2 * goal_pose.position.x + start_vec.x + goal_vec.x),
+  bx_(-3 * start_pose.position.x + 3 * goal_pose.position.x - 2 * start_vec.x - goal_vec.x),
+  cx_(start_vec.x),
+  dx_(start_pose.position.x),
+  ay_(2 * start_pose.position.y - 2 * goal_pose.position.y + start_vec.y + goal_vec.y),
+  by_(-3 * start_pose.position.y + 3 * goal_pose.position.y - 2 * start_vec.y - goal_vec.y),
+  cy_(start_vec.y),
+  dy_(start_pose.position.y),
+  az_(2 * start_pose.position.z - 2 * goal_pose.position.z + start_vec.z + goal_vec.z),
+  bz_(-3 * start_pose.position.z + 3 * goal_pose.position.z - 2 * start_vec.z - goal_vec.z),
+  cz_(start_vec.z),
+  dz_(start_pose.position.z),
+  length_(getLength(100))
 {
-  ax_ = 2 * start_pose.position.x - 2 * goal_pose.position.x + start_vec.x + goal_vec.x;
-  bx_ = -3 * start_pose.position.x + 3 * goal_pose.position.x - 2 * start_vec.x - goal_vec.x;
-  cx_ = start_vec.x;
-  dx_ = start_pose.position.x;
-
-  ay_ = 2 * start_pose.position.y - 2 * goal_pose.position.y + start_vec.y + goal_vec.y;
-  by_ = -3 * start_pose.position.y + 3 * goal_pose.position.y - 2 * start_vec.y - goal_vec.y;
-  cy_ = start_vec.y;
-  dy_ = start_pose.position.y;
-
-  az_ = 2 * start_pose.position.z - 2 * goal_pose.position.z + start_vec.z + goal_vec.z;
-  bz_ = -3 * start_pose.position.z + 3 * goal_pose.position.z - 2 * start_vec.z - goal_vec.z;
-  cz_ = start_vec.z;
-  dz_ = start_pose.position.z;
-  length_ = getLength(100);
 }
 
 double HermiteCurve::getSquaredDistanceIn2D(


### PR DESCRIPTION
# Description

## Abstract

Remove some warnings from [SonarCloud.](https://sonarcloud.io/issues?issueStatuses=OPEN%2CCONFIRMED&open=AZJS0wpltJsnZH2iyX9Y)

## Background

Static analysis results from SonarCloud found non-recommended formats and other issues in the geometry library.

## Details

I have fixed some of the areas where warnings were issued.

## References

https://sonarcloud.io/issues?issueStatuses=OPEN%2CCONFIRMED

# Destructive Changes

N/A

# Known Limitations

N/A
