### PR TITLE
Rjd 1388/follow trajectory fix

### DIFF
--- a/simulation/behavior_tree_plugin/src/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
@@ -79,7 +79,7 @@ auto FollowPolylineTrajectoryAction::tick() -> BT::NodeStatus
                  traffic_simulator::follow_trajectory::ValidatedEntityStatus(
                    static_cast<traffic_simulator::EntityStatus>(*canonicalized_entity_status),
                    behavior_parameter, step_time),
-                 hdmap_utils, behavior_parameter, *polyline_trajectory,
+                 hdmap_utils, *polyline_trajectory,
                  default_matching_distance_for_lanelet_pose_calculation, getTargetSpeed(),
                  step_time);
              entity_status_updated.has_value()) {

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
@@ -79,7 +79,7 @@ auto FollowPolylineTrajectoryAction::tick() -> BT::NodeStatus
                  traffic_simulator::follow_trajectory::ValidatedEntityStatus(
                    static_cast<traffic_simulator::EntityStatus>(*canonicalized_entity_status),
                    behavior_parameter, step_time),
-                 hdmap_utils, behavior_parameter, *polyline_trajectory,
+                 hdmap_utils, *polyline_trajectory,
                  default_matching_distance_for_lanelet_pose_calculation, getTargetSpeed(),
                  step_time);
              entity_status_updated.has_value()) {

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/polyline_trajectory_follower.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/polyline_trajectory_follower.hpp
@@ -21,7 +21,6 @@
 #include <traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp>
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator/hdmap_utils/hdmap_utils.hpp>
-#include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <traffic_simulator_msgs/msg/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/polyline_trajectory.hpp>
 
@@ -37,7 +36,6 @@ public:
   static auto makeUpdatedEntityStatus(
     const ValidatedEntityStatus & validated_entity_status,
     const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr,
-    const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter,
     traffic_simulator_msgs::msg::PolylineTrajectory & polyline_trajectory,
     const double matching_distance, const std::optional<double> target_speed,
     const double step_time) -> std::optional<EntityStatus>;

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.hpp
@@ -20,7 +20,6 @@
 #include <traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp>
 #include <traffic_simulator/data_type/entity_status.hpp>
 #include <traffic_simulator/hdmap_utils/hdmap_utils.hpp>
-#include <traffic_simulator_msgs/msg/behavior_parameter.hpp>
 #include <traffic_simulator_msgs/msg/entity_status.hpp>
 #include <traffic_simulator_msgs/msg/polyline_trajectory.hpp>
 
@@ -36,7 +35,6 @@ public:
     const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr,
     const ValidatedEntityStatus & validated_entity_status,
     const traffic_simulator_msgs::msg::PolylineTrajectory & polyline_trajectory,
-    const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter,
     const std::optional<double> target_speed, const double matching_distance,
     const double step_time);
 
@@ -45,7 +43,6 @@ public:
 private:
   const std::shared_ptr<hdmap_utils::HdMapUtils> hdmap_utils_ptr;
   const ValidatedEntityStatus validated_entity_status;
-  const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter;
   const traffic_simulator_msgs::msg::PolylineTrajectory polyline_trajectory;
   const double step_time;
   const double matching_distance;

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -37,7 +37,7 @@ public:
 
   const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
-  const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter;
+  const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter_;
   const geometry_msgs::msg::Vector3 current_velocity;
 
   ValidatedEntityStatus() = delete;
@@ -70,6 +70,11 @@ public:
   {
     return entity_status_.action_status.accel.linear.x;
   }
+  auto behaviorParameter() const noexcept(true)
+    -> const traffic_simulator_msgs::msg::BehaviorParameter &
+  {
+    return behavior_parameter_;
+  }
 
 private:
   auto validatePosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)
@@ -82,9 +87,9 @@ private:
     const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter,
     const double step_time) const noexcept(false) -> void;
 
-  auto validatedBehaviorParameter(
+  auto validateBehaviorParameter(
     const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter) const noexcept(false)
-    -> traffic_simulator_msgs::msg::BehaviorParameter;
+    -> void;
 
   auto buildUpdatedPoseOrientation(const geometry_msgs::msg::Vector3 & desired_velocity) const
     noexcept(true) -> geometry_msgs::msg::Quaternion;

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -55,11 +55,15 @@ public:
   ~ValidatedEntityStatus() = default;
 
 private:
-  auto validatedPosition() const noexcept(false) -> geometry_msgs::msg::Point;
+  auto validatedPosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)
+    -> geometry_msgs::msg::Point;
 
-  auto validatedLinearSpeed() const noexcept(false) -> double;
+  auto validatedLinearSpeed(const double entity_speed) const noexcept(false) -> double;
 
-  auto validatedLinearAcceleration() const noexcept(false) -> double;
+  auto validatedLinearAcceleration(
+    const double acceleration,
+    const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter,
+    const double step_time) const noexcept(false) -> double;
 
   auto validatedBehaviorParameter(
     const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter) const noexcept(false)
@@ -68,8 +72,9 @@ private:
   auto buildUpdatedPoseOrientation(const geometry_msgs::msg::Vector3 & desired_velocity) const
     noexcept(true) -> geometry_msgs::msg::Quaternion;
 
-  auto buildValidatedCurrentVelocity(const double speed) const noexcept(false)
-    -> geometry_msgs::msg::Vector3;
+  auto buildValidatedCurrentVelocity(
+    const double speed, const geometry_msgs::msg::Quaternion & entity_orientation) const
+    noexcept(false) -> geometry_msgs::msg::Vector3;
 
   template <
     typename T, std::enable_if_t<math::geometry::IsLikeVector3<T>::value, std::nullptr_t> = nullptr>

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -47,38 +47,18 @@ public:
   ValidatedEntityStatus & operator=(ValidatedEntityStatus && other) noexcept(true) = delete;
   ~ValidatedEntityStatus() = default;
 
-  auto name() const noexcept(true) -> const std::string & { return entity_status_.name; }
-  auto time() const noexcept(true) -> double { return entity_status_.time; }
-  auto boundingBox() const noexcept(true) -> const traffic_simulator_msgs::msg::BoundingBox &
-  {
-    return entity_status_.bounding_box;
-  }
-  auto laneletPoseValid() const noexcept(true) -> bool { return entity_status_.lanelet_pose_valid; }
-  auto position() const noexcept(true) -> const geometry_msgs::msg::Point &
-  {
-    return entity_status_.pose.position;
-  }
-  auto orientation() const noexcept(true) -> const geometry_msgs::msg::Quaternion &
-  {
-    return entity_status_.pose.orientation;
-  }
-  auto linearSpeed() const noexcept(true) -> double
-  {
-    return entity_status_.action_status.twist.linear.x;
-  }
-  auto linearAcceleration() const noexcept(true) -> double
-  {
-    return entity_status_.action_status.accel.linear.x;
-  }
-  auto behaviorParameter() const noexcept(true)
-    -> const traffic_simulator_msgs::msg::BehaviorParameter &
-  {
-    return behavior_parameter_;
-  }
-  auto currentVelocity() const noexcept(true) -> const geometry_msgs::msg::Vector3 &
-  {
-    return current_velocity_;
-  }
+  // clang-format off
+  auto name()               const noexcept(true) -> const std::string &                                    { return entity_status_.name;                         }
+  auto time()               const noexcept(true) -> double                                                 { return entity_status_.time;                         }
+  auto boundingBox()        const noexcept(true) -> const traffic_simulator_msgs::msg::BoundingBox &       { return entity_status_.bounding_box;                 }
+  auto laneletPoseValid()   const noexcept(true) -> bool                                                   { return entity_status_.lanelet_pose_valid;           }
+  auto position()           const noexcept(true) -> const geometry_msgs::msg::Point &                      { return entity_status_.pose.position;                }
+  auto orientation()        const noexcept(true) -> const geometry_msgs::msg::Quaternion &                 { return entity_status_.pose.orientation;             }
+  auto linearSpeed()        const noexcept(true) -> double                                                 { return entity_status_.action_status.twist.linear.x; }
+  auto linearAcceleration() const noexcept(true) -> double                                                 { return entity_status_.action_status.accel.linear.x; }
+  auto behaviorParameter()  const noexcept(true) -> const traffic_simulator_msgs::msg::BehaviorParameter & { return behavior_parameter_;                         }
+  auto currentVelocity()    const noexcept(true) -> const geometry_msgs::msg::Vector3 &                    { return current_velocity_;                           }
+  // clang-format on
 
 private:
   auto validatePosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -38,7 +38,6 @@ public:
   const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
   const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter;
-  const double linear_acceleration;
   const geometry_msgs::msg::Vector3 current_velocity;
 
   ValidatedEntityStatus() = delete;
@@ -63,6 +62,10 @@ public:
   {
     return entity_status_.action_status.twist.linear.x;
   }
+  auto linearAcceleration() const noexcept(true) -> double
+  {
+    return entity_status_.action_status.accel.linear.x;
+  }
 
 private:
   auto validatedPosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)
@@ -70,10 +73,10 @@ private:
 
   auto validateLinearSpeed(const double entity_speed) const noexcept(false) -> void;
 
-  auto validatedLinearAcceleration(
+  auto validateLinearAcceleration(
     const double acceleration,
     const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter,
-    const double step_time) const noexcept(false) -> double;
+    const double step_time) const noexcept(false) -> void;
 
   auto validatedBehaviorParameter(
     const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter) const noexcept(false)

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -38,7 +38,7 @@ public:
   const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
   const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter_;
-  const geometry_msgs::msg::Vector3 current_velocity;
+  const geometry_msgs::msg::Vector3 current_velocity_;
 
   ValidatedEntityStatus() = delete;
   ValidatedEntityStatus(const ValidatedEntityStatus & other);
@@ -74,6 +74,10 @@ public:
     -> const traffic_simulator_msgs::msg::BehaviorParameter &
   {
     return behavior_parameter_;
+  }
+  auto currentVelocity() const noexcept(true) -> const geometry_msgs::msg::Vector3 &
+  {
+    return current_velocity_;
   }
 
 private:

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -72,8 +72,8 @@ public:
   }
 
 private:
-  auto validatedPosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)
-    -> geometry_msgs::msg::Point;
+  auto validatePosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)
+    -> void;
 
   auto validateLinearSpeed(const double entity_speed) const noexcept(false) -> void;
 

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -35,7 +35,7 @@ public:
   auto buildUpdatedEntityStatus(const geometry_msgs::msg::Vector3 & desired_velocity) const
     -> traffic_simulator_msgs::msg::EntityStatus;
 
-  const double step_time;
+  const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
   const std::string & name;
   const double time;

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -38,7 +38,6 @@ public:
   const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
   const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter;
-  const double linear_speed;
   const double linear_acceleration;
   const geometry_msgs::msg::Vector3 current_velocity;
 
@@ -60,12 +59,16 @@ public:
   {
     return entity_status_.pose.position;
   }
+  auto linearSpeed() const noexcept(true) -> double
+  {
+    return entity_status_.action_status.twist.linear.x;
+  }
 
 private:
   auto validatedPosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)
     -> geometry_msgs::msg::Point;
 
-  auto validatedLinearSpeed(const double entity_speed) const noexcept(false) -> double;
+  auto validateLinearSpeed(const double entity_speed) const noexcept(false) -> void;
 
   auto validatedLinearAcceleration(
     const double acceleration,

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -37,7 +37,6 @@ public:
 
   const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box;
   const bool lanelet_pose_valid;
   const geometry_msgs::msg::Point position;
   const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter;
@@ -54,6 +53,10 @@ public:
 
   auto name() const noexcept(true) -> const std::string & { return entity_status_.name; }
   auto time() const noexcept(true) -> double { return entity_status_.time; }
+  auto boundingBox() const noexcept(true) -> const traffic_simulator_msgs::msg::BoundingBox &
+  {
+    return entity_status_.bounding_box;
+  }
 
 private:
   auto validatedPosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -35,17 +35,17 @@ public:
   auto buildUpdatedEntityStatus(const geometry_msgs::msg::Vector3 & desired_velocity) const
     -> traffic_simulator_msgs::msg::EntityStatus;
 
+  const double step_time;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
   const std::string & name;
   const double time;
-  const double step_time;
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box;
+  const bool lanelet_pose_valid;
   const geometry_msgs::msg::Point position;
+  const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter;
   const double linear_speed;
   const double linear_acceleration;
-  const bool lanelet_pose_valid;
   const geometry_msgs::msg::Vector3 current_velocity;
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box;
-  const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter;
 
   ValidatedEntityStatus() = delete;
   ValidatedEntityStatus(const ValidatedEntityStatus & other);

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -37,7 +37,6 @@ public:
 
   const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
-  const double time;
   const traffic_simulator_msgs::msg::BoundingBox & bounding_box;
   const bool lanelet_pose_valid;
   const geometry_msgs::msg::Point position;
@@ -54,6 +53,7 @@ public:
   ~ValidatedEntityStatus() = default;
 
   auto name() const noexcept(true) -> const std::string & { return entity_status_.name; }
+  auto time() const noexcept(true) -> double { return entity_status_.time; }
 
 private:
   auto validatedPosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -37,7 +37,6 @@ public:
 
   const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
-  const std::string & name;
   const double time;
   const traffic_simulator_msgs::msg::BoundingBox & bounding_box;
   const bool lanelet_pose_valid;
@@ -53,6 +52,8 @@ public:
   ValidatedEntityStatus(ValidatedEntityStatus && other) noexcept(true) = delete;
   ValidatedEntityStatus & operator=(ValidatedEntityStatus && other) noexcept(true) = delete;
   ~ValidatedEntityStatus() = default;
+
+  auto name() const noexcept(true) -> const std::string & { return entity_status_.name; }
 
 private:
   auto validatedPosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -58,6 +58,10 @@ public:
   {
     return entity_status_.pose.position;
   }
+  auto orientation() const noexcept(true) -> const geometry_msgs::msg::Quaternion &
+  {
+    return entity_status_.pose.orientation;
+  }
   auto linearSpeed() const noexcept(true) -> double
   {
     return entity_status_.action_status.twist.linear.x;

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -35,11 +35,6 @@ public:
   auto buildUpdatedEntityStatus(const geometry_msgs::msg::Vector3 & desired_velocity) const
     -> traffic_simulator_msgs::msg::EntityStatus;
 
-  const double step_time_;
-  const traffic_simulator_msgs::msg::EntityStatus entity_status_;
-  const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter_;
-  const geometry_msgs::msg::Vector3 current_velocity_;
-
   ValidatedEntityStatus() = delete;
   ValidatedEntityStatus(const ValidatedEntityStatus & other);
   ValidatedEntityStatus & operator=(const ValidatedEntityStatus & other) = delete;
@@ -102,6 +97,11 @@ private:
       ", Variable: ", std::quoted(variable_name), ", variable contains NaN or inf value, ",
       "Value: ", variable);
   }
+
+  const double step_time_;
+  const traffic_simulator_msgs::msg::EntityStatus entity_status_;
+  const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter_;
+  const geometry_msgs::msg::Vector3 current_velocity_;
 };
 
 }  // namespace follow_trajectory

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -37,7 +37,6 @@ public:
 
   const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
-  const bool lanelet_pose_valid;
   const geometry_msgs::msg::Point position;
   const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter;
   const double linear_speed;
@@ -57,6 +56,7 @@ public:
   {
     return entity_status_.bounding_box;
   }
+  auto laneletPoseValid() const noexcept(true) -> bool { return entity_status_.lanelet_pose_valid; }
 
 private:
   auto validatedPosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/polyline_trajectory_follower/validated_entity_status.hpp
@@ -37,7 +37,6 @@ public:
 
   const double step_time_;
   const traffic_simulator_msgs::msg::EntityStatus entity_status_;
-  const geometry_msgs::msg::Point position;
   const traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter;
   const double linear_speed;
   const double linear_acceleration;
@@ -57,6 +56,10 @@ public:
     return entity_status_.bounding_box;
   }
   auto laneletPoseValid() const noexcept(true) -> bool { return entity_status_.lanelet_pose_valid; }
+  auto position() const noexcept(true) -> const geometry_msgs::msg::Point &
+  {
+    return entity_status_.pose.position;
+  }
 
 private:
   auto validatedPosition(const geometry_msgs::msg::Point & entity_position) const noexcept(false)

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_follower.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_follower.cpp
@@ -35,18 +35,16 @@ namespace follow_trajectory
 auto PolylineTrajectoryFollower::makeUpdatedEntityStatus(
   const ValidatedEntityStatus & validated_entity_status,
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr,
-  const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter,
   traffic_simulator_msgs::msg::PolylineTrajectory & polyline_trajectory,
   const double matching_distance, const std::optional<double> target_speed, const double step_time)
   -> std::optional<EntityStatus>
 {
   assert(step_time > 0.0);
   while (not polyline_trajectory.shape.vertices.empty()) {
-    const auto updated_entity_opt =
-      PolylineTrajectoryPositioner(
-        hdmap_utils_ptr, validated_entity_status, polyline_trajectory, behavior_parameter,
-        target_speed, matching_distance, step_time)
-        .makeUpdatedEntityStatus();
+    const auto updated_entity_opt = PolylineTrajectoryPositioner(
+                                      hdmap_utils_ptr, validated_entity_status, polyline_trajectory,
+                                      target_speed, matching_distance, step_time)
+                                      .makeUpdatedEntityStatus();
     if (updated_entity_opt.has_value()) {
       return updated_entity_opt;
     } else {

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_follower.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_follower.cpp
@@ -50,7 +50,7 @@ auto PolylineTrajectoryFollower::makeUpdatedEntityStatus(
     if (updated_entity_opt.has_value()) {
       return updated_entity_opt;
     } else {
-      discardTheFrontWaypoint(polyline_trajectory, validated_entity_status.entity_status_.time);
+      discardTheFrontWaypoint(polyline_trajectory, validated_entity_status.time());
     }
   }
   return std::nullopt;

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -47,7 +47,7 @@ PolylineTrajectoryPositioner::PolylineTrajectoryPositioner(
   nearest_waypoint_with_specified_time_it(nearestWaypointWithSpecifiedTimeIterator()),
   nearest_waypoint_position(validatedEntityTargetPosition()),
   distance_to_nearest_waypoint(distanceAlongLanelet(
-    hdmap_utils_ptr, validated_entity_status.bounding_box, matching_distance,
+    hdmap_utils_ptr, validated_entity_status.boundingBox(), matching_distance,
     validated_entity_status.entity_status_.pose.position, nearest_waypoint_position)),
   total_remaining_distance(totalRemainingDistance(matching_distance, hdmap_utils_ptr)),
   time_to_nearest_waypoint(
@@ -112,7 +112,7 @@ auto PolylineTrajectoryPositioner::totalRemainingDistance(
           const double total_distance, const auto & vertex) {
           const auto next = std::next(&vertex);
           return total_distance + distanceAlongLanelet(
-                                    hdmap_utils_ptr, validated_entity_status.bounding_box,
+                                    hdmap_utils_ptr, validated_entity_status.boundingBox(),
                                     matching_distance, vertex.position.position,
                                     next->position.position);
         });

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -243,7 +243,7 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredAcceleration() const no
 
   try {
     const double desired_acceleration = follow_waypoint_controller.getAcceleration(
-      total_remaining_time, total_remaining_distance, validated_entity_status.linear_acceleration,
+      total_remaining_time, total_remaining_distance, validated_entity_status.linearAcceleration(),
       validated_entity_status.linearSpeed());
 
     if (not std::isfinite(desired_acceleration)) {
@@ -330,7 +330,7 @@ auto PolylineTrajectoryPositioner::makeUpdatedEntityStatus() const -> std::optio
         maximum speed including braking - in this case accuracy of arrival is checked
       */
       if (follow_waypoint_controller.areConditionsOfArrivalMet(
-            validated_entity_status.linear_acceleration, validated_entity_status.linearSpeed(),
+            validated_entity_status.linearAcceleration(), validated_entity_status.linearSpeed(),
             distance_to_nearest_waypoint)) {
         return std::nullopt;
       } else {
@@ -359,7 +359,7 @@ auto PolylineTrajectoryPositioner::makeUpdatedEntityStatus() const -> std::optio
     */
   } else if (math::arithmetic::isDefinitelyLessThan(time_to_nearest_waypoint, step_time / 2.0)) {
     if (follow_waypoint_controller.areConditionsOfArrivalMet(
-          validated_entity_status.linear_acceleration, validated_entity_status.linearSpeed(),
+          validated_entity_status.linearAcceleration(), validated_entity_status.linearSpeed(),
           distance_to_nearest_waypoint)) {
       return std::nullopt;
     } else {
@@ -422,7 +422,7 @@ auto PolylineTrajectoryPositioner::validatePredictedState(const double desired_a
 {
   const auto predicted_state_opt = follow_waypoint_controller.getPredictedWaypointArrivalState(
     desired_acceleration, total_remaining_time, total_remaining_distance,
-    validated_entity_status.linear_acceleration, validated_entity_status.linearSpeed());
+    validated_entity_status.linearAcceleration(), validated_entity_status.linearSpeed());
   if (not std::isinf(total_remaining_time) and not predicted_state_opt.has_value()) {
     THROW_SIMULATION_ERROR(
       "An error occurred in the internal state of FollowTrajectoryAction. Please report the "
@@ -431,7 +431,7 @@ auto PolylineTrajectoryPositioner::validatePredictedState(const double desired_a
       " calculated invalid acceleration:", " desired_acceleration: ", desired_acceleration,
       ", total_remaining_time: ", total_remaining_time,
       ", total_remaining_distance: ", total_remaining_distance,
-      ", acceleration: ", validated_entity_status.linear_acceleration,
+      ", acceleration: ", validated_entity_status.linearAcceleration(),
       ", speed: ", validated_entity_status.linearSpeed(), ". ", follow_waypoint_controller);
   }
 }

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -202,7 +202,7 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredVelocity(const double d
   const double dy = nearest_waypoint_position.y - validated_entity_status.position.y;
   // if entity is on lane use pitch from lanelet, otherwise use pitch on target
   const double pitch =
-    validated_entity_status.lanelet_pose_valid
+    validated_entity_status.laneletPoseValid()
       ? -math::geometry::convertQuaternionToEulerAngle(
            validated_entity_status.entity_status_.pose.orientation)
            .y

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -198,8 +198,8 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredVelocity(const double d
     THROW_SIMULATION_ERROR("The followingMode is only supported for position.");
   }
 
-  const double dx = nearest_waypoint_position.x - validated_entity_status.position.x;
-  const double dy = nearest_waypoint_position.y - validated_entity_status.position.y;
+  const double dx = nearest_waypoint_position.x - validated_entity_status.position().x;
+  const double dy = nearest_waypoint_position.y - validated_entity_status.position().y;
   // if entity is on lane use pitch from lanelet, otherwise use pitch on target
   const double pitch =
     validated_entity_status.laneletPoseValid()
@@ -207,7 +207,7 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredVelocity(const double d
            validated_entity_status.entity_status_.pose.orientation)
            .y
       : std::atan2(
-          nearest_waypoint_position.z - validated_entity_status.position.z, std::hypot(dy, dx));
+          nearest_waypoint_position.z - validated_entity_status.position().z, std::hypot(dy, dx));
   const double yaw = std::atan2(dy, dx);  // Use yaw on target
 
   const auto desired_velocity = geometry_msgs::build<geometry_msgs::msg::Vector3>()

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -203,9 +203,7 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredVelocity(const double d
   // if entity is on lane use pitch from lanelet, otherwise use pitch on target
   const double pitch =
     validated_entity_status.laneletPoseValid()
-      ? -math::geometry::convertQuaternionToEulerAngle(
-           validated_entity_status.entity_status_.pose.orientation)
-           .y
+      ? -math::geometry::convertQuaternionToEulerAngle(validated_entity_status.orientation()).y
       : std::atan2(
           nearest_waypoint_position.z - validated_entity_status.position().z, std::hypot(dy, dx));
   const double yaw = std::atan2(dy, dx);  // Use yaw on target

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -36,11 +36,9 @@ PolylineTrajectoryPositioner::PolylineTrajectoryPositioner(
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr,
   const ValidatedEntityStatus & validated_entity_status,
   const traffic_simulator_msgs::msg::PolylineTrajectory & polyline_trajectory,
-  const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter,
   const std::optional<double> target_speed, const double matching_distance, const double step_time)
 : hdmap_utils_ptr(hdmap_utils_ptr),
   validated_entity_status(validated_entity_status),
-  behavior_parameter(behavior_parameter),
   polyline_trajectory(polyline_trajectory),
   step_time(step_time),
   matching_distance(matching_distance),

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -244,7 +244,7 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredAcceleration() const no
   try {
     const double desired_acceleration = follow_waypoint_controller.getAcceleration(
       total_remaining_time, total_remaining_distance, validated_entity_status.linear_acceleration,
-      validated_entity_status.linear_speed);
+      validated_entity_status.linearSpeed());
 
     if (not std::isfinite(desired_acceleration)) {
       THROW_SIMULATION_ERROR(
@@ -309,7 +309,7 @@ auto PolylineTrajectoryPositioner::makeUpdatedEntityStatus() const -> std::optio
   const auto desired_velocity = validatedEntityDesiredVelocity(desired_speed);
 
   if (const bool target_passed =
-        validated_entity_status.linear_speed * step_time > distance_to_nearest_waypoint and
+        validated_entity_status.linearSpeed() * step_time > distance_to_nearest_waypoint and
         math::geometry::innerProduct(desired_velocity, validated_entity_status.current_velocity) <
           0.0;
       target_passed) {
@@ -330,7 +330,7 @@ auto PolylineTrajectoryPositioner::makeUpdatedEntityStatus() const -> std::optio
         maximum speed including braking - in this case accuracy of arrival is checked
       */
       if (follow_waypoint_controller.areConditionsOfArrivalMet(
-            validated_entity_status.linear_acceleration, validated_entity_status.linear_speed,
+            validated_entity_status.linear_acceleration, validated_entity_status.linearSpeed(),
             distance_to_nearest_waypoint)) {
         return std::nullopt;
       } else {
@@ -342,7 +342,7 @@ auto PolylineTrajectoryPositioner::makeUpdatedEntityStatus() const -> std::optio
         irrelevant
       */
       if (const double this_step_distance =
-            (validated_entity_status.linear_speed + desired_acceleration * step_time) * step_time;
+            (validated_entity_status.linearSpeed() + desired_acceleration * step_time) * step_time;
           this_step_distance > distance_to_nearest_waypoint) {
         return std::nullopt;
       } else {
@@ -359,7 +359,7 @@ auto PolylineTrajectoryPositioner::makeUpdatedEntityStatus() const -> std::optio
     */
   } else if (math::arithmetic::isDefinitelyLessThan(time_to_nearest_waypoint, step_time / 2.0)) {
     if (follow_waypoint_controller.areConditionsOfArrivalMet(
-          validated_entity_status.linear_acceleration, validated_entity_status.linear_speed,
+          validated_entity_status.linear_acceleration, validated_entity_status.linearSpeed(),
           distance_to_nearest_waypoint)) {
       return std::nullopt;
     } else {
@@ -405,7 +405,7 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredSpeed(
   const double desired_acceleration) const noexcept(false) -> double
 {
   const double desired_speed =
-    validated_entity_status.linear_speed + desired_acceleration * step_time;
+    validated_entity_status.linearSpeed() + desired_acceleration * step_time;
 
   if (not std::isfinite(desired_speed)) {
     THROW_SIMULATION_ERROR(
@@ -422,7 +422,7 @@ auto PolylineTrajectoryPositioner::validatePredictedState(const double desired_a
 {
   const auto predicted_state_opt = follow_waypoint_controller.getPredictedWaypointArrivalState(
     desired_acceleration, total_remaining_time, total_remaining_distance,
-    validated_entity_status.linear_acceleration, validated_entity_status.linear_speed);
+    validated_entity_status.linear_acceleration, validated_entity_status.linearSpeed());
   if (not std::isinf(total_remaining_time) and not predicted_state_opt.has_value()) {
     THROW_SIMULATION_ERROR(
       "An error occurred in the internal state of FollowTrajectoryAction. Please report the "
@@ -432,7 +432,7 @@ auto PolylineTrajectoryPositioner::validatePredictedState(const double desired_a
       ", total_remaining_time: ", total_remaining_time,
       ", total_remaining_distance: ", total_remaining_distance,
       ", acceleration: ", validated_entity_status.linear_acceleration,
-      ", speed: ", validated_entity_status.linear_speed, ". ", follow_waypoint_controller);
+      ", speed: ", validated_entity_status.linearSpeed(), ". ", follow_waypoint_controller);
   }
 }
 

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -52,7 +52,7 @@ PolylineTrajectoryPositioner::PolylineTrajectoryPositioner(
   total_remaining_distance(totalRemainingDistance(matching_distance, hdmap_utils_ptr)),
   time_to_nearest_waypoint(
     (std::isnan(polyline_trajectory.base_time) ? 0.0 : polyline_trajectory.base_time) +
-    polyline_trajectory.shape.vertices.front().time - validated_entity_status.time),
+    polyline_trajectory.shape.vertices.front().time - validated_entity_status.time()),
   total_remaining_time(totalRemainingTime()),
   follow_waypoint_controller(FollowWaypointController(
     validated_entity_status.behavior_parameter, step_time,
@@ -134,7 +134,7 @@ auto PolylineTrajectoryPositioner::totalRemainingTime() const noexcept(false) ->
   } else {
     const double remaining_time =
       (std::isnan(polyline_trajectory.base_time) ? 0.0 : polyline_trajectory.base_time) +
-      nearest_waypoint_with_specified_time_it->time - validated_entity_status.time;
+      nearest_waypoint_with_specified_time_it->time - validated_entity_status.time();
 
     /*
       The condition below should ideally be remaining_time < 0.
@@ -365,7 +365,7 @@ auto PolylineTrajectoryPositioner::makeUpdatedEntityStatus() const -> std::optio
     } else {
       THROW_SIMULATION_ERROR(
         "Vehicle ", std::quoted(validated_entity_status.name()), " at time ",
-        validated_entity_status.time, "s (remaining time is ", time_to_nearest_waypoint,
+        validated_entity_status.time(), "s (remaining time is ", time_to_nearest_waypoint,
         "s), has completed a trajectory to the nearest waypoint with", " specified time equal to ",
         polyline_trajectory.shape.vertices.front().time, "s at a distance equal to ",
         distance_to_nearest_waypoint,

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -48,7 +48,7 @@ PolylineTrajectoryPositioner::PolylineTrajectoryPositioner(
   nearest_waypoint_position(validatedEntityTargetPosition()),
   distance_to_nearest_waypoint(distanceAlongLanelet(
     hdmap_utils_ptr, validated_entity_status.boundingBox(), matching_distance,
-    validated_entity_status.entity_status_.pose.position, nearest_waypoint_position)),
+    validated_entity_status.position(), nearest_waypoint_position)),
   total_remaining_distance(totalRemainingDistance(matching_distance, hdmap_utils_ptr)),
   time_to_nearest_waypoint(
     (std::isnan(polyline_trajectory.base_time) ? 0.0 : polyline_trajectory.base_time) +

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -308,7 +308,7 @@ auto PolylineTrajectoryPositioner::makeUpdatedEntityStatus() const -> std::optio
 
   if (const bool target_passed =
         validated_entity_status.linearSpeed() * step_time > distance_to_nearest_waypoint and
-        math::geometry::innerProduct(desired_velocity, validated_entity_status.current_velocity) <
+        math::geometry::innerProduct(desired_velocity, validated_entity_status.currentVelocity()) <
           0.0;
       target_passed) {
     return std::nullopt;

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -55,7 +55,7 @@ PolylineTrajectoryPositioner::PolylineTrajectoryPositioner(
     polyline_trajectory.shape.vertices.front().time - validated_entity_status.time()),
   total_remaining_time(totalRemainingTime()),
   follow_waypoint_controller(FollowWaypointController(
-    validated_entity_status.behavior_parameter, step_time,
+    validated_entity_status.behaviorParameter(), step_time,
     isNearestWaypointWithSpecifiedTimeSameAsLastWaypoint(),
     std::isinf(total_remaining_time) ? target_speed : std::nullopt))
 {

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/polyline_trajectory_positioner.cpp
@@ -160,7 +160,7 @@ auto PolylineTrajectoryPositioner::totalRemainingTime() const noexcept(false) ->
     */
     if (remaining_time < -step_time) {
       THROW_SIMULATION_ERROR(
-        "Vehicle ", std::quoted(validated_entity_status.name),
+        "Vehicle ", std::quoted(validated_entity_status.name()),
         " failed to reach the trajectory waypoint at the specified time. The specified time "
         "is ",
         nearest_waypoint_with_specified_time_it->time, " (in ",
@@ -218,7 +218,7 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredVelocity(const double d
     THROW_SIMULATION_ERROR(
       "An error occurred in the internal state of FollowTrajectoryAction. Please report the "
       "following information to the developer: Vehicle ",
-      std::quoted(validated_entity_status.name),
+      std::quoted(validated_entity_status.name()),
       "'s desired velocity contains NaN or infinity. The value is [", desired_velocity.x, ", ",
       desired_velocity.y, ", ", desired_velocity.z, "].");
   }
@@ -250,14 +250,14 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredAcceleration() const no
       THROW_SIMULATION_ERROR(
         "An error occurred in the internal state of FollowTrajectoryAction. Please report the "
         "following information to the developer: Vehicle ",
-        std::quoted(validated_entity_status.name),
+        std::quoted(validated_entity_status.name()),
         "'s desired acceleration value contains NaN or infinity. The value is ",
         desired_acceleration, ". ");
     }
     return desired_acceleration;
   } catch (const ControllerError & e) {
     THROW_SIMULATION_ERROR(
-      "Vehicle ", std::quoted(validated_entity_status.name),
+      "Vehicle ", std::quoted(validated_entity_status.name()),
       " - controller operation problem encountered. ",
       follow_waypoint_controller.getFollowedWaypointDetails(polyline_trajectory), e.what());
   }
@@ -364,7 +364,7 @@ auto PolylineTrajectoryPositioner::makeUpdatedEntityStatus() const -> std::optio
       return std::nullopt;
     } else {
       THROW_SIMULATION_ERROR(
-        "Vehicle ", std::quoted(validated_entity_status.name), " at time ",
+        "Vehicle ", std::quoted(validated_entity_status.name()), " at time ",
         validated_entity_status.time, "s (remaining time is ", time_to_nearest_waypoint,
         "s), has completed a trajectory to the nearest waypoint with", " specified time equal to ",
         polyline_trajectory.shape.vertices.front().time, "s at a distance equal to ",
@@ -395,7 +395,7 @@ auto PolylineTrajectoryPositioner::validatedEntityTargetPosition() const noexcep
     THROW_SIMULATION_ERROR(
       "An error occurred in the internal state of FollowTrajectoryAction. Please report the "
       "following information to the developer: Vehicle ",
-      std::quoted(validated_entity_status.name),
+      std::quoted(validated_entity_status.name()),
       "'s target position coordinate value contains NaN or infinity. The value is [",
       target_position.x, ", ", target_position.y, ", ", target_position.z, "].");
   }
@@ -411,7 +411,7 @@ auto PolylineTrajectoryPositioner::validatedEntityDesiredSpeed(
     THROW_SIMULATION_ERROR(
       "An error occurred in the internal state of FollowTrajectoryAction. Please report the "
       "following information to the developer: Vehicle ",
-      std::quoted(validated_entity_status.name),
+      std::quoted(validated_entity_status.name()),
       "'s desired speed value is NaN or infinity. The value is ", desired_speed, ". ");
   }
   return desired_speed;
@@ -427,7 +427,7 @@ auto PolylineTrajectoryPositioner::validatePredictedState(const double desired_a
     THROW_SIMULATION_ERROR(
       "An error occurred in the internal state of FollowTrajectoryAction. Please report the "
       "following information to the developer: FollowWaypointController for vehicle ",
-      std::quoted(validated_entity_status.name),
+      std::quoted(validated_entity_status.name()),
       " calculated invalid acceleration:", " desired_acceleration: ", desired_acceleration,
       ", total_remaining_time: ", total_remaining_time,
       ", total_remaining_distance: ", total_remaining_distance,

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -39,7 +39,7 @@ ValidatedEntityStatus::ValidatedEntityStatus(
 : step_time_(step_time),
   entity_status_(entity_status),
   behavior_parameter_(behavior_parameter),
-  current_velocity(buildValidatedCurrentVelocity(linearSpeed(), orientation()))
+  current_velocity_(buildValidatedCurrentVelocity(linearSpeed(), orientation()))
 {
   validateBehaviorParameter(behaviorParameter());
   validatePosition(position());

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -38,7 +38,6 @@ ValidatedEntityStatus::ValidatedEntityStatus(
   const double step_time) noexcept(false)
 : step_time_(step_time),
   entity_status_(entity_status),
-  position(validatedPosition(entity_status_.pose.position)),
   behavior_parameter(validatedBehaviorParameter(behavior_parameter)),
   linear_speed(validatedLinearSpeed(entity_status_.action_status.twist.linear.x)),
   linear_acceleration(validatedLinearAcceleration(

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -36,17 +36,17 @@ ValidatedEntityStatus::ValidatedEntityStatus(
   const traffic_simulator_msgs::msg::EntityStatus & entity_status,
   const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter,
   const double step_time) noexcept(false)
-: entity_status_(entity_status),
+: step_time(step_time),
+  entity_status_(entity_status),
   name(entity_status_.name),
   time(entity_status_.time),
-  step_time(step_time),
+  bounding_box(entity_status_.bounding_box),
+  lanelet_pose_valid(entity_status_.lanelet_pose_valid),
   position(validatedPosition()),
+  behavior_parameter(validatedBehaviorParameter(behavior_parameter)),
   linear_speed(validatedLinearSpeed()),
   linear_acceleration(validatedLinearAcceleration()),
-  lanelet_pose_valid(entity_status_.lanelet_pose_valid),
-  current_velocity(buildValidatedCurrentVelocity(linear_speed)),
-  bounding_box(entity_status_.bounding_box),
-  behavior_parameter(validatedBehaviorParameter(behavior_parameter))
+  current_velocity(buildValidatedCurrentVelocity(linear_speed))
 {
 }
 

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -38,7 +38,6 @@ ValidatedEntityStatus::ValidatedEntityStatus(
   const double step_time) noexcept(false)
 : step_time_(step_time),
   entity_status_(entity_status),
-  lanelet_pose_valid(entity_status_.lanelet_pose_valid),
   position(validatedPosition(entity_status_.pose.position)),
   behavior_parameter(validatedBehaviorParameter(behavior_parameter)),
   linear_speed(validatedLinearSpeed(entity_status_.action_status.twist.linear.x)),

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -38,16 +38,17 @@ ValidatedEntityStatus::ValidatedEntityStatus(
   const double step_time) noexcept(false)
 : step_time_(step_time),
   entity_status_(entity_status),
-  behavior_parameter(validatedBehaviorParameter(behavior_parameter)),
+  behavior_parameter_(behavior_parameter),
   current_velocity(buildValidatedCurrentVelocity(linearSpeed(), orientation()))
 {
+  validateBehaviorParameter(behaviorParameter());
   validatePosition(position());
   validateLinearSpeed(linearSpeed());
-  validateLinearAcceleration(linearAcceleration(), behavior_parameter, step_time_);
+  validateLinearAcceleration(linearAcceleration(), behaviorParameter(), step_time_);
 }
 
 ValidatedEntityStatus::ValidatedEntityStatus(const ValidatedEntityStatus & other)
-: ValidatedEntityStatus(other.entity_status_, other.behavior_parameter, other.step_time_)
+: ValidatedEntityStatus(other.entity_status_, other.behavior_parameter_, other.step_time_)
 {
 }
 
@@ -176,9 +177,9 @@ auto ValidatedEntityStatus::buildValidatedCurrentVelocity(
   return entity_velocity;
 }
 
-auto ValidatedEntityStatus::validatedBehaviorParameter(
+auto ValidatedEntityStatus::validateBehaviorParameter(
   const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter) const noexcept(false)
-  -> traffic_simulator_msgs::msg::BehaviorParameter
+  -> void
 {
   if (not std::isfinite(behavior_parameter.dynamic_constraints.max_acceleration_rate)) {
     throwDetailedValidationError(
@@ -200,7 +201,6 @@ auto ValidatedEntityStatus::validatedBehaviorParameter(
       "behavior_parameter.dynamic_constraints.max_acceleration_rate",
       behavior_parameter.dynamic_constraints.max_acceleration_rate);
   }
-  return behavior_parameter;
 }
 }  // namespace follow_trajectory
 }  // namespace traffic_simulator

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -41,6 +41,7 @@ ValidatedEntityStatus::ValidatedEntityStatus(
   behavior_parameter(validatedBehaviorParameter(behavior_parameter)),
   current_velocity(buildValidatedCurrentVelocity(linearSpeed(), entity_status_.pose.orientation))
 {
+  validatePosition(position());
   validateLinearSpeed(linearSpeed());
   validateLinearAcceleration(linearAcceleration(), behavior_parameter, step_time_);
 }
@@ -123,13 +124,12 @@ auto ValidatedEntityStatus::buildUpdatedEntityStatus(
     .lanelet_pose_valid(updated_lanelet_pose_valid);
 }
 
-auto ValidatedEntityStatus::validatedPosition(const geometry_msgs::msg::Point & entity_position)
-  const noexcept(false) -> geometry_msgs::msg::Point
+auto ValidatedEntityStatus::validatePosition(
+  const geometry_msgs::msg::Point & entity_position) const noexcept(false) -> void
 {
   if (not math::geometry::isFinite(entity_position)) {
     throwDetailedValidationError("entity_position", entity_position);
   }
-  return entity_position;
 }
 
 auto ValidatedEntityStatus::validateLinearSpeed(const double entity_speed) const noexcept(false)

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -38,7 +38,6 @@ ValidatedEntityStatus::ValidatedEntityStatus(
   const double step_time) noexcept(false)
 : step_time_(step_time),
   entity_status_(entity_status),
-  name(entity_status_.name),
   time(entity_status_.time),
   bounding_box(entity_status_.bounding_box),
   lanelet_pose_valid(entity_status_.lanelet_pose_valid),

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -39,7 +39,7 @@ ValidatedEntityStatus::ValidatedEntityStatus(
 : step_time_(step_time),
   entity_status_(entity_status),
   behavior_parameter(validatedBehaviorParameter(behavior_parameter)),
-  current_velocity(buildValidatedCurrentVelocity(linearSpeed(), entity_status_.pose.orientation))
+  current_velocity(buildValidatedCurrentVelocity(linearSpeed(), orientation()))
 {
   validatePosition(position());
   validateLinearSpeed(linearSpeed());
@@ -57,7 +57,7 @@ auto ValidatedEntityStatus::buildUpdatedPoseOrientation(
 {
   if (desired_velocity.x == 0.0 and desired_velocity.y == 0.0 and desired_velocity.z == 0.0) {
     // do not change orientation if there is no designed_velocity vector
-    return entity_status_.pose.orientation;
+    return orientation();
   } else {
     // if there is a designed_velocity vector, set the orientation in the direction of it
     const geometry_msgs::msg::Vector3 direction =
@@ -87,7 +87,7 @@ auto ValidatedEntityStatus::buildUpdatedEntityStatus(
       .z(0.0);
   const auto updated_action_status_twist_angular =
     math::geometry::convertQuaternionToEulerAngle(
-      math::geometry::getRotation(entity_status_.pose.orientation, updated_pose_orientation)) /
+      math::geometry::getRotation(orientation(), updated_pose_orientation)) /
     step_time_;
   const auto updated_action_status_twist = geometry_msgs::build<geometry_msgs::msg::Twist>()
                                              .linear(updated_action_status_twist_linear)
@@ -106,10 +106,9 @@ auto ValidatedEntityStatus::buildUpdatedEntityStatus(
       .twist(updated_action_status_twist)
       .accel(updated_action_status_accel)
       .linear_jerk(entity_status_.action_status.linear_jerk);
-  const auto updated_pose =
-    geometry_msgs::build<geometry_msgs::msg::Pose>()
-      .position(entity_status_.pose.position + desired_velocity * step_time_)
-      .orientation(updated_pose_orientation);
+  const auto updated_pose = geometry_msgs::build<geometry_msgs::msg::Pose>()
+                              .position(position() + desired_velocity * step_time_)
+                              .orientation(updated_pose_orientation);
   constexpr bool updated_lanelet_pose_valid = false;
 
   return traffic_simulator_msgs::build<traffic_simulator_msgs::msg::EntityStatus>()

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -39,11 +39,10 @@ ValidatedEntityStatus::ValidatedEntityStatus(
 : step_time_(step_time),
   entity_status_(entity_status),
   behavior_parameter(validatedBehaviorParameter(behavior_parameter)),
-  linear_acceleration(validatedLinearAcceleration(
-    entity_status_.action_status.accel.linear.x, behavior_parameter, step_time_)),
   current_velocity(buildValidatedCurrentVelocity(linearSpeed(), entity_status_.pose.orientation))
 {
   validateLinearSpeed(linearSpeed());
+  validateLinearAcceleration(linearAcceleration(), behavior_parameter, step_time_);
 }
 
 ValidatedEntityStatus::ValidatedEntityStatus(const ValidatedEntityStatus & other)
@@ -141,10 +140,10 @@ auto ValidatedEntityStatus::validateLinearSpeed(const double entity_speed) const
   }
 }
 
-auto ValidatedEntityStatus::validatedLinearAcceleration(
+auto ValidatedEntityStatus::validateLinearAcceleration(
   const double acceleration,
   const traffic_simulator_msgs::msg::BehaviorParameter & behavior_parameter,
-  const double step_time) const noexcept(false) -> double
+  const double step_time) const noexcept(false) -> void
 {
   const double max_acceleration = std::min(
     acceleration + behavior_parameter.dynamic_constraints.max_acceleration_rate * step_time,
@@ -159,7 +158,6 @@ auto ValidatedEntityStatus::validatedLinearAcceleration(
   } else if (not std::isfinite(min_acceleration)) {
     throwDetailedValidationError("minimum acceleration", min_acceleration);
   }
-  return acceleration;
 }
 
 auto ValidatedEntityStatus::buildValidatedCurrentVelocity(

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -39,11 +39,11 @@ ValidatedEntityStatus::ValidatedEntityStatus(
 : step_time_(step_time),
   entity_status_(entity_status),
   behavior_parameter(validatedBehaviorParameter(behavior_parameter)),
-  linear_speed(validatedLinearSpeed(entity_status_.action_status.twist.linear.x)),
   linear_acceleration(validatedLinearAcceleration(
     entity_status_.action_status.accel.linear.x, behavior_parameter, step_time_)),
-  current_velocity(buildValidatedCurrentVelocity(linear_speed, entity_status_.pose.orientation))
+  current_velocity(buildValidatedCurrentVelocity(linearSpeed(), entity_status_.pose.orientation))
 {
+  validateLinearSpeed(linearSpeed());
 }
 
 ValidatedEntityStatus::ValidatedEntityStatus(const ValidatedEntityStatus & other)
@@ -133,13 +133,12 @@ auto ValidatedEntityStatus::validatedPosition(const geometry_msgs::msg::Point & 
   return entity_position;
 }
 
-auto ValidatedEntityStatus::validatedLinearSpeed(const double entity_speed) const noexcept(false)
-  -> double
+auto ValidatedEntityStatus::validateLinearSpeed(const double entity_speed) const noexcept(false)
+  -> void
 {
   if (not std::isfinite(entity_speed)) {
     throwDetailedValidationError("entity_speed", entity_speed);
   }
-  return entity_speed;
 }
 
 auto ValidatedEntityStatus::validatedLinearAcceleration(

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -38,7 +38,6 @@ ValidatedEntityStatus::ValidatedEntityStatus(
   const double step_time) noexcept(false)
 : step_time_(step_time),
   entity_status_(entity_status),
-  time(entity_status_.time),
   bounding_box(entity_status_.bounding_box),
   lanelet_pose_valid(entity_status_.lanelet_pose_valid),
   position(validatedPosition(entity_status_.pose.position)),

--- a/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
+++ b/simulation/traffic_simulator/src/behavior/polyline_trajectory_follower/validated_entity_status.cpp
@@ -38,7 +38,6 @@ ValidatedEntityStatus::ValidatedEntityStatus(
   const double step_time) noexcept(false)
 : step_time_(step_time),
   entity_status_(entity_status),
-  bounding_box(entity_status_.bounding_box),
   lanelet_pose_valid(entity_status_.lanelet_pose_valid),
   position(validatedPosition(entity_status_.pose.position)),
   behavior_parameter(validatedBehaviorParameter(behavior_parameter)),

--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -159,7 +159,7 @@ void EgoEntity::onUpdate(double current_time, double step_time)
             traffic_simulator::follow_trajectory::ValidatedEntityStatus(
               static_cast<traffic_simulator::EntityStatus>(*status_), behavior_parameter_,
               step_time),
-            hdmap_utils_ptr_, behavior_parameter_, *polyline_trajectory_,
+            hdmap_utils_ptr_, *polyline_trajectory_,
             getDefaultMatchingDistanceForLaneletPoseCalculation(), getTargetSpeed(), step_time);
         non_canonicalized_updated_status.has_value()) {
       // prefer current lanelet on ss2 side


### PR DESCRIPTION
Merge this **before** #1449

# Description

This PR fixes a bug in follow trajectory action. The bug was caused by wrong data field initialization order. This wrong order caused one function to use a data field before its initialization, and wrong speed and acceleration values were calculated.

<!--
> Please check examples and comment out this sentence. Minimal example is [here](pull_request_samples/example_simple.md) and detailed example is [here](pull_request_samples/example_detail.md)

## Abstract

> [Required] This section is required, keep it short, clear and to the point.  
> Delete this sentence and explain this pull request shortly.  

## Background

> [Optional] If there is no background information that needs explanation (e.g., just a typo correction, etc.), you can skip this section.  
> Delete this sentence and explain the circumstances that led to this pull request being sent.  

## Details

> [Optional] If there are only differences whose effects are so obvious that no explanation is needed, or if there are no differences in the code (e.g., documentation additions), you can skip this section.  
> Delete this sentence and describe this pull request.  
> For example, it is desirable to describe the specifications of added functions, and detailed explanations of bugs that have been fixed.  

## References

> [Optional] If the referenced material does not exist, you can skip this section.  
> Describe any standards, algorithms, books, articles, etc. that you referenced when creating the pull request. If there is any novelty, mention it.  

# Destructive Changes

> [Optional] If no destructive change exists, you can skip this section.  
> Include a description of the changes and a migration guide and send the pull request with a bump major label. (Example : https://github.com/tier4/scenario_simulator_v2/pull/1139)  
> Otherwise, skip the "Destructive Changes" section and make sure this pull request is labeled `bump minor` or `bump patch`.  

# Known Limitations

> [Optional] If there are no known limitations that you can think of, you can skip this section. If there are any limitations on the features or fixes added by this pull request, delete this sentence and clearly describe them.
> For example, the lane matching algorithm currently (1/25/2024) employed is unable to match Entity that is heavily tilted with respect to the lane, and it is difficult to throw an exception.  
> If the developer is aware of the existence of such problems or limitations, describe them in detail. The problems or limitation should be listed as an Issue on GitHub and a link to it should be provided in this section.  
-->