### PR TITLE
fix(concealer): fix interval in engege - to catch a single state change

### DIFF
--- a/external/concealer/src/field_operator_application_for_autoware_universe.cpp
+++ b/external/concealer/src/field_operator_application_for_autoware_universe.cpp
@@ -371,7 +371,9 @@ auto FieldOperatorApplicationFor<AutowareUniverse>::engage() -> void
         // ignore timeout error because this service is validated by Autoware state transition.
         return;
       }
-    });
+    // There is no exact technical basis for the interval value equal to 100 ms, it is chosen by experiments and 
+    // should be sufficiently small to detect a single state change like WaitingForEngage->Driving->WaitingForEngage
+    }, std::chrono::milliseconds(100));
   });
 }
 

--- a/external/concealer/src/field_operator_application_for_autoware_universe.cpp
+++ b/external/concealer/src/field_operator_application_for_autoware_universe.cpp
@@ -362,18 +362,20 @@ auto FieldOperatorApplicationFor<AutowareUniverse>::clearRoute() -> void
 auto FieldOperatorApplicationFor<AutowareUniverse>::engage() -> void
 {
   task_queue.delay([this]() {
-    waitForAutowareStateToBeDriving([this]() {
-      auto request = std::make_shared<tier4_external_api_msgs::srv::Engage::Request>();
-      request->engage = true;
-      try {
-        return requestEngage(request);
-      } catch (const decltype(requestEngage)::TimeoutError &) {
-        // ignore timeout error because this service is validated by Autoware state transition.
-        return;
-      }
-    // There is no exact technical basis for the interval value equal to 100 ms, it is chosen by experiments and 
-    // should be sufficiently small to detect a single state change like WaitingForEngage->Driving->WaitingForEngage
-    }, std::chrono::milliseconds(100));
+    waitForAutowareStateToBeDriving(
+      [this]() {
+        auto request = std::make_shared<tier4_external_api_msgs::srv::Engage::Request>();
+        request->engage = true;
+        try {
+          return requestEngage(request);
+        } catch (const decltype(requestEngage)::TimeoutError &) {
+          // ignore timeout error because this service is validated by Autoware state transition.
+          return;
+        }
+        // There is no exact technical basis for the interval value equal to 100 ms, it is chosen by experiments and
+        // should be sufficiently small to detect a single state change like WaitingForEngage->Driving->WaitingForEngage
+      },
+      std::chrono::milliseconds(100));
   });
 }
 


### PR DESCRIPTION
# Description

## Abstract

This PR introduces a fix for the case where `FollowTrajectoryAction` for `Ego` is triggered immediately after the simulation starts. Task `waitForAutowareStateToBeDriving`, which monitors state changes, **does not throw** an **unexpected** exception from now on.

## Background

In a typical scenario:
- after the `Ego` is spawned,
- plan is performed (as a result of [`requestAssignRoute`](https://github.com/tier4/scenario_simulator_v2/blob/950da41d1496b68de7a37e2df95d26d0ec3e4191/simulation/traffic_simulator/src/entity/ego_entity.cpp#L209)), 
- and then [engage](https://github.com/tier4/scenario_simulator_v2/blob/950da41d1496b68de7a37e2df95d26d0ec3e4191/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp#L188) is performed. 
- then when the `Ego` is [engaged](https://github.com/tier4/scenario_simulator_v2/blob/950da41d1496b68de7a37e2df95d26d0ec3e4191/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp#L190) the simulation time starts - i.e. `Ego` has `Driving` state. (simulation time starts thanks to call  [`activateNonUserDefinedControllers`](https://github.com/tier4/scenario_simulator_v2/blob/950da41d1496b68de7a37e2df95d26d0ec3e4191/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp#L191)).  

---

To monitor if state changes are performed successfully and to throw an exception if any state change takes too long, tasks in `TaskQueue` are used. More specifically, these tasks are used:
- `waitForAutowareStateToBeWaitingForRoute` - which monitors if the `Ego` has successfully transitioned to state `WaitingForRoute` - i.e. if `Ego` is ready for planning
- `waitForAutowareStateToBeWaitingForEngage` - which monitors if the `Ego` has successfully transitioned to state `WaitingForEngage` - that is, if `Ego` is ready for engage
- `waitForAutowareStateToBeDriving` - which monitors if the `Ego` has successfully transitioned to state `Driving` - i.e. if the `Ego` is driving

## Details

Issue which fixes this PR occurs in [`waitForAutowareStateToBeDriving`](https://github.com/tier4/scenario_simulator_v2/blob/950da41d1496b68de7a37e2df95d26d0ec3e4191/external/concealer/include/concealer/transition_assertion.hpp#L45-L66) monitor. It occurs when there is:
- a **single change** of state `WaitingForEngage` -> `Driving` (which causes the simulation to start )
- is **immediately followed by another change** `Driving` -> `WaitingForEngage`.

Because for the default interval (equal to `1s`) such a single change is too fast and **is not detected**. Which causes that the **simulation time starts**, but the **monitor continues to work** and waits for the change `WaitingForEngage` -> `Driving`.
If the monitor does not detect this expected state change before the `initialize_duration` time expires, then an exception is thrown.

This case occurs in a scenario where `FollowTrajectoryAction` is triggered for `Ego` as soon as the simulation time starts (more precisely, for a stimulation time equal to 0.0). An example of such a scenario is [RoutingAction.FollowTrajectoryAction-autoware](https://github.com/tier4/scenario_simulator_v2/blob/950da41d1496b68de7a37e2df95d26d0ec3e4191/test_runner/scenario_test_runner/scenario/RoutingAction.FollowTrajectoryAction-autoware.yaml#L79-L82). 

To fix this issue without a lot of code changes, the interval in monitor [`waitForAutowareStateToBeDriving`](https://github.com/tier4/scenario_simulator_v2/blob/950da41d1496b68de7a37e2df95d26d0ec3e4191/external/concealer/include/concealer/transition_assertion.hpp#L45-L66)  can be set smaller. In this PR, **it is set to a value equal to 100ms** - which has fixed the issue in local tests. Previously for [RoutingAction.FollowTrajectoryAction-autoware](https://github.com/tier4/scenario_simulator_v2/blob/950da41d1496b68de7a37e2df95d26d0ec3e4191/test_runner/scenario_test_runner/scenario/RoutingAction.FollowTrajectoryAction-autoware.yaml#L79-L82), **0 successes** and 5 failures occurred, after fix: **5 successes** and 0 failures.

### Before

https://github.com/user-attachments/assets/ca141a11-a70c-41b2-ab06-4d9cf5093a0c



### After

https://github.com/user-attachments/assets/59d19cea-ebb7-4f0a-9fe4-f15b1d37b66c

## References
--

# Destructive Changes
--

# Known Limitations
--
