### PR TITLE
fix(traffic_light): don't call addTrafficLight() when the traffic light id has already existed in map

### DIFF
--- a/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
+++ b/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
@@ -115,6 +115,10 @@ auto TrafficLightsBase::isTrafficLightAdded(const lanelet::Id traffic_light_id) 
 
 auto TrafficLightsBase::addTrafficLight(const lanelet::Id traffic_light_id) -> void
 {
+  if (isTrafficLightAdded(traffic_light_id)) {
+    return;
+  }
+
   // emplace will not modify the map if the key already exists
   traffic_lights_map_.emplace(
     std::piecewise_construct, std::forward_as_tuple(traffic_light_id),

--- a/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
+++ b/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
@@ -115,10 +115,6 @@ auto TrafficLightsBase::isTrafficLightAdded(const lanelet::Id traffic_light_id) 
 
 auto TrafficLightsBase::addTrafficLight(const lanelet::Id traffic_light_id) -> void
 {
-  if (isTrafficLightAdded(traffic_light_id)) {
-    return;
-  }
-
   // emplace will not modify the map if the key already exists
   traffic_lights_map_.emplace(
     std::piecewise_construct, std::forward_as_tuple(traffic_light_id),
@@ -127,6 +123,10 @@ auto TrafficLightsBase::addTrafficLight(const lanelet::Id traffic_light_id) -> v
 
 auto TrafficLightsBase::getTrafficLight(const lanelet::Id traffic_light_id) -> TrafficLight &
 {
+  if (isTrafficLightAdded(traffic_light_id)) {
+    return traffic_lights_map_.at(traffic_light_id);
+  }
+
   addTrafficLight(traffic_light_id);
   return traffic_lights_map_.at(traffic_light_id);
 }

--- a/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
+++ b/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
@@ -123,11 +123,9 @@ auto TrafficLightsBase::addTrafficLight(const lanelet::Id traffic_light_id) -> v
 
 auto TrafficLightsBase::getTrafficLight(const lanelet::Id traffic_light_id) -> TrafficLight &
 {
-  if (isTrafficLightAdded(traffic_light_id)) {
-    return traffic_lights_map_.at(traffic_light_id);
+  if (not isTrafficLightAdded(traffic_light_id)) {
+    addTrafficLight(traffic_light_id);
   }
-
-  addTrafficLight(traffic_light_id);
   return traffic_lights_map_.at(traffic_light_id);
 }
 


### PR DESCRIPTION
# Description

The following function in `traffic_light_base.cpp` is quite heavy because it always tries adding traffic light even when the traffic light has been registered in simulator.

```c++
auto TrafficLightsBase::getTrafficLight(const lanelet::Id traffic_light_id) -> TrafficLight &
{
  addTrafficLight(traffic_light_id);
  return traffic_lights_map_.at(traffic_light_id);
}
```

As a result, it becomes a bottle neck of simulator when I write a code to update traffic light color frequently.

![Screenshot from 2024-11-13 13-29-45](https://github.com/user-attachments/assets/6454f800-440f-4590-b4fe-166239307818)

## Abstract

I added the guard to prevent redundant process like this:

```patch
diff --git a/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp b/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
index 48110784a..906e80258 100644
--- a/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
+++ b/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
@@ -123,6 +123,10 @@ auto TrafficLightsBase::addTrafficLight(const lanelet::Id traffic_light_id) -> v
 
 auto TrafficLightsBase::getTrafficLight(const lanelet::Id traffic_light_id) -> TrafficLight &
 {
+  if (isTrafficLightAdded(traffic_light_id)) {
+    return traffic_lights_map_.at(traffic_light_id);
+  }
+
   addTrafficLight(traffic_light_id);
   return traffic_lights_map_.at(traffic_light_id);
 }

```

## Background

N/A

## Details

With this PR, I confirmed the process load became light.

![image](https://github.com/user-attachments/assets/45ba28da-d44c-4dd1-813b-adf76b79977d)

## References

N/A

# Destructive Changes

N/A

# Known Limitations

N/A
