### PR TITLE
Refactor curvature sampling loop to avoid using float counter

### DIFF
--- a/common/math/geometry/src/spline/hermite_curve.cpp
+++ b/common/math/geometry/src/spline/hermite_curve.cpp
@@ -316,7 +316,11 @@ std::pair<double, double> HermiteCurve::get2DMinMaxCurvatureValue() const
   /**
    * @brief 0.1 is a sampling resolution of the curvature
    */
-  for (double s = 0; s <= 1; s = s + 0.1) {
+  const int sample_count = 10;
+  const double resolution = 1.0 / sample_count;
+
+  for (int i = 0; i <= sample_count; ++i) {
+    double s = i * resolution;
     double curvature = get2DCurvature(s);
     curvatures.push_back(curvature);
   }

--- a/common/math/geometry/src/spline/hermite_curve.cpp
+++ b/common/math/geometry/src/spline/hermite_curve.cpp
@@ -313,17 +313,19 @@ std::pair<double, double> HermiteCurve::get2DMinMaxCurvatureValue() const
 {
   std::pair<double, double> ret;
   std::vector<double> curvatures;
-  /**
-   * @brief 0.1 is a sampling resolution of the curvature
-   */
-  const int sample_count = 10;
-  const double resolution = 1.0 / sample_count;
+
+  /// @note Specifies the number of samples. The curve is divided into 10 segments for calculation.
+  constexpr int sample_count = 10;
+
+  /// @note Sampling resolution. Calculated as 1.0 divided by sample_count.
+  constexpr double resolution = 1.0 / sample_count;
 
   for (int i = 0; i <= sample_count; ++i) {
     double s = i * resolution;
     double curvature = get2DCurvature(s);
     curvatures.push_back(curvature);
   }
+
   ret.first = *std::min_element(curvatures.begin(), curvatures.end());
   ret.second = *std::max_element(curvatures.begin(), curvatures.end());
   return ret;


### PR DESCRIPTION
## Description

Refactor curvature sampling loop to avoid using float counter

## Abstract

Refactor of the curvature sampling loop in hermite_curve.cpp to avoid using a float counter, improving precision and readability.

## Background

This refactor addresses the potential issues with floating-point precision in the curvature sampling loop.

## Details

The original loop used a floating-point counter (for (double s = 0; s <= 1; s = s + 0.1)). This has been refactored to an integer-based loop with a fixed sample count of 10, which eliminates the need for floating-point arithmetic in the loop control.

## References

- https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&types=BUG&id=tier4_scenario_simulator_v2&open=AZINWTIYjvEq9OQMnMBA

## Destructive Changes

N/A

## Known Limitations

N/A