### PR TITLE
Fix Docker Build for Arm64

### DIFF
--- a/.github/workflows/DockerArm64.yaml
+++ b/.github/workflows/DockerArm64.yaml
@@ -1,4 +1,4 @@
-name: Docker
+name: Docker Arm64
 on:
   pull_request:
     paths:
@@ -19,14 +19,13 @@ on:
 
 jobs:
   push_docker:
-    name: Push Docker Image
+    name: Push Docker Arm64 Image
     runs-on: ubuntu-22.04
     timeout-minutes: 720
     strategy:
       matrix:
         rosdistro: [humble]
         arch: [amd64]
-
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -50,29 +49,10 @@ jobs:
 
       - name: Build (${{ matrix.arch }})
         if: github.event_name == 'pull_request'
-        uses: docker/bake-action@v3
-        with:
-          files: |
-            ./docker-bake.hcl
-          workdir: .
-          set: |
-            *.cache-to=type=gha,mode=max
-            *.cache-from=type=gha
-          push: false
-          targets: |
-            ${{ matrix.rosdistro }}_base_${{ matrix.arch }}
+        run: 
+          docker buildx build --platform linux/arm64/v8 -t ghcr.io/tier4/scenario_simulator_v2:humble --build-arg ROS_DISTRO=humble .
 
       - name: Build and push (${{ matrix.arch }})
         if: github.event_name == 'workflow_dispatch'
-        uses: docker/bake-action@v3
-        with:
-          files: |
-            ./docker-bake.hcl
-          workdir: .
-          set: |
-            *.cache-to=type=gha,mode=max
-            *.cache-from=type=gha
-            *.tags=ghcr.io/tier4/scenario_simulator_v2:humble-${{ github.event.inputs.version }}
-          push: true
-          targets: |
-            ${{ matrix.rosdistro }}_base_${{ matrix.arch }}
+        run:           
+          docker buildx build --platform linux/arm64/v8 -t ghcr.io/tier4/scenario_simulator_v2:humble --build-arg ROS_DISTRO=humble --push .


### PR DESCRIPTION
## Description

This pull request introduces a new GitHub Actions workflow for building Docker images targeting the Arm64 architecture. It aims to address the previously broken Arm64 build process by creating a separate workflow file for Arm64 builds.

## Abstract

This PR fixes the Docker build process for Arm64 by adding a new workflow file .github/workflows/DockerArm64.yaml, which includes the necessary steps and configurations for building and pushing Arm64-compatible images.

## Background

The Docker build process for Arm64 was previously broken, as noted in pull request #1295. This issue was temporarily addressed by limiting the builds to amd64 only. This PR seeks to resolve this by reintroducing a dedicated workflow for Arm64.

## Details

The new workflow file .github/workflows/DockerArm64.yaml includes:

- A push_docker job for building and pushing Docker images targeting the Arm64 architecture.
- The use of docker/setup-buildx-action and docker/setup-qemu-action to ensure compatibility with Arm64 builds.
- Conditional logic to handle build triggers for both pull_request and workflow_dispatch events.
- Removal of previous Arm64-related comments from the main Docker.yaml workflow file.

> [!IMPORTANT]
> This action is separated with the assumption that Arm64 runners will be introduced in the future. Running the Docker command directly is the only solution that has been confirmed so far.

## References

- #1295

## Destructive Changes

N/A

## Known Limitations

N/A
