### PR TITLE
Refactor/distance condition

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/distance_condition.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/distance_condition.hpp
@@ -120,7 +120,7 @@ struct DistanceCondition : private Scope, private SimulatorCore::ConditionEvalua
     throw SyntaxError(__FILE__, ":", __LINE__);
   }
 
-  auto evaluate(const EntityRef &, const Position &) const -> double;
+  auto evaluate(const Entity &, const Position &) const -> double;
 
   auto evaluate() -> Object;
 };

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/distance_condition.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/distance_condition.hpp
@@ -115,12 +115,14 @@ struct DistanceCondition : private Scope, private SimulatorCore::ConditionEvalua
   template <
     CoordinateSystem::value_type, RelativeDistanceType::value_type, RoutingAlgorithm::value_type,
     Boolean::value_type>
-  auto distance(const EntityRef &, const Position &) const -> double
+  static auto distance(const EntityRef &, const Position &) -> double
   {
     throw SyntaxError(__FILE__, ":", __LINE__);
   }
 
-  auto evaluate(const Entity &, const Position &) const -> double;
+  static auto evaluate(
+    const Entities *, const Entity &, const Position &, CoordinateSystem, RelativeDistanceType,
+    RoutingAlgorithm, Boolean) -> double;
 
   auto evaluate() -> Object;
 };
@@ -129,20 +131,20 @@ struct DistanceCondition : private Scope, private SimulatorCore::ConditionEvalua
 // cspell: ignore euclidian
 
 // clang-format off
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  false>(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  true >(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  false>(const EntityRef &, const Position &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  true >(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  false>(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  true >(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  false>(const EntityRef &, const Position &) -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  true >(const EntityRef &, const Position &) -> double;
 // clang-format on
 }  // namespace syntax
 }  // namespace openscenario_interpreter

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/distance_condition.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/distance_condition.hpp
@@ -112,8 +112,6 @@ struct DistanceCondition : private Scope, private SimulatorCore::ConditionEvalua
 
   auto description() const -> std::string;
 
-  auto distance(const EntityRef &) const -> double;
-
   template <
     CoordinateSystem::value_type, RelativeDistanceType::value_type, RoutingAlgorithm::value_type,
     Boolean::value_type>
@@ -121,6 +119,8 @@ struct DistanceCondition : private Scope, private SimulatorCore::ConditionEvalua
   {
     throw SyntaxError(__FILE__, ":", __LINE__);
   }
+
+  auto evaluate(const EntityRef &) const -> double;
 
   auto evaluate() -> Object;
 };

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/distance_condition.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/syntax/distance_condition.hpp
@@ -115,12 +115,12 @@ struct DistanceCondition : private Scope, private SimulatorCore::ConditionEvalua
   template <
     CoordinateSystem::value_type, RelativeDistanceType::value_type, RoutingAlgorithm::value_type,
     Boolean::value_type>
-  auto distance(const EntityRef &) const -> double
+  auto distance(const EntityRef &, const Position &) const -> double
   {
     throw SyntaxError(__FILE__, ":", __LINE__);
   }
 
-  auto evaluate(const EntityRef &) const -> double;
+  auto evaluate(const EntityRef &, const Position &) const -> double;
 
   auto evaluate() -> Object;
 };
@@ -129,20 +129,20 @@ struct DistanceCondition : private Scope, private SimulatorCore::ConditionEvalua
 // cspell: ignore euclidian
 
 // clang-format off
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, false>(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, true >(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  false>(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  true >(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  false>(const EntityRef &) const -> double;
-template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  true >(const EntityRef &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::entity, RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, false>(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::undefined, true >(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  false>(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::lateral,           RoutingAlgorithm::shortest,  true >(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  false>(const EntityRef &, const Position &) const -> double;
+template <> auto DistanceCondition::distance<CoordinateSystem::lane,   RelativeDistanceType::longitudinal,      RoutingAlgorithm::shortest,  true >(const EntityRef &, const Position &) const -> double;
 // clang-format on
 }  // namespace syntax
 }  // namespace openscenario_interpreter

--- a/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
@@ -69,52 +69,58 @@ auto DistanceCondition::description() const -> std::string
   return description.str();
 }
 
-#define SWITCH_COORDINATE_SYSTEM(FUNCTION, ...)            \
-  switch (coordinate_system) {                             \
-    case CoordinateSystem::entity:                         \
-      FUNCTION(__VA_ARGS__, CoordinateSystem::entity);     \
-      break;                                               \
-    case CoordinateSystem::lane:                           \
-      FUNCTION(__VA_ARGS__, CoordinateSystem::lane);       \
-      break;                                               \
-    case CoordinateSystem::road:                           \
-      FUNCTION(__VA_ARGS__, CoordinateSystem::road);       \
-      break;                                               \
-    case CoordinateSystem::trajectory:                     \
-      FUNCTION(__VA_ARGS__, CoordinateSystem::trajectory); \
-      break;                                               \
+#define SWITCH_COORDINATE_SYSTEM(FUNCTION, ...)                                         \
+  switch (coordinate_system) {                                                          \
+    case CoordinateSystem::entity:                                                      \
+      FUNCTION(__VA_ARGS__, CoordinateSystem::entity);                                  \
+      break;                                                                            \
+    case CoordinateSystem::lane:                                                        \
+      FUNCTION(__VA_ARGS__, CoordinateSystem::lane);                                    \
+      break;                                                                            \
+    case CoordinateSystem::road:                                                        \
+      FUNCTION(__VA_ARGS__, CoordinateSystem::road);                                    \
+      break;                                                                            \
+    case CoordinateSystem::trajectory:                                                  \
+      FUNCTION(__VA_ARGS__, CoordinateSystem::trajectory);                              \
+      break;                                                                            \
+    default:                                                                            \
+      throw UNEXPECTED_ENUMERATION_VALUE_ASSIGNED(CoordinateSystem, coordinate_system); \
   }
 
-#define SWITCH_RELATIVE_DISTANCE_TYPE(FUNCTION, ...)                  \
-  switch (relative_distance_type) {                                   \
-    case RelativeDistanceType::longitudinal:                          \
-      FUNCTION(__VA_ARGS__, RelativeDistanceType::longitudinal);      \
-      break;                                                          \
-    case RelativeDistanceType::lateral:                               \
-      FUNCTION(__VA_ARGS__, RelativeDistanceType::lateral);           \
-      break;                                                          \
-    case RelativeDistanceType::euclidianDistance:                     \
-      FUNCTION(__VA_ARGS__, RelativeDistanceType::euclidianDistance); \
-      break;                                                          \
+#define SWITCH_RELATIVE_DISTANCE_TYPE(FUNCTION, ...)                                             \
+  switch (relative_distance_type) {                                                              \
+    case RelativeDistanceType::longitudinal:                                                     \
+      FUNCTION(__VA_ARGS__, RelativeDistanceType::longitudinal);                                 \
+      break;                                                                                     \
+    case RelativeDistanceType::lateral:                                                          \
+      FUNCTION(__VA_ARGS__, RelativeDistanceType::lateral);                                      \
+      break;                                                                                     \
+    case RelativeDistanceType::euclidianDistance:                                                \
+      FUNCTION(__VA_ARGS__, RelativeDistanceType::euclidianDistance);                            \
+      break;                                                                                     \
+    default:                                                                                     \
+      throw UNEXPECTED_ENUMERATION_VALUE_ASSIGNED(RelativeDistanceType, relative_distance_type); \
   }
 
-#define SWITCH_ROUTING_ALGORITHM(FUNCTION, ...)                     \
-  switch (routing_algorithm) {                                      \
-    case RoutingAlgorithm::assigned_route:                          \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::assigned_route);      \
-      break;                                                        \
-    case RoutingAlgorithm::fastest:                                 \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::fastest);             \
-      break;                                                        \
-    case RoutingAlgorithm::least_intersections:                     \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::least_intersections); \
-      break;                                                        \
-    case RoutingAlgorithm::shortest:                                \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::shortest);            \
-      break;                                                        \
-    case RoutingAlgorithm::undefined:                               \
-      FUNCTION(__VA_ARGS__, RoutingAlgorithm::undefined);           \
-      break;                                                        \
+#define SWITCH_ROUTING_ALGORITHM(FUNCTION, ...)                                         \
+  switch (routing_algorithm) {                                                          \
+    case RoutingAlgorithm::assigned_route:                                              \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::assigned_route);                          \
+      break;                                                                            \
+    case RoutingAlgorithm::fastest:                                                     \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::fastest);                                 \
+      break;                                                                            \
+    case RoutingAlgorithm::least_intersections:                                         \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::least_intersections);                     \
+      break;                                                                            \
+    case RoutingAlgorithm::shortest:                                                    \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::shortest);                                \
+      break;                                                                            \
+    case RoutingAlgorithm::undefined:                                                   \
+      FUNCTION(__VA_ARGS__, RoutingAlgorithm::undefined);                               \
+      break;                                                                            \
+    default:                                                                            \
+      throw UNEXPECTED_ENUMERATION_VALUE_ASSIGNED(RoutingAlgorithm, routing_algorithm); \
   }
 
 #define SWITCH_FREESPACE(FUNCTION, ...) \

--- a/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
@@ -122,7 +122,7 @@ auto DistanceCondition::description() const -> std::string
 
 #define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity)
 
-auto DistanceCondition::distance(const EntityRef & triggering_entity) const -> double
+auto DistanceCondition::evaluate(const EntityRef & triggering_entity) const -> double
 {
   SWITCH_COORDINATE_SYSTEM(
     SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
@@ -731,7 +731,7 @@ auto DistanceCondition::evaluate() -> Object
 
   return asBoolean(triggering_entities.apply([&](auto && triggering_entity) {
     results.push_back(
-      triggering_entity.apply([&](const auto & object) { return distance(object); }));
+      triggering_entity.apply([&](const auto & object) { return evaluate(object); }));
     return not results.back().size() or rule(results.back(), value).min();
   }));
 }

--- a/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
@@ -128,12 +128,15 @@ auto DistanceCondition::description() const -> std::string
 
 #define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity, position)
 
-auto DistanceCondition::evaluate(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+auto DistanceCondition::evaluate(const Entity & triggering_entity, const Position & position) const
+  -> double
 {
-  SWITCH_COORDINATE_SYSTEM(
-    SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
-  return Double::nan();
+  if (global().entities->isAdded(triggering_entity)) {
+    SWITCH_COORDINATE_SYSTEM(
+      SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
+  } else {
+    return Double::nan();
+  }
 }
 
 template <>
@@ -736,7 +739,7 @@ auto DistanceCondition::evaluate() -> Object
 {
   results.clear();
 
-  return asBoolean(triggering_entities.apply([&](auto && triggering_entity) {
+  return asBoolean(triggering_entities.apply([&](const auto & triggering_entity) {
     results.push_back(triggering_entity.apply(
       [&](const auto & triggering_entity) { return evaluate(triggering_entity, position); }));
     return not results.back().size() or rule(results.back(), value).min();

--- a/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
@@ -120,9 +120,10 @@ auto DistanceCondition::description() const -> std::string
 #define SWITCH_FREESPACE(FUNCTION, ...) \
   return freespace ? FUNCTION(__VA_ARGS__, true) : FUNCTION(__VA_ARGS__, false)
 
-#define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity)
+#define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity, position)
 
-auto DistanceCondition::evaluate(const EntityRef & triggering_entity) const -> double
+auto DistanceCondition::evaluate(
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   SWITCH_COORDINATE_SYSTEM(
     SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
@@ -132,7 +133,7 @@ auto DistanceCondition::evaluate(const EntityRef & triggering_entity) const -> d
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined,
-  false>(const EntityRef & triggering_entity) const -> double
+  false>(const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -166,7 +167,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined,
-  true>(const EntityRef & triggering_entity) const -> double
+  true>(const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -200,7 +201,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -230,7 +231,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -260,7 +261,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -290,7 +291,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -320,7 +321,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -369,7 +370,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -418,7 +419,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -467,7 +468,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -516,7 +517,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::shortest, false>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -569,7 +570,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::shortest, true>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -622,7 +623,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::shortest, false>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -675,7 +676,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::shortest, true>(
-  const EntityRef & triggering_entity) const -> double
+  const EntityRef & triggering_entity, const Position & position) const -> double
 {
   return apply<double>(
     overload(
@@ -730,8 +731,8 @@ auto DistanceCondition::evaluate() -> Object
   results.clear();
 
   return asBoolean(triggering_entities.apply([&](auto && triggering_entity) {
-    results.push_back(
-      triggering_entity.apply([&](const auto & object) { return evaluate(object); }));
+    results.push_back(triggering_entity.apply(
+      [&](const auto & triggering_entity) { return evaluate(triggering_entity, position); }));
     return not results.back().size() or rule(results.back(), value).min();
   }));
 }

--- a/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
@@ -335,43 +335,27 @@ auto DistanceCondition::distance<
   return apply<double>(
     overload(
       [&](const WorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .offset;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .offset;
       },
       [&](const RelativeWorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .offset;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .offset;
       },
       [&](const RelativeObjectPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return makeNativeRelativeLanePosition(
-                   triggering_entity, static_cast<NativeLanePosition>(position))
-            .offset;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return makeNativeRelativeLanePosition(
+                 triggering_entity, static_cast<NativeLanePosition>(position))
+          .offset;
       },
       [&](const LanePosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .offset;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .offset;
       }),
     position);
 }
@@ -384,43 +368,27 @@ auto DistanceCondition::distance<
   return apply<double>(
     overload(
       [&](const WorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeBoundingBoxRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .offset;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeBoundingBoxRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .offset;
       },
       [&](const RelativeWorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeBoundingBoxRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .offset;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeBoundingBoxRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .offset;
       },
       [&](const RelativeObjectPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return makeNativeBoundingBoxRelativeLanePosition(
-                   triggering_entity, static_cast<NativeLanePosition>(position))
-            .offset;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return makeNativeBoundingBoxRelativeLanePosition(
+                 triggering_entity, static_cast<NativeLanePosition>(position))
+          .offset;
       },
       [&](const LanePosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeBoundingBoxRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .offset;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeBoundingBoxRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .offset;
       }),
     position);
 }
@@ -433,43 +401,27 @@ auto DistanceCondition::distance<
   return apply<double>(
     overload(
       [&](const WorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .s;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .s;
       },
       [&](const RelativeWorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .s;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .s;
       },
       [&](const RelativeObjectPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return makeNativeRelativeLanePosition(
-                   triggering_entity, static_cast<NativeLanePosition>(position))
-            .s;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return makeNativeRelativeLanePosition(
+                 triggering_entity, static_cast<NativeLanePosition>(position))
+          .s;
       },
       [&](const LanePosition & position) {
-        if (global().entities->ref(triggering_entity).template as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .s;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .s;
       }),
     position);
 }
@@ -482,43 +434,27 @@ auto DistanceCondition::distance<
   return apply<double>(
     overload(
       [&](const WorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeBoundingBoxRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .s;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeBoundingBoxRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .s;
       },
       [&](const RelativeWorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeBoundingBoxRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .s;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeBoundingBoxRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .s;
       },
       [&](const RelativeObjectPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return makeNativeBoundingBoxRelativeLanePosition(
-                   triggering_entity, static_cast<NativeLanePosition>(position))
-            .s;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return makeNativeBoundingBoxRelativeLanePosition(
+                 triggering_entity, static_cast<NativeLanePosition>(position))
+          .s;
       },
       [&](const LanePosition & position) {
-        if (global().entities->ref(triggering_entity).template as<ScenarioObject>().is_added) {
-          return static_cast<traffic_simulator::LaneletPose>(
-                   makeNativeBoundingBoxRelativeLanePosition(
-                     triggering_entity, static_cast<NativeLanePosition>(position)))
-            .s;
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return static_cast<traffic_simulator::LaneletPose>(
+                 makeNativeBoundingBoxRelativeLanePosition(
+                   triggering_entity, static_cast<NativeLanePosition>(position)))
+          .s;
       }),
     position);
 }
@@ -531,47 +467,31 @@ auto DistanceCondition::distance<
   return apply<double>(
     overload(
       [&](const WorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .offset);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .offset);
       },
       [&](const RelativeWorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .offset);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .offset);
       },
       [&](const RelativeObjectPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(makeNativeRelativeLanePosition(
-                            triggering_entity, static_cast<NativeLanePosition>(position),
-                            RoutingAlgorithm::shortest)
-                            .offset);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(makeNativeRelativeLanePosition(
+                          triggering_entity, static_cast<NativeLanePosition>(position),
+                          RoutingAlgorithm::shortest)
+                          .offset);
       },
       [&](const LanePosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .offset);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .offset);
       }),
     position);
 }
@@ -584,47 +504,31 @@ auto DistanceCondition::distance<
   return apply<double>(
     overload(
       [&](const WorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeBoundingBoxRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .offset);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeBoundingBoxRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .offset);
       },
       [&](const RelativeWorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeBoundingBoxRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .offset);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeBoundingBoxRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .offset);
       },
       [&](const RelativeObjectPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(makeNativeBoundingBoxRelativeLanePosition(
-                            triggering_entity, static_cast<NativeLanePosition>(position),
-                            RoutingAlgorithm::shortest)
-                            .offset);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(makeNativeBoundingBoxRelativeLanePosition(
+                          triggering_entity, static_cast<NativeLanePosition>(position),
+                          RoutingAlgorithm::shortest)
+                          .offset);
       },
       [&](const LanePosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeBoundingBoxRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .offset);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeBoundingBoxRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .offset);
       }),
     position);
 }
@@ -637,47 +541,31 @@ auto DistanceCondition::distance<
   return apply<double>(
     overload(
       [&](const WorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .s);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .s);
       },
       [&](const RelativeWorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .s);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .s);
       },
       [&](const RelativeObjectPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(makeNativeRelativeLanePosition(
-                            triggering_entity, static_cast<NativeLanePosition>(position),
-                            RoutingAlgorithm::shortest)
-                            .s);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(makeNativeRelativeLanePosition(
+                          triggering_entity, static_cast<NativeLanePosition>(position),
+                          RoutingAlgorithm::shortest)
+                          .s);
       },
       [&](const LanePosition & position) {
-        if (global().entities->ref(triggering_entity).template as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .s);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .s);
       }),
     position);
 }
@@ -690,47 +578,31 @@ auto DistanceCondition::distance<
   return apply<double>(
     overload(
       [&](const WorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeBoundingBoxRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .s);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeBoundingBoxRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .s);
       },
       [&](const RelativeWorldPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeBoundingBoxRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .s);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeBoundingBoxRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .s);
       },
       [&](const RelativeObjectPosition & position) {
-        if (global().entities->ref(triggering_entity).as<ScenarioObject>().is_added) {
-          return std::abs(makeNativeBoundingBoxRelativeLanePosition(
-                            triggering_entity, static_cast<NativeLanePosition>(position),
-                            RoutingAlgorithm::shortest)
-                            .s);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(makeNativeBoundingBoxRelativeLanePosition(
+                          triggering_entity, static_cast<NativeLanePosition>(position),
+                          RoutingAlgorithm::shortest)
+                          .s);
       },
       [&](const LanePosition & position) {
-        if (global().entities->ref(triggering_entity).template as<ScenarioObject>().is_added) {
-          return std::abs(static_cast<traffic_simulator::LaneletPose>(
-                            makeNativeBoundingBoxRelativeLanePosition(
-                              triggering_entity, static_cast<NativeLanePosition>(position),
-                              RoutingAlgorithm::shortest))
-                            .s);
-        } else {
-          return std::numeric_limits<double>::quiet_NaN();
-        }
+        return std::abs(static_cast<traffic_simulator::LaneletPose>(
+                          makeNativeBoundingBoxRelativeLanePosition(
+                            triggering_entity, static_cast<NativeLanePosition>(position),
+                            RoutingAlgorithm::shortest))
+                          .s);
       }),
     position);
 }

--- a/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/distance_condition.cpp
@@ -128,10 +128,12 @@ auto DistanceCondition::description() const -> std::string
 
 #define DISTANCE(...) distance<__VA_ARGS__>(triggering_entity, position)
 
-auto DistanceCondition::evaluate(const Entity & triggering_entity, const Position & position) const
-  -> double
+auto DistanceCondition::evaluate(
+  const Entities * entities, const Entity & triggering_entity, const Position & position,
+  CoordinateSystem coordinate_system, RelativeDistanceType relative_distance_type,
+  RoutingAlgorithm routing_algorithm, Boolean freespace) -> double
 {
-  if (global().entities->isAdded(triggering_entity)) {
+  if (entities->isAdded(triggering_entity)) {
     SWITCH_COORDINATE_SYSTEM(
       SWITCH_RELATIVE_DISTANCE_TYPE, SWITCH_ROUTING_ALGORITHM, SWITCH_FREESPACE, DISTANCE);
   } else {
@@ -142,7 +144,7 @@ auto DistanceCondition::evaluate(const Entity & triggering_entity, const Positio
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined,
-  false>(const EntityRef & triggering_entity, const Position & position) const -> double
+  false>(const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -176,7 +178,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::euclidianDistance, RoutingAlgorithm::undefined,
-  true>(const EntityRef & triggering_entity, const Position & position) const -> double
+  true>(const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -210,7 +212,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -240,7 +242,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -270,7 +272,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -300,7 +302,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::entity, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -330,7 +332,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -363,7 +365,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -396,7 +398,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, false>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -429,7 +431,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::undefined, true>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -462,7 +464,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::shortest, false>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -499,7 +501,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::lateral, RoutingAlgorithm::shortest, true>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -536,7 +538,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::shortest, false>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -573,7 +575,7 @@ auto DistanceCondition::distance<
 template <>
 auto DistanceCondition::distance<
   CoordinateSystem::lane, RelativeDistanceType::longitudinal, RoutingAlgorithm::shortest, true>(
-  const EntityRef & triggering_entity, const Position & position) const -> double
+  const EntityRef & triggering_entity, const Position & position) -> double
 {
   return apply<double>(
     overload(
@@ -612,8 +614,11 @@ auto DistanceCondition::evaluate() -> Object
   results.clear();
 
   return asBoolean(triggering_entities.apply([&](const auto & triggering_entity) {
-    results.push_back(triggering_entity.apply(
-      [&](const auto & triggering_entity) { return evaluate(triggering_entity, position); }));
+    results.push_back(triggering_entity.apply([&](const auto & triggering_entity) {
+      return evaluate(
+        global().entities, triggering_entity, position, coordinate_system, relative_distance_type,
+        routing_algorithm, freespace);
+    }));
     return not results.back().size() or rule(results.back(), value).min();
   }));
 }


### PR DESCRIPTION
# Description

## Abstract

Added a static member function version of `DistanceCondition::evaluate`.

## Background

The static version of `DistanceCondition::evaluate` is useful for implementing TimeToCollisionCondition, so we implemented it.

## Details

None.

## References

None.

# Destructive Changes

None.

# Known Limitations

None.