### PR TITLE
Add missing include

### DIFF
--- a/common/math/geometry/include/geometry/vector3/normalize.hpp
+++ b/common/math/geometry/include/geometry/vector3/normalize.hpp
@@ -17,6 +17,7 @@
 
 #include <geometry/vector3/is_like_vector3.hpp>
 #include <geometry/vector3/norm.hpp>
+#include <geometry/vector3/operator.hpp>
 #include <scenario_simulator_exception/exception.hpp>
 
 namespace math

--- a/external/concealer/src/execute.cpp
+++ b/external/concealer/src/execute.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <memory>
 #include <type_traits>
+#include <array>
 
 namespace concealer
 {

--- a/external/concealer/src/execute.cpp
+++ b/external/concealer/src/execute.cpp
@@ -17,13 +17,13 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <array>
 #include <concealer/execute.hpp>
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <type_traits>
-#include <array>
 
 namespace concealer
 {


### PR DESCRIPTION
## Abstract

This pull request adds missing includes in the files normalize.hpp and execute.cpp.

## Background

This update addresses a missing include issue in the geometry/vector3 and concealer namespaces, which caused compilation errors in certain scenarios.

## Details

Added the following includes:

- geometry/vector3/operator.hpp in normalize.hpp
- rray in execute.cpp

These changes ensure that the necessary headers are included to avoid future compilation issues.

## References

This PR fixes errors or warnings that appeared during Clang builds.

## Destructive Changes

N/A

## Known Limitations

N/A