### PR TITLE
Update Docker.yaml

### DIFF
--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -25,7 +25,8 @@ jobs:
     strategy:
       matrix:
         rosdistro: [humble]
-        arch: [amd64, arm64]
+        # arch: [amd64, arm64]
+        arch: [amd64]
 
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
# Description

Arm64 CI was broken, so remove it temporarily.

## Abstract

Remove ARM64 CI.

## Background

[Arm64 CI was broken,](https://github.com/tier4/scenario_simulator_v2/actions/runs/12384406410/job/34568901074) so remove it temporarily.

## Details

Remove arm64 CI from matrix.

```
    strategy:
      matrix:
        rosdistro: [humble]
        # arch: [amd64, arm64]
        arch: [amd64]
```

## References

N/A

# Destructive Changes

N/A

# Known Limitations

N/A
