### PR TITLE
Refactor/relative distance condition

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/relative_distance_condition.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/relative_distance_condition.hpp
@@ -104,7 +104,7 @@ struct RelativeDistanceCondition : private Scope, private SimulatorCore::Conditi
     throw SyntaxError(__FILE__, ":", __LINE__);
   }
 
-  auto evaluate(const EntityRef &, const EntityRef &) -> double;
+  auto evaluate(const Entity &, const Entity &) -> double;
 
   auto evaluate() -> Object;
 };

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/relative_distance_condition.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/relative_distance_condition.hpp
@@ -99,12 +99,12 @@ struct RelativeDistanceCondition : private Scope, private SimulatorCore::Conditi
   template <
     CoordinateSystem::value_type, RelativeDistanceType::value_type, RoutingAlgorithm::value_type,
     Boolean::value_type>
-  auto distance(const EntityRef &) -> double
+  auto distance(const EntityRef &, const EntityRef &) -> double
   {
     throw SyntaxError(__FILE__, ":", __LINE__);
   }
 
-  auto evaluate(const EntityRef &) -> double;
+  auto evaluate(const EntityRef &, const EntityRef &) -> double;
 
   auto evaluate() -> Object;
 };
@@ -113,20 +113,20 @@ struct RelativeDistanceCondition : private Scope, private SimulatorCore::Conditi
 // cspell: ignore euclidian
 
 // clang-format off
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, false>(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, true >(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  false>(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  true >(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  false>(const EntityRef &) -> double;
-template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  true >(const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, false>(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, true >(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  false>(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  true >(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  false>(const EntityRef &, const EntityRef &) -> double;
+template <> auto RelativeDistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  true >(const EntityRef &, const EntityRef &) -> double;
 // clang-format on
 }  // namespace syntax
 }  // namespace openscenario_interpreter

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/relative_distance_condition.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/relative_distance_condition.hpp
@@ -99,12 +99,14 @@ struct RelativeDistanceCondition : private Scope, private SimulatorCore::Conditi
   template <
     CoordinateSystem::value_type, RelativeDistanceType::value_type, RoutingAlgorithm::value_type,
     Boolean::value_type>
-  auto distance(const EntityRef &, const EntityRef &) -> double
+  static auto distance(const EntityRef &, const EntityRef &) -> double
   {
     throw SyntaxError(__FILE__, ":", __LINE__);
   }
 
-  auto evaluate(const Entity &, const Entity &) -> double;
+  static auto evaluate(
+    const Entities *, const Entity &, const Entity &, CoordinateSystem, RelativeDistanceType,
+    RoutingAlgorithm, Boolean) -> double;
 
   auto evaluate() -> Object;
 };

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/relative_distance_condition.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/relative_distance_condition.hpp
@@ -104,7 +104,7 @@ struct RelativeDistanceCondition : private Scope, private SimulatorCore::Conditi
     throw SyntaxError(__FILE__, ":", __LINE__);
   }
 
-  auto distance(const EntityRef &) -> double;
+  auto evaluate(const EntityRef &) -> double;
 
   auto evaluate() -> Object;
 };

--- a/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
@@ -403,11 +403,14 @@ auto RelativeDistanceCondition::distance<
 #define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity, entity_ref)
 
 auto RelativeDistanceCondition::evaluate(
-  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
+  const Entity & triggering_entity, const Entity & entity_ref) -> double
 {
-  SWITCH_COORDINATE_SYSTEM(
-    SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
-  return Double::nan();
+  if (global().entities->isAdded(triggering_entity) and global().entities->isAdded(entity_ref)) {
+    SWITCH_COORDINATE_SYSTEM(
+      SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
+  } else {
+    return Double::nan();
+  }
 }
 
 auto RelativeDistanceCondition::evaluate() -> Object

--- a/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
@@ -317,9 +317,11 @@ auto RelativeDistanceCondition::distance<
 #define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity, entity_ref)
 
 auto RelativeDistanceCondition::evaluate(
-  const Entity & triggering_entity, const Entity & entity_ref) -> double
+  const Entities * entities, const Entity & triggering_entity, const Entity & entity_ref,
+  CoordinateSystem coordinate_system, RelativeDistanceType relative_distance_type,
+  RoutingAlgorithm routing_algorithm, Boolean freespace) -> double
 {
-  if (global().entities->isAdded(triggering_entity) and global().entities->isAdded(entity_ref)) {
+  if (entities->isAdded(triggering_entity) and entities->isAdded(entity_ref)) {
     SWITCH_COORDINATE_SYSTEM(
       SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
   } else {
@@ -332,8 +334,11 @@ auto RelativeDistanceCondition::evaluate() -> Object
   results.clear();
 
   return asBoolean(triggering_entities.apply([&](const auto & triggering_entity) {
-    results.push_back(triggering_entity.apply(
-      [&](const auto & triggering_entity) { return evaluate(triggering_entity, entity_ref); }));
+    results.push_back(triggering_entity.apply([&](const auto & triggering_entity) {
+      return evaluate(
+        global().entities, triggering_entity, entity_ref, coordinate_system, relative_distance_type,
+        routing_algorithm, freespace);
+    }));
     return not results.back().size() or rule(results.back(), value).min();
   }));
 }

--- a/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
@@ -343,52 +343,58 @@ auto RelativeDistanceCondition::distance<
   }
 }
 
-#define SWITCH_COORDINATE_SYSTEM(FUNCTION, ...)            \
-  switch (coordinate_system) {                             \
-    case CoordinateSystem::entity:                         \
-      FUNCTION(__VA_ARGS__, CoordinateSystem::entity);     \
-      break;                                               \
-    case CoordinateSystem::lane:                           \
-      FUNCTION(__VA_ARGS__, CoordinateSystem::lane);       \
-      break;                                               \
-    case CoordinateSystem::road:                           \
-      FUNCTION(__VA_ARGS__, CoordinateSystem::road);       \
-      break;                                               \
-    case CoordinateSystem::trajectory:                     \
-      FUNCTION(__VA_ARGS__, CoordinateSystem::trajectory); \
-      break;                                               \
+#define SWITCH_COORDINATE_SYSTEM(FUNCTION, ...)                                         \
+  switch (coordinate_system) {                                                          \
+    case CoordinateSystem::entity:                                                      \
+      FUNCTION(__VA_ARGS__, CoordinateSystem::entity);                                  \
+      break;                                                                            \
+    case CoordinateSystem::lane:                                                        \
+      FUNCTION(__VA_ARGS__, CoordinateSystem::lane);                                    \
+      break;                                                                            \
+    case CoordinateSystem::road:                                                        \
+      FUNCTION(__VA_ARGS__, CoordinateSystem::road);                                    \
+      break;                                                                            \
+    case CoordinateSystem::trajectory:                                                  \
+      FUNCTION(__VA_ARGS__, CoordinateSystem::trajectory);                              \
+      break;                                                                            \
+    default:                                                                            \
+      throw UNEXPECTED_ENUMERATION_VALUE_ASSIGNED(CoordinateSystem, coordinate_system); \
   }
 
-#define SWITCH_RELATIVE_DISTANCE_TYPE(FUNCTION, ...)                  \
-  switch (relative_distance_type) {                                   \
-    case RelativeDistanceType::longitudinal:                          \
-      FUNCTION(__VA_ARGS__, RelativeDistanceType::longitudinal);      \
-      break;                                                          \
-    case RelativeDistanceType::lateral:                               \
-      FUNCTION(__VA_ARGS__, RelativeDistanceType::lateral);           \
-      break;                                                          \
-    case RelativeDistanceType::euclidianDistance:                     \
-      FUNCTION(__VA_ARGS__, RelativeDistanceType::euclidianDistance); \
-      break;                                                          \
+#define SWITCH_RELATIVE_DISTANCE_TYPE(FUNCTION, ...)                                             \
+  switch (relative_distance_type) {                                                              \
+    case RelativeDistanceType::longitudinal:                                                     \
+      FUNCTION(__VA_ARGS__, RelativeDistanceType::longitudinal);                                 \
+      break;                                                                                     \
+    case RelativeDistanceType::lateral:                                                          \
+      FUNCTION(__VA_ARGS__, RelativeDistanceType::lateral);                                      \
+      break;                                                                                     \
+    case RelativeDistanceType::euclidianDistance:                                                \
+      FUNCTION(__VA_ARGS__, RelativeDistanceType::euclidianDistance);                            \
+      break;                                                                                     \
+    default:                                                                                     \
+      throw UNEXPECTED_ENUMERATION_VALUE_ASSIGNED(RelativeDistanceType, relative_distance_type); \
   }
 
-#define SWITCH_ROUTING_ALGORITHM(FUNCTION, ...)                     \
-  switch (routing_algorithm) {                                      \
-    case RoutingAlgorithm::assigned_route:                          \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::assigned_route);      \
-      break;                                                        \
-    case RoutingAlgorithm::fastest:                                 \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::fastest);             \
-      break;                                                        \
-    case RoutingAlgorithm::least_intersections:                     \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::least_intersections); \
-      break;                                                        \
-    case RoutingAlgorithm::shortest:                                \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::shortest);            \
-      break;                                                        \
-    case RoutingAlgorithm::undefined:                               \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::undefined);           \
-      break;                                                        \
+#define SWITCH_ROUTING_ALGORITHM(FUNCTION, ...)                                         \
+  switch (routing_algorithm) {                                                          \
+    case RoutingAlgorithm::assigned_route:                                              \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::assigned_route);                          \
+      break;                                                                            \
+    case RoutingAlgorithm::fastest:                                                     \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::fastest);                                 \
+      break;                                                                            \
+    case RoutingAlgorithm::least_intersections:                                         \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::least_intersections);                     \
+      break;                                                                            \
+    case RoutingAlgorithm::shortest:                                                    \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::shortest);                                \
+      break;                                                                            \
+    case RoutingAlgorithm::undefined:                                                   \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::undefined);                               \
+      break;                                                                            \
+    default:                                                                            \
+      throw UNEXPECTED_ENUMERATION_VALUE_ASSIGNED(RoutingAlgorithm, routing_algorithm); \
   }
 
 #define SWITCH_FREESPACE(FUNCTION, ...) \

--- a/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
@@ -67,7 +67,7 @@ auto RelativeDistanceCondition::description() const -> String
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(triggering_entity).as<ScenarioObject>().is_added and
@@ -81,7 +81,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(triggering_entity).as<ScenarioObject>().is_added and
@@ -100,7 +100,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(triggering_entity).as<ScenarioObject>().is_added and
@@ -117,7 +117,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(triggering_entity).as<ScenarioObject>().is_added and
@@ -132,7 +132,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined,
-  true>(const EntityRef & triggering_entity) -> double
+  true>(const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(triggering_entity).as<ScenarioObject>().is_added and
@@ -149,7 +149,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined,
-  false>(const EntityRef & triggering_entity) -> double
+  false>(const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(triggering_entity).as<ScenarioObject>().is_added and
@@ -166,7 +166,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(entity_ref).as<ScenarioObject>().is_added and
@@ -194,7 +194,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(entity_ref).as<ScenarioObject>().is_added and
@@ -222,7 +222,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(triggering_entity).as<ScenarioObject>().is_added and
@@ -250,7 +250,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(triggering_entity).as<ScenarioObject>().is_added and
@@ -278,7 +278,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::shortest, true>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(entity_ref).as<ScenarioObject>().is_added and
@@ -295,7 +295,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::shortest, false>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(entity_ref).as<ScenarioObject>().is_added and
@@ -312,7 +312,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::shortest, true>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(entity_ref).as<ScenarioObject>().is_added and
@@ -329,7 +329,7 @@ auto RelativeDistanceCondition::distance<
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::shortest, false>(
-  const EntityRef & triggering_entity) -> double
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   if (
     global().entities->at(entity_ref).as<ScenarioObject>().is_added and
@@ -394,9 +394,10 @@ auto RelativeDistanceCondition::distance<
 #define SWITCH_FREESPACE(FUNCTION, ...) \
   return freespace ? FUNCTION(__VA_ARGS__, true) : FUNCTION(__VA_ARGS__, false)
 
-#define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity)
+#define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity, entity_ref)
 
-auto RelativeDistanceCondition::evaluate(const EntityRef & triggering_entity) -> double
+auto RelativeDistanceCondition::evaluate(
+  const EntityRef & triggering_entity, const EntityRef & entity_ref) -> double
 {
   SWITCH_COORDINATE_SYSTEM(
     SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
@@ -408,8 +409,8 @@ auto RelativeDistanceCondition::evaluate() -> Object
   results.clear();
 
   return asBoolean(triggering_entities.apply([&](const auto & triggering_entity) {
-    results.push_back(
-      triggering_entity.apply([&](const auto & object) { return evaluate(object); }));
+    results.push_back(triggering_entity.apply(
+      [&](const auto & triggering_entity) { return evaluate(triggering_entity, entity_ref); }));
     return not results.back().size() or rule(results.back(), value).min();
   }));
 }

--- a/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/relative_distance_condition.cpp
@@ -78,9 +78,6 @@ auto RelativeDistanceCondition::distance<
   }
 }
 
-/**
- * @note This implementation differs from the OpenSCENARIO standard. See the section "6.4. Distances" in the OpenSCENARIO User Guide.
- */
 template <>
 auto RelativeDistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, true>(
@@ -89,6 +86,10 @@ auto RelativeDistanceCondition::distance<
   if (
     global().entities->at(triggering_entity).as<ScenarioObject>().is_added and
     global().entities->at(entity_ref).as<ScenarioObject>().is_added) {
+    /**
+       @note This implementation differs from the OpenSCENARIO standard. See
+       the section "5.4. Distances" in the OpenSCENARIO User Guide.
+    */
     return std::abs(
       makeNativeBoundingBoxRelativeWorldPosition(triggering_entity, entity_ref).position.x);
   } else {
@@ -395,7 +396,7 @@ auto RelativeDistanceCondition::distance<
 
 #define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity)
 
-auto RelativeDistanceCondition::distance(const EntityRef & triggering_entity) -> double
+auto RelativeDistanceCondition::evaluate(const EntityRef & triggering_entity) -> double
 {
   SWITCH_COORDINATE_SYSTEM(
     SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
@@ -408,7 +409,7 @@ auto RelativeDistanceCondition::evaluate() -> Object
 
   return asBoolean(triggering_entities.apply([&](const auto & triggering_entity) {
     results.push_back(
-      triggering_entity.apply([&](const auto & object) { return distance(object); }));
+      triggering_entity.apply([&](const auto & object) { return evaluate(object); }));
     return not results.back().size() or rule(results.back(), value).min();
   }));
 }


### PR DESCRIPTION
# Description

## Abstract

Added a static member function version of `RelativeDistanceCondition::evaluate`.

## Background

The static version of `RelativeDistanceCondition::evaluate` is useful for implementing TimeToCollisionCondition, so we implemented it.

## Details

None.

## References

None.

# Destructive Changes

None.

# Known Limitations

None.
