### PR TITLE
Add Rviz Marker for some conditions

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/openscenario_interpreter.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/openscenario_interpreter.hpp
@@ -15,11 +15,6 @@
 #ifndef OPENSCENARIO_INTERPRETER__OPENSCENARIO_INTERPRETER_HPP_
 #define OPENSCENARIO_INTERPRETER__OPENSCENARIO_INTERPRETER_HPP_
 
-#include <boost/variant.hpp>
-#include <chrono>
-#include <lifecycle_msgs/msg/state.hpp>
-#include <lifecycle_msgs/msg/transition.hpp>
-#include <memory>
 #include <openscenario_interpreter/console/escape_sequence.hpp>
 #include <openscenario_interpreter/simulator_core.hpp>
 #include <openscenario_interpreter/syntax/custom_command_action.hpp>
@@ -27,11 +22,19 @@
 #include <openscenario_interpreter/syntax/scenario_definition.hpp>
 #include <openscenario_interpreter/utility/execution_timer.hpp>
 #include <openscenario_interpreter/utility/visibility.hpp>
-#include <openscenario_interpreter_msgs/msg/context.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <scenario_simulator_exception/exception.hpp>
 #include <simple_junit/junit5.hpp>
+
+#include <lifecycle_msgs/msg/state.hpp>
+#include <lifecycle_msgs/msg/transition.hpp>
+#include <openscenario_interpreter_msgs/msg/context.hpp>
+
+#include <boost/variant.hpp>
+
+#include <chrono>
+#include <memory>
 #include <utility>
 
 #define INTERPRETER_INFO_STREAM(...) \
@@ -63,6 +66,8 @@ class Interpreter : public rclcpp_lifecycle::LifecycleNode,
   bool publish_empty_context;
 
   bool record;
+
+  bool publish_visualization;
 
   std::shared_ptr<OpenScenario> script;
 

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/reach_position_condition.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/reach_position_condition.hpp
@@ -21,6 +21,7 @@
 #include <openscenario_interpreter/syntax/position.hpp>
 #include <openscenario_interpreter/syntax/rule.hpp>
 #include <openscenario_interpreter/syntax/triggering_entities.hpp>
+#include <openscenario_interpreter/visualization_buffer.hpp>
 #include <pugixml.hpp>
 #include <valarray>
 
@@ -38,7 +39,8 @@ inline namespace syntax
  *  </xsd:complexType>
  *
  * -------------------------------------------------------------------------- */
-struct ReachPositionCondition : private SimulatorCore::CoordinateSystemConversion
+struct ReachPositionCondition : private SimulatorCore::CoordinateSystemConversion,
+                                private VisualizationBuffer::Target
 {
   const Double tolerance;
 
@@ -53,6 +55,8 @@ struct ReachPositionCondition : private SimulatorCore::CoordinateSystemConversio
   const bool consider_z;
 
   explicit ReachPositionCondition(const pugi::xml_node &, Scope &, const TriggeringEntities &);
+
+  auto visualize() const -> void;
 
   auto description() const -> String;
 

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/visualization_buffer.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/visualization_buffer.hpp
@@ -15,8 +15,9 @@
 #ifndef OPENSCENARIO_INTERPRETER__VISUALIZATION_BUFFER_HPP_
 #define OPENSCENARIO_INTERPRETER__VISUALIZATION_BUFFER_HPP_
 
-#include <memory>
 #include <rclcpp/rclcpp.hpp>
+
+#include <memory>
 
 namespace openscenario_interpreter
 {
@@ -71,6 +72,14 @@ public:
     {
       if (active()) {
         buffer->markers.push_back(marker);
+      }
+    }
+
+    template <typename F>
+    void call_visualize(F && function) const
+    {
+      if (active()) {
+        function();
       }
     }
   };

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/visualization_buffer.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/visualization_buffer.hpp
@@ -1,0 +1,80 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENSCENARIO_INTERPRETER__VISUALIZATION_BUFFER_HPP_
+#define OPENSCENARIO_INTERPRETER__VISUALIZATION_BUFFER_HPP_
+
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+
+namespace openscenario_interpreter
+{
+class VisualizationBuffer
+{
+  static inline std::unique_ptr<VisualizationBuffer> buffer = nullptr;
+
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr publisher;
+  std::vector<visualization_msgs::msg::Marker> markers;
+
+public:
+  template <typename Node>
+  VisualizationBuffer(Node && node, const std::string topic = "/simulation/interpreter/markers")
+  {
+    publisher = rclcpp::create_publisher<visualization_msgs::msg::MarkerArray>(
+      node, topic, rclcpp::QoS(rclcpp::KeepLast(1)));
+  }
+
+  static auto active() { return static_cast<bool>(buffer); }
+
+  template <typename Node>
+  static auto activate(const Node & node) -> void
+  {
+    if (not active()) {
+      buffer = std::make_unique<VisualizationBuffer>(node);
+    } else {
+      throw Error("The visualization buffer has already been instantiated.");
+    }
+  }
+
+  static auto deactivate() -> void
+  {
+    if (active()) {
+      buffer.reset();
+    }
+  }
+
+  static auto flush() -> void
+  {
+    if (active()) {
+      visualization_msgs::msg::MarkerArray message;
+      message.markers = buffer->markers;
+      buffer->publisher->publish(message);
+      buffer->markers.clear();
+    }
+  }
+
+  class Target
+  {
+  public:
+    void add(const visualization_msgs::msg::Marker & marker) const
+    {
+      if (active()) {
+        buffer->markers.push_back(marker);
+      }
+    }
+  };
+};
+}  // namespace openscenario_interpreter
+
+#endif  // OPENSCENARIO_INTERPRETER__VISUALIZATION_BUFFER_HPP_

--- a/openscenario/openscenario_interpreter/package.xml
+++ b/openscenario/openscenario_interpreter/package.xml
@@ -25,6 +25,7 @@
   <depend>tier4_simulation_msgs</depend>
   <depend>traffic_simulator</depend>
   <depend>traffic_simulator_msgs</depend>
+  <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_copyright</test_depend>

--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -14,8 +14,6 @@
 
 #define OPENSCENARIO_INTERPRETER_NO_EXTENSION
 
-#include <algorithm>
-#include <boost/json.hpp>
 #include <openscenario_interpreter/openscenario_interpreter.hpp>
 #include <openscenario_interpreter/record.hpp>
 #include <openscenario_interpreter/syntax/object_controller.hpp>
@@ -26,6 +24,10 @@
 #include <openscenario_interpreter/visualization_buffer.hpp>
 #include <status_monitor/status_monitor.hpp>
 #include <traffic_simulator/data_type/lanelet_pose.hpp>
+
+#include <boost/json.hpp>
+
+#include <algorithm>
 
 #define DECLARE_PARAMETER(IDENTIFIER) \
   declare_parameter<decltype(IDENTIFIER)>(#IDENTIFIER, IDENTIFIER)
@@ -50,9 +52,12 @@ Interpreter::Interpreter(const rclcpp::NodeOptions & options)
   DECLARE_PARAMETER(output_directory);
   DECLARE_PARAMETER(publish_empty_context);
   DECLARE_PARAMETER(record);
+  DECLARE_PARAMETER(publish_visualization);
 }
 
-Interpreter::~Interpreter() {}
+Interpreter::~Interpreter()
+{
+}
 
 auto Interpreter::currentLocalFrameRate() const -> std::chrono::milliseconds
 {
@@ -227,7 +232,9 @@ auto Interpreter::on_activate(const rclcpp_lifecycle::State &) -> Result
         SimulatorCore::activate(
           shared_from_this(), makeCurrentConfiguration(), local_real_time_factor, local_frame_rate);
 
-        VisualizationBuffer::activate(shared_from_this());
+        if (publish_visualization) {
+          VisualizationBuffer::activate(shared_from_this());
+        }
 
         /*
            DIRTY HACK!

--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -44,7 +44,8 @@ Interpreter::Interpreter(const rclcpp::NodeOptions & options)
   osc_path(""),
   output_directory("/tmp"),
   publish_empty_context(false),
-  record(false)
+  record(false),
+  publish_visualization(false)
 {
   DECLARE_PARAMETER(local_frame_rate);
   DECLARE_PARAMETER(local_real_time_factor);

--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -115,6 +115,7 @@ auto Interpreter::on_configure(const rclcpp_lifecycle::State &) -> Result
       GET_PARAMETER(output_directory);
       GET_PARAMETER(publish_empty_context);
       GET_PARAMETER(record);
+      GET_PARAMETER(publish_visualization);
 
       script = std::make_shared<OpenScenario>(osc_path);
 

--- a/openscenario/openscenario_interpreter/src/syntax/reach_position_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/reach_position_condition.cpp
@@ -130,6 +130,28 @@ auto ReachPositionCondition::visualize() const -> void
     return marker;
   };
 
+  const auto make_distance_label_marker = [&](auto && triggering_entity) {
+    visualization_msgs::msg::Marker marker;
+    marker.header.frame_id = "map";
+    marker.header.stamp = rclcpp::Clock().now();
+    marker.ns = "reach_position_condition/" + triggering_entity.name();
+    marker.id = 4;
+    marker.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+    marker.action = visualization_msgs::msg::Marker::ADD;
+    auto relative_pose = makeNativeRelativeWorldPosition(center, triggering_entity.name());
+    marker.pose.position.x = center.position.x - relative_pose.position.x / 2;
+    marker.pose.position.y = center.position.y - relative_pose.position.y / 2;
+    marker.pose.position.z = center.position.z - relative_pose.position.z / 2;
+    marker.text = std::to_string(hypot(
+      relative_pose.position.x, relative_pose.position.y, relative_pose.position.z, consider_z));
+    marker.scale.z = 0.3;
+    marker.color.a = 0.8;
+    marker.color.r = 1.0;
+    marker.color.g = 0.0;
+    marker.color.b = 0.0;
+    return marker;
+  };
+
   std::for_each(
     triggering_entities.entity_refs.begin(), triggering_entities.entity_refs.end(),
     [&](auto && triggering_entity) {
@@ -137,6 +159,7 @@ auto ReachPositionCondition::visualize() const -> void
         add(make_radius_marker(object));
         add(make_label_marker(object));
         add(make_distance_marker(object));
+        add(make_distance_label_marker(object));
       });
     });
 }

--- a/openscenario/openscenario_interpreter/src/syntax/reach_position_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/reach_position_condition.cpp
@@ -166,7 +166,7 @@ auto ReachPositionCondition::evaluate() -> Object
       return hypot(pose.position.x, pose.position.y, pose.position.z, consider_z);
     });
 
-  visualize();
+  call_visualize([this]() { visualize(); });
 
   results.clear();
 

--- a/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
+++ b/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
@@ -2876,6 +2876,18 @@ Visualization Manager:
             Reliability Policy: Reliable
             Value: /simulation/debug_marker
           Value: true
+        - Class: rviz_default_plugins/MarkerArray
+          Enabled: true
+          Name: Interpreter Marker
+          Namespaces:
+            {}
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /simulation/interpreter/markers
+          Value: true
         - Class: rviz_common/Group
           Displays:
             - Alpha: 0.9990000128746033
@@ -2984,19 +2996,7 @@ Visualization Manager:
           Name: Simple Sensor Simulator
       Enabled: true
       Name: Simulation
-    - Class: rviz_default_plugins/MarkerArray
       Enabled: true
-      Name: MarkerArray
-      Namespaces:
-        reach_position_condition/ego: true
-      Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /simulation/interpreter/markers
-      Value: true
-  Enabled: true
   Global Options:
     Background Color: 10; 10; 10
     Fixed Frame: map

--- a/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
+++ b/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
@@ -2984,6 +2984,18 @@ Visualization Manager:
           Name: Simple Sensor Simulator
       Enabled: true
       Name: Simulation
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: MarkerArray
+      Namespaces:
+        reach_position_condition/ego: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /simulation/interpreter/markers
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 10; 10; 10

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -80,6 +80,7 @@ def launch_setup(context, *args, **kwargs):
     output_directory                    = LaunchConfiguration("output_directory",                       default=Path("/tmp"))
     port                                = LaunchConfiguration("port",                                   default=5555)
     publish_empty_context               = LaunchConfiguration("publish_empty_context",                  default=False)
+    publish_visualization               = LaunchConfiguration("publish_visualization",                  default=False)
     record                              = LaunchConfiguration("record",                                 default=True)
     rviz_config                         = LaunchConfiguration("rviz_config",                            default=default_rviz_config_file())
     scenario                            = LaunchConfiguration("scenario",                               default=Path("/dev/null"))
@@ -104,6 +105,7 @@ def launch_setup(context, *args, **kwargs):
     print(f"output_directory                    := {output_directory.perform(context)}")
     print(f"port                                := {port.perform(context)}")
     print(f"publish_empty_context               := {publish_empty_context.perform(context)}")
+    print(f"publish_visualization               := {publish_visualization.perform(context)}")
     print(f"record                              := {record.perform(context)}")
     print(f"rviz_config                         := {rviz_config.perform(context)}")
     print(f"scenario                            := {scenario.perform(context)}")
@@ -129,6 +131,7 @@ def launch_setup(context, *args, **kwargs):
             {"launch_autoware": launch_autoware},
             {"port": port},
             {"publish_empty_context" : publish_empty_context},
+            {"publish_visualization": publish_visualization},
             {"record": record},
             {"rviz_config": rviz_config},
             {"sensor_model": sensor_model},
@@ -172,6 +175,7 @@ def launch_setup(context, *args, **kwargs):
         DeclareLaunchArgument("launch_autoware",                     default_value=launch_autoware                    ),
         DeclareLaunchArgument("launch_rviz",                         default_value=launch_rviz                        ),
         DeclareLaunchArgument("publish_empty_context",               default_value=publish_empty_context              ),
+        DeclareLaunchArgument("publish_visualization",               default_value=publish_visualization              ),
         DeclareLaunchArgument("output_directory",                    default_value=output_directory                   ),
         DeclareLaunchArgument("rviz_config",                         default_value=rviz_config                        ),
         DeclareLaunchArgument("scenario",                            default_value=scenario                           ),


### PR DESCRIPTION
# Description

## Abstract

This PR will add Rviz Marker for ReachPositionCondition.

## Background

Currently, `interpreter` does not expose its internal state for Rviz. However, there is a demand for showing state in Rviz for see internal state.

## Details

For efficiency, I added VisualizationBuffer and collect all markers in it.
To share VisualizationBuffer across each `Condition` syntax processor, I use singleton for it (like `SimulatorCore`).

# Known Limitations

As `traffic_simulator` and `openscenario_interpreter` are different package, distance line (red line between target position and current position) might not be accurate in case of using routing algorithm in distance calculation.