### PR TITLE
Fix Arm Docker Build Support

### DIFF
--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -51,6 +51,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Docker Qemu Setup
+        run: |
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx create --use
+          docker buildx inspect --bootstrap
+
       - name: Build (${{ matrix.arch }})
         if: github.event_name == 'pull_request'
         uses: docker/bake-action@v3

--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -25,11 +25,8 @@ jobs:
     strategy:
       matrix:
         rosdistro: [humble]
-        arch: [amd64]
-        # Build test for arm64 CPU is broken.
-        # This is a temporary solution and will be repaired in the future.
-        # See also https://github.com/tier4/scenario_simulator_v2/pull/1295
-        # arch: [amd64, arm64]
+        arch: [amd64, arm64]
+
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -36,17 +36,11 @@ RUN vcs import external < dependency_${ROS_DISTRO}.repos
 WORKDIR /home/ubuntu/Desktop/scenario_simulator_ws/src
 RUN --mount=type=cache,id=apt-cache-arm64,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib-arm64,target=/var/lib/apt,sharing=locked \
-    source /opt/ros/${ROS_DISTRO}/setup.bash \
-    && apt-get update \
-    && rosdep install -iy --from-paths . --rosdistro ${ROS_DISTRO}
+    bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash && apt-get update && rosdep install -iy --from-paths . --rosdistro ${ROS_DISTRO}"
 
 WORKDIR /home/ubuntu/Desktop/scenario_simulator_ws
 
-RUN source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --symlink-install \
-    --cmake-args \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_CPP_MOCK_SCENARIOS=ON
+RUN bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash && colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_CPP_MOCK_SCENARIOS=ON"
 COPY ./docker-entrypoint.sh /
 RUN chmod a+x /docker-entrypoint.sh
 


### PR DESCRIPTION
## Abstract

This pull request fixes the Docker build support for Arm architecture by resolving issues with Qemu setup and Docker configuration.

## Background

The previous Docker build for Arm64 was temporarily disabled due to a known issue (see [PR #1295](https://github.com/tier4/scenario_simulator_v2/pull/1295)). This pull request reinstates Arm64 build support.

## Details

This update adds a Qemu setup step to the GitHub Actions workflow, enabling Arm64 support for Docker builds. It modifies the Dockerfile.arm64 to streamline the build process and ensures compatibility with the humble ROS distribution.

## Destructive Changes

N/A

## Known Limitations

The bug fixed in this PR may recur, so it should be monitored closely. We recommend migrating promptly if an Ubuntu Arm64 runner is added to the GitHub self-hosted runner.

## References

#1295 