### PR TITLE
Fixed logic to remove duplicate topics.

### DIFF
--- a/rviz_plugins/openscenario_visualization/src/context_panel_plugin.cpp
+++ b/rviz_plugins/openscenario_visualization/src/context_panel_plugin.cpp
@@ -112,8 +112,8 @@ void ContextPanel::updateTopicCandidates()
       }
     }
 
-    std::sort(topics_.begin(), topics_.end());
-    topics_.erase(std::unique(topics_.begin(), topics_.end()), topics_.end());
+    std::set<std::string> unique_topics(topics_.begin(), topics_.end());
+    topics_.assign(unique_topics.begin(), unique_topics.end());
 
     ui_->TopicSelect->clear();
     ui_->TopicSelect->addItem("simulation/context");

--- a/rviz_plugins/openscenario_visualization/src/context_panel_plugin.cpp
+++ b/rviz_plugins/openscenario_visualization/src/context_panel_plugin.cpp
@@ -111,7 +111,10 @@ void ContextPanel::updateTopicCandidates()
         }
       }
     }
-    std::unique(topics_.begin(), topics_.end());
+
+    std::sort(topics_.begin(), topics_.end());
+    topics_.erase(std::unique(topics_.begin(), topics_.end()), topics_.end());
+
     ui_->TopicSelect->clear();
     ui_->TopicSelect->addItem("simulation/context");
     for (const auto & topic : topics_) {


### PR DESCRIPTION
## Abstract

This pull request fixes the logic to remove duplicate topics in the updateTopicCandidates function, improving the behavior by correctly sorting and eliminating duplicates from the topic list.

## Background

This change was necessary because the previous implementation did not properly handle the removal of duplicate topics, which could lead to incorrect behavior when selecting topics in the UI.

## Details

The fix was made by adding a call to std::sort() followed by std::unique(), ensuring that the topics_ vector is both sorted and has its duplicates removed. The previous implementation only applied std::unique() without sorting, which led to incomplete duplicate removal.

## References

- https://sonarcloud.io/project/issues?open=AZINWTJ9jvEq9OQMnMEc&id=tier4_scenario_simulator_v2

## Destructive Changes

N/A

## Known Limitations

N/A
