### PR TITLE
chore: update rviz config based on autoware.rviz

### DIFF
--- a/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
+++ b/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
@@ -4,10 +4,11 @@ Panels:
     Name: Displays
     Property Tree Widget:
       Expanded:
-        - /Map1/Lanelet2VectorMap1
         - /Sensing1/LiDAR1/ConcatenatePointCloud1/Autocompute Value Bounds1
+        - /Simulation1
+        - /Simulation1/Simple Sensor Simulator1
       Splitter Ratio: 0.557669460773468
-    Tree Height: 1445
+    Tree Height: 832
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -19,8 +20,6 @@ Panels:
       - /Current View1
     Name: Views
     Splitter Ratio: 0.5
-  - Class: tier4_localization_rviz_plugin/InitialPoseButtonPanel
-    Name: InitialPoseButtonPanel
   - Class: AutowareDateTimePanel
     Name: AutowareDateTimePanel
   - Class: rviz_plugins::AutowareStatePanel
@@ -64,56 +63,6 @@ Visualization Manager:
           Value: false
         - Class: rviz_common/Group
           Displays:
-            - Class: rviz_plugins/SteeringAngle
-              Enabled: true
-              Left: 128
-              Length: 256
-              Name: SteeringAngle
-              Scale: 17
-              Text Color: 25; 255; 240
-              Top: 128
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Reliable
-                Value: /vehicle/status/steering_status
-              Value: true
-              Value Scale: 0.14999249577522278
-              Value height offset: 0
-            - Class: rviz_plugins/ConsoleMeter
-              Enabled: true
-              Left: 512
-              Length: 256
-              Name: ConsoleMeter
-              Text Color: 25; 255; 240
-              Top: 128
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Reliable
-                Value: /vehicle/status/velocity_status
-              Value: true
-              Value Scale: 0.14999249577522278
-              Value height offset: 0
-            - Alpha: 0.9990000128746033
-              Class: rviz_plugins/VelocityHistory
-              Color Border Vel Max: 3
-              Constant Color:
-                Color: 255; 255; 255
-                Value: true
-              Enabled: true
-              Name: VelocityHistory
-              Scale: 0.30000001192092896
-              Timeout: 10
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Reliable
-                Value: /vehicle/status/velocity_status
-              Value: true
             - Alpha: 0.30000001192092896
               Class: rviz_default_plugins/RobotModel
               Collision Enabled: false
@@ -132,6 +81,160 @@ Visualization Manager:
                 Expand Link Details: false
                 Expand Tree: false
                 Link Tree Style: Links in Alphabetic Order
+                ars408_front_center:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                base_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                camera0/camera_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                camera0/camera_optical_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                camera1/camera_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                camera1/camera_optical_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                camera2/camera_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                camera2/camera_optical_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                camera3/camera_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                camera3/camera_optical_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                camera4/camera_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                camera4/camera_optical_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                camera5/camera_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                camera5/camera_optical_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                camera6/camera_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                camera6/camera_optical_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                camera7/camera_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                camera7/camera_optical_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                gnss_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                livox_front_left:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                livox_front_left_base_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                livox_front_right:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                livox_front_right_base_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                sensor_kit_base_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                tamagawa/imu_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                velodyne_left:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                velodyne_left_base_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                velodyne_rear:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                velodyne_rear_base_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                velodyne_right:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                velodyne_right_base_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                velodyne_top:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
+                velodyne_top_base_link:
+                  Alpha: 1
+                  Show Axes: false
+                  Show Trail: false
+                  Value: true
               Mass Properties:
                 Inertia: false
                 Mass: false
@@ -154,32 +257,46 @@ Visualization Manager:
               Value: true
               Wave Color: 255; 255; 255
               Wave Velocity: 40
-            - Class: rviz_plugins/MaxVelocity
+            - Background Alpha: 0.5
+              Background Color: 23; 28; 31
+              Class: autoware_overlay_rviz_plugin/SignalDisplay
+              Dark Traffic Color: 255; 51; 51
               Enabled: true
-              Left: 595
-              Length: 96
-              Name: MaxVelocity
-              Text Color: 255; 255; 255
-              Top: 280
-              Topic: /planning/scenario_planning/current_max_velocity
+              Gear Topic Test: /vehicle/status/gear_status
+              Handle Angle Scale: 17
+              Hazard Lights Topic: /vehicle/status/hazard_lights_status
+              Height: 100
+              Left: 0
+              Light Traffic Color: 255; 153; 153
+              Name: SignalDisplay
+              Primary Color: 174; 174; 174
+              Signal Color: 0; 230; 120
+              Speed Limit Topic: /planning/scenario_planning/current_max_velocity
+              Speed Topic: /vehicle/status/velocity_status
+              Steering Topic: /vehicle/status/steering_status
+              Top: 10
+              Traffic Topic: /planning/scenario_planning/lane_driving/behavior_planning/debug/traffic_signal
+              Turn Signals Topic: /vehicle/status/turn_indicators_status
               Value: true
-              Value Scale: 0.25
-            - Class: rviz_plugins/TurnSignal
-              Enabled: true
-              Height: 256
-              Left: 196
-              Name: TurnSignal
-              Top: 350
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Reliable
-                Value: /vehicle/status/turn_indicators_status
-              Value: true
-              Width: 512
+              Width: 550
           Enabled: true
           Name: Vehicle
+        - Class: rviz_plugins/MrmSummaryOverlayDisplay
+          Enabled: false
+          Font Size: 10
+          Left: 512
+          Max Letter Num: 100
+          Name: MRM Summary
+          Text Color: 25; 255; 240
+          Top: 64
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /system/emergency/hazard_status
+          Value: false
+          Value height offset: 0
       Enabled: true
       Name: System
     - Class: rviz_common/Group
@@ -222,7 +339,23 @@ Visualization Manager:
           Enabled: true
           Name: Lanelet2VectorMap
           Namespaces:
-            {}
+            center_lane_line: false
+            center_line_arrows: false
+            crosswalk_lanelet_id: true
+            crosswalk_lanelets: true
+            lane_start_bound: false
+            lanelet direction: true
+            lanelet_id: false
+            left_lane_bound: true
+            parking_lots: true
+            parking_space: true
+            right_lane_bound: true
+            road_lanelets: false
+            stop_lines: true
+            traffic_light: true
+            traffic_light_id: false
+            traffic_light_reg_elem_id: false
+            traffic_light_triangle: true
           Topic:
             Depth: 5
             Durability Policy: Transient Local
@@ -575,15 +708,21 @@ Visualization Manager:
                   CYCLIST:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
-                  Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Confidence Interval: 95%
                   Display Acceleration: true
+                  Display Existence Probability: false
                   Display Label: true
-                  Display PoseWithCovariance: true
+                  Display Pose Covariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
+                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
+                  Display Yaw Covariance: false
+                  Display Yaw Rate: false
+                  Display Yaw Rate Covariance: false
                   Enabled: true
                   Line Width: 0.029999999329447746
                   MOTORCYCLE:
@@ -592,6 +731,7 @@ Visualization Manager:
                   Name: DetectedObjects
                   Namespaces:
                     {}
+                  Object Fill Type: skeleton
                   PEDESTRIAN:
                     Alpha: 0.9990000128746033
                     Color: 255; 192; 203
@@ -626,15 +766,22 @@ Visualization Manager:
                   CYCLIST:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
-                  Class: autoware_auto_perception_rviz_plugin/TrackedObjects
+                  Class: autoware_perception_rviz_plugin/TrackedObjects
+                  Confidence Interval: 95%
                   Display Acceleration: true
+                  Display Existence Probability: false
                   Display Label: true
-                  Display PoseWithCovariance: true
+                  Display Pose Covariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
+                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
+                  Display Yaw Covariance: false
+                  Display Yaw Rate: false
+                  Display Yaw Rate Covariance: false
+                  Dynamic Status: All
                   Enabled: true
                   Line Width: 0.029999999329447746
                   MOTORCYCLE:
@@ -643,6 +790,7 @@ Visualization Manager:
                   Name: TrackedObjects
                   Namespaces:
                     {}
+                  Object Fill Type: skeleton
                   PEDESTRIAN:
                     Alpha: 0.9990000128746033
                     Color: 255; 192; 203
@@ -677,23 +825,30 @@ Visualization Manager:
                   CYCLIST:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
-                  Class: autoware_auto_perception_rviz_plugin/PredictedObjects
+                  Class: autoware_perception_rviz_plugin/PredictedObjects
+                  Confidence Interval: 95%
                   Display Acceleration: true
+                  Display Existence Probability: false
                   Display Label: true
-                  Display PoseWithCovariance: false
+                  Display Pose Covariance: true
                   Display Predicted Path Confidence: true
                   Display Predicted Paths: true
                   Display Twist: true
+                  Display Twist Covariance: false
                   Display UUID: true
                   Display Velocity: true
+                  Display Yaw Covariance: false
+                  Display Yaw Rate: false
+                  Display Yaw Rate Covariance: false
                   Enabled: true
-                  Line Width: 0.5
+                  Line Width: 0.029999999329447746
                   MOTORCYCLE:
                     Alpha: 0.9990000128746033
                     Color: 119; 11; 32
                   Name: PredictedObjects
                   Namespaces:
                     {}
+                  Object Fill Type: skeleton
                   PEDESTRIAN:
                     Alpha: 0.9990000128746033
                     Color: 255; 192; 203
@@ -745,7 +900,7 @@ Visualization Manager:
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
-                Value: /perception/traffic_light_recognition/debug/rois
+                Value: /perception/traffic_light_recognition/traffic_light/debug/rois
               Value: false
             - Class: rviz_default_plugins/MarkerArray
               Enabled: true
@@ -796,7 +951,12 @@ Visualization Manager:
               Enabled: true
               Name: RouteArea
               Namespaces:
-                {}
+                end_lanelets: true
+                goal_lanelets: true
+                lane_start_bound: false
+                left_lane_bound: false
+                right_lane_bound: false
+                route_lanelets: true
               Topic:
                 Depth: 5
                 Durability Policy: Transient Local
@@ -824,6 +984,18 @@ Visualization Manager:
                 Reliability Policy: Reliable
                 Value: /planning/mission_planning/echo_back_goal_pose
               Value: true
+            - Background Alpha: 0.5
+              Background Color: 23; 28; 31
+              Class: autoware_mission_details_overlay_rviz_plugin/MissionDetailsDisplay
+              Enabled: true
+              Height: 100
+              Name: MissionDetailsDisplay
+              Remaining Distance and Time Topic: /planning/mission_remaining_distance_time
+              Right: 10
+              Text Color: 194; 194; 194
+              Top: 10
+              Value: true
+              Width: 170
           Enabled: true
           Name: MissionPlanning
         - Class: rviz_common/Group
@@ -844,15 +1016,17 @@ Visualization Manager:
                 Alpha: 1
                 Color: 230; 230; 50
                 Offset from BaseLink: 0
-                Rear Overhang: 1.0299999713897705
+                Rear Overhang: 1.100000023841858
                 Value: false
-                Vehicle Length: 4.769999980926514
-                Vehicle Width: 1.8300000429153442
+                Vehicle Length: 4.889999866485596
+                Vehicle Width: 1.8960000276565552
               View Path:
                 Alpha: 0.9990000128746033
-                Color: 0; 0; 0
-                Constant Color: false
                 Constant Width: false
+                Fade Out Distance: 0
+                Max Velocity Color: 0; 230; 120
+                Mid Velocity Color: 32; 138; 174
+                Min Velocity Color: 63; 46; 227
                 Value: true
                 Width: 2
               View Point:
@@ -898,15 +1072,17 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.4000000059604645
-                        Color: 0; 0; 0
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -954,9 +1130,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 210; 110; 10
-                        Constant Color: true
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -987,7 +1165,7 @@ Visualization Manager:
                         Filter size: 10
                         History Policy: Keep Last
                         Reliability Policy: Reliable
-                        Value: /planning/path_reference/avoidance
+                        Value: /planning/path_reference/static_obstacle_avoidance
                       Value: false
                       View Drivable Area:
                         Alpha: 0.9990000128746033
@@ -1004,9 +1182,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 210; 110; 210
-                        Constant Color: true
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1054,9 +1234,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 210; 210; 110
-                        Constant Color: true
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1104,9 +1286,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 210; 210; 110
-                        Constant Color: true
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1154,9 +1338,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 110; 110; 210
-                        Constant Color: true
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1204,9 +1390,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 210; 110; 110
-                        Constant Color: true
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1248,15 +1436,17 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 115; 210; 22
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1304,9 +1494,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 115; 210; 22
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1348,15 +1540,17 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 115; 210; 22
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1398,15 +1592,17 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 115; 210; 22
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1454,9 +1650,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 115; 210; 22
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1504,9 +1702,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 115; 210; 22
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1537,7 +1737,7 @@ Visualization Manager:
                         Filter size: 10
                         History Policy: Keep Last
                         Reliability Policy: Reliable
-                        Value: /planning/path_candidate/avoidance
+                        Value: /planning/path_candidate/static_obstacle_avoidance
                       Value: true
                       View Drivable Area:
                         Alpha: 0.9990000128746033
@@ -1548,15 +1748,17 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 115; 210; 22
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1598,15 +1800,17 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 115; 210; 22
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1648,15 +1852,17 @@ Visualization Manager:
                         Alpha: 1
                         Color: 230; 230; 50
                         Offset from BaseLink: 0
-                        Rear Overhang: 1.0299999713897705
+                        Rear Overhang: 1.100000023841858
                         Value: false
-                        Vehicle Length: 4.769999980926514
-                        Vehicle Width: 1.8300000429153442
+                        Vehicle Length: 4.889999866485596
+                        Vehicle Width: 1.8960000276565552
                       View Path:
                         Alpha: 0.30000001192092896
-                        Color: 115; 210; 22
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -1693,7 +1899,7 @@ Visualization Manager:
                       Displays:
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: true
-                          Name: VirtualWall (Avoidance)
+                          Name: VirtualWall (StaticObstacleAvoidance)
                           Namespaces:
                             {}
                           Topic:
@@ -1701,7 +1907,7 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/avoidance
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/virtual_wall/static_obstacle_avoidance
                           Value: true
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: true
@@ -1945,18 +2151,6 @@ Visualization Manager:
                           Value: true
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: true
-                          Name: VirtualWall (OutOfLane)
-                          Namespaces:
-                            {}
-                          Topic:
-                            Depth: 5
-                            Durability Policy: Volatile
-                            History Policy: Keep Last
-                            Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/virtual_wall/out_of_lane
-                          Value: true
-                        - Class: rviz_default_plugins/MarkerArray
-                          Enabled: true
                           Name: VirtualWall (NoDrivableLane)
                           Namespaces:
                             {}
@@ -1966,18 +2160,6 @@ Visualization Manager:
                             History Policy: Keep Last
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/virtual_wall/no_drivable_lane
-                          Value: true
-                        - Class: rviz_default_plugins/MarkerArray
-                          Enabled: true
-                          Name: VirtualWall (DynamicObstacleStop)
-                          Namespaces:
-                            {}
-                          Topic:
-                            Depth: 5
-                            Durability Policy: Volatile
-                            History Policy: Keep Last
-                            Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/virtual_wall/dynamic_obstacle_stop
                           Value: true
                       Enabled: true
                       Name: VirtualWall
@@ -2018,32 +2200,6 @@ Visualization Manager:
                             History Policy: Keep Last
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection
-                          Value: false
-                        - Alpha: 0.5
-                          Autocompute Intensity Bounds: true
-                          Class: grid_map_rviz_plugin/GridMap
-                          Color: 200; 200; 200
-                          Color Layer: color
-                          Color Transformer: IntensityLayer
-                          Enabled: false
-                          Height Layer: elevation
-                          Height Transformer: Layer
-                          History Length: 1
-                          Invert Rainbow: false
-                          Max Color: 255; 255; 255
-                          Max Intensity: 10
-                          Min Color: 0; 0; 0
-                          Min Intensity: 0
-                          Name: IntersectionOcclusion
-                          Show Grid Lines: false
-                          Topic:
-                            Depth: 5
-                            Durability Policy: Volatile
-                            Filter size: 10
-                            History Policy: Keep Last
-                            Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection/occlusion_grid
-                          Use Rainbow: true
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
@@ -2143,7 +2299,7 @@ Visualization Manager:
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
-                          Name: Avoidance
+                          Name: StaticObstacleAvoidance
                           Namespaces:
                             {}
                           Topic:
@@ -2151,11 +2307,11 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/avoidance
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/static_obstacle_avoidance
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
-                          Name: LaneChange
+                          Name: LeftLaneChange
                           Namespaces:
                             {}
                           Topic:
@@ -2163,7 +2319,19 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lane_change
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lane_change_left
+                          Value: false
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: false
+                          Name: RightLaneChange
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/lane_change_right
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
@@ -2227,7 +2395,7 @@ Visualization Manager:
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
-                          Name: OutOfLane
+                          Name: DynamicObstacleAvoidance
                           Namespaces:
                             {}
                           Topic:
@@ -2235,19 +2403,7 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/out_of_lane
-                          Value: false
-                        - Class: rviz_default_plugins/MarkerArray
-                          Enabled: false
-                          Name: DynamicAvoidance
-                          Namespaces:
-                            {}
-                          Topic:
-                            Depth: 5
-                            Durability Policy: Volatile
-                            History Policy: Keep Last
-                            Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/dynamic_avoidance
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/dynamic_obstacle_avoidance
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
@@ -2261,25 +2417,13 @@ Visualization Manager:
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/no_drivable_lane
                           Value: false
-                        - Class: rviz_default_plugins/MarkerArray
-                          Enabled: false
-                          Name: DynamicObstacleStop
-                          Namespaces:
-                            {}
-                          Topic:
-                            Depth: 5
-                            Durability Policy: Volatile
-                            History Policy: Keep Last
-                            Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/dynamic_obstacle_stop
-                          Value: false
                       Enabled: false
                       Name: DebugMarker
                     - Class: rviz_common/Group
                       Displays:
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
-                          Name: Info (Avoidance)
+                          Name: Info (StaticObstacleAvoidance)
                           Namespaces:
                             {}
                           Topic:
@@ -2287,7 +2431,7 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/avoidance
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/static_obstacle_avoidance
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
@@ -2375,7 +2519,7 @@ Visualization Manager:
                           Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
-                          Name: Info (DynamicAvoidance)
+                          Name: Info (DynamicObstacleAvoidance)
                           Namespaces:
                             {}
                           Topic:
@@ -2383,7 +2527,7 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/dynamic_avoidance
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/info/dynamic_obstacle_avoidance
                           Value: false
                       Enabled: false
                       Name: InfoMarker
@@ -2413,9 +2557,11 @@ Visualization Manager:
                         Vehicle Width: 1.8300000429153442
                       View Path:
                         Alpha: 0.9990000128746033
-                        Color: 0; 0; 0
-                        Constant Color: false
                         Constant Width: false
+                        Fade Out Distance: 0
+                        Max Velocity Color: 0; 230; 120
+                        Mid Velocity Color: 32; 138; 174
+                        Min Velocity Color: 63; 46; 227
                         Value: true
                         Width: 2
                       View Point:
@@ -2476,7 +2622,7 @@ Visualization Manager:
                           Value: true
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: true
-                          Name: VirtualWall (ObstacleCruise)
+                          Name: VirtualWall (ObstacleCruise Stop)
                           Namespaces:
                             {}
                           Topic:
@@ -2484,7 +2630,79 @@ Visualization Manager:
                             Durability Policy: Volatile
                             History Policy: Keep Last
                             Reliability Policy: Reliable
-                            Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/virtual_wall
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/virtual_wall/stop
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (ObstacleCruise Cruise)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/virtual_wall/cruise
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (ObstacleCruise SlowDown)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/virtual_wall/slow_down
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (MotionVelocitySmoother)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/velocity_smoother/virtual_wall
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (OutOfLane)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/out_of_lane/virtual_walls
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (ObstacleVelocityLimiter)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_velocity_limiter/virtual_walls
+                          Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (DynamicObstacleStop)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/dynamic_obstacle_stop/virtual_walls
                           Value: true
                       Enabled: true
                       Name: VirtualWall
@@ -2561,30 +2779,6 @@ Visualization Manager:
                           Displays:
                             - Class: rviz_default_plugins/MarkerArray
                               Enabled: true
-                              Name: CruiseVirtualWall
-                              Namespaces:
-                                {}
-                              Topic:
-                                Depth: 5
-                                Durability Policy: Volatile
-                                History Policy: Keep Last
-                                Reliability Policy: Reliable
-                                Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/debug/cruise/virtual_wall
-                              Value: true
-                            - Class: rviz_default_plugins/MarkerArray
-                              Enabled: true
-                              Name: SlowDownVirtualWall
-                              Namespaces:
-                                {}
-                              Topic:
-                                Depth: 5
-                                Durability Policy: Volatile
-                                History Policy: Keep Last
-                                Reliability Policy: Reliable
-                                Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/debug/slow_down/virtual_wall
-                              Value: true
-                            - Class: rviz_default_plugins/MarkerArray
-                              Enabled: true
                               Name: DebugMarker
                               Namespaces:
                                 {}
@@ -2609,6 +2803,46 @@ Visualization Manager:
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/debug/marker
                           Value: false
+                        - Class: rviz_common/Group
+                          Displays:
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: OutOfLane
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/out_of_lane/debug_markers
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: ObstacleVelocityLimiter
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_velocity_limiter/debug_markers
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: DynamicObstacleStop
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/dynamic_obstacle_stop/debug_markers
+                              Value: true
+                          Enabled: false
+                          Name: MotionVelocityPlanner
                       Enabled: false
                       Name: DebugMarker
                   Enabled: true
@@ -2730,21 +2964,23 @@ Visualization Manager:
             Filter size: 10
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /control/trajectory_follower/lateral/predicted_trajectory
+            Value: /control/trajectory_follower/controller_node_exe/debug/predicted_trajectory_in_frenet_coordinate
           Value: true
           View Footprint:
             Alpha: 1
             Color: 230; 230; 50
             Offset from BaseLink: 0
-            Rear Overhang: 1.0299999713897705
+            Rear Overhang: 1.100000023841858
             Value: false
-            Vehicle Length: 4.769999980926514
-            Vehicle Width: 1.8300000429153442
+            Vehicle Length: 4.889999866485596
+            Vehicle Width: 1.8960000276565552
           View Path:
             Alpha: 1
-            Color: 255; 255; 255
-            Constant Color: true
             Constant Width: true
+            Fade Out Distance: 0
+            Max Velocity Color: 0; 230; 120
+            Mid Velocity Color: 32; 138; 174
+            Min Velocity Color: 63; 46; 227
             Value: true
             Width: 0.05000000074505806
           View Point:
@@ -2765,6 +3001,94 @@ Visualization Manager:
             Constant Color: false
             Scale: 0.30000001192092896
             Value: false
+        - Class: rviz_plugins/Trajectory
+          Color Border Vel Max: 3
+          Enabled: false
+          Name: Resampled Reference Trajectory
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /control/trajectory_follower/controller_node_exe/debug/resampled_reference_trajectory
+          Value: false
+          View Footprint:
+            Alpha: 1
+            Color: 230; 230; 50
+            Offset from BaseLink: 0
+            Rear Overhang: 1.0299999713897705
+            Value: false
+            Vehicle Length: 4.769999980926514
+            Vehicle Width: 1.8300000429153442
+          View Path:
+            Alpha: 1
+            Constant Width: true
+            Fade Out Distance: 0
+            Max Velocity Color: 0; 230; 120
+            Mid Velocity Color: 32; 138; 174
+            Min Velocity Color: 63; 46; 227
+            Value: false
+            Width: 0.20000000298023224
+          View Point:
+            Alpha: 1
+            Color: 0; 60; 255
+            Offset: 0
+            Radius: 0.10000000149011612
+            Value: true
+          View Text Slope:
+            Scale: 0.30000001192092896
+            Value: false
+          View Text Velocity:
+            Scale: 0.30000001192092896
+            Value: false
+          View Velocity:
+            Alpha: 1
+            Color: 0; 0; 0
+            Constant Color: false
+            Scale: 0.30000001192092896
+            Value: false
+        - Class: rviz_common/Group
+          Displays:
+            - Class: rviz_default_plugins/MarkerArray
+              Enabled: true
+              Name: VirtualWall (AEB)
+              Namespaces:
+                {}
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /control/autonomous_emergency_braking/virtual_wall
+              Value: true
+            - Class: rviz_default_plugins/MarkerArray
+              Enabled: true
+              Name: VirtualWall (velocity control)
+              Namespaces:
+                {}
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /control/trajectory_follower/controller_node_exe/virtual_wall
+              Value: true
+          Enabled: true
+          Name: VirtualWall
+        - Class: rviz_default_plugins/Marker
+          Enabled: false
+          Name: Stop Reason
+          Namespaces:
+            {}
+          Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            Filter size: 10
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /control/trajectory_follower/longitudinal/stop_reason
+          Value: false
         - Class: rviz_default_plugins/MarkerArray
           Enabled: false
           Name: Debug/MPC
@@ -2805,6 +3129,1133 @@ Visualization Manager:
       Name: Control
     - Class: rviz_common/Group
       Displays:
+        - Class: rviz_common/Group
+          Displays: ~
+          Enabled: true
+          Name: Map
+        - Class: rviz_common/Group
+          Displays:
+            - Class: rviz_default_plugins/Camera
+              Enabled: true
+              Far Plane Distance: 100
+              Image Rendering: background and overlay
+              Name: PointcloudOnCamera
+              Overlay Alpha: 0.5
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /sensing/camera/camera6/image_raw
+              Value: true
+              Visibility:
+                Control:
+                  "": true
+                  Value: false
+                Debug:
+                  Control: true
+                  Localization:
+                    "": true
+                    Value: true
+                  Map: true
+                  Perception:
+                    "": true
+                    Value: true
+                  Planning:
+                    "":
+                      "": true
+                      Value: true
+                    Value: true
+                  Sensing:
+                    ConcatenatePointCloud: true
+                    RadarRawObjects(white): true
+                    Value: true
+                  Value: true
+                Localization:
+                  "":
+                    "": true
+                    Value: true
+                  Value: false
+                Map:
+                  "": true
+                  Value: false
+                Perception:
+                  "":
+                    "": true
+                    Value: true
+                  Value: false
+                Planning:
+                  "":
+                    "": true
+                    Value: true
+                  Value: false
+                Sensing:
+                  "":
+                    "": true
+                    Value: true
+                  Value: true
+                Simulation:
+                  Condition Group: true
+                  Debug Marker: true
+                  Entity Marker: true
+                  Lanelet Marker: true
+                  Simple Sensor Simulator:
+                    Detected Objects: true
+                    Occupancy Grid Map: true
+                    Simple LiDAR: true
+                    Value: true
+                  Traffic Light Marker: true
+                  Value: true
+                System:
+                  "": true
+                  Value: false
+                Value: true
+              Zoom Factor: 1
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 5
+                Min Value: -1
+                Value: false
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz_default_plugins/PointCloud2
+              Color: 255; 255; 255
+              Color Transformer: AxisColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: ConcatenatePointCloud
+              Position Transformer: XYZ
+              Selectable: false
+              Size (Pixels): 3
+              Size (m): 0.019999999552965164
+              Style: Points
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /sensing/lidar/concatenated/pointcloud
+              Use Fixed Frame: false
+              Use rainbow: true
+              Value: true
+            - BUS:
+                Alpha: 0.5
+                Color: 255; 255; 255
+              CAR:
+                Alpha: 0.5
+                Color: 255; 255; 255
+              CYCLIST:
+                Alpha: 0.5
+                Color: 255; 255; 255
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.029999999329447746
+              MOTORCYCLE:
+                Alpha: 0.5
+                Color: 255; 255; 255
+              Name: RadarRawObjects(white)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.5
+                Color: 255; 255; 255
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.5
+                Color: 255; 255; 255
+              TRUCK:
+                Alpha: 0.5
+                Color: 255; 255; 255
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /sensing/radar/detected_objects
+              UNKNOWN:
+                Alpha: 0.5
+                Color: 255; 255; 255
+              Value: true
+              Visualization Type: Normal
+          Enabled: false
+          Name: Sensing
+        - Class: rviz_common/Group
+          Displays:
+            - Alpha: 0.9990000128746033
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz_default_plugins/PointCloud2
+              Color: 85; 255; 0
+              Color Transformer: FlatColor
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 85; 255; 127
+              Max Intensity: 0
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: NDT pointclouds
+              Position Transformer: XYZ
+              Selectable: false
+              Size (Pixels): 10
+              Size (m): 0.5
+              Style: Squares
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/pose_estimator/points_aligned
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Alpha: 1
+              Autocompute Intensity Bounds: true
+              Autocompute Value Bounds:
+                Max Value: 10
+                Min Value: -10
+                Value: true
+              Axis: Z
+              Channel Name: intensity
+              Class: rviz_default_plugins/PointCloud2
+              Color: 255; 255; 255
+              Color Transformer: ""
+              Decay Time: 0
+              Enabled: true
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 4096
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: NDTLoadedPCDMap
+              Position Transformer: ""
+              Selectable: true
+              Size (Pixels): 3
+              Size (m): 0.10000000149011612
+              Style: Flat Squares
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/pose_estimator/debug/loaded_pointcloud_map
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
+            - Buffer Size: 200
+              Class: rviz_plugins::PoseHistory
+              Enabled: true
+              Line:
+                Alpha: 0.9990000128746033
+                Color: 170; 255; 127
+                Value: true
+                Width: 0.10000000149011612
+              Name: NDTPoseHistory
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/pose_estimator/pose
+              Value: true
+            - Buffer Size: 1000
+              Class: rviz_plugins::PoseHistory
+              Enabled: true
+              Line:
+                Alpha: 0.9990000128746033
+                Color: 0; 255; 255
+                Value: true
+                Width: 0.10000000149011612
+              Name: EKFPoseHistory
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/pose_twist_fusion_filter/pose
+              Value: true
+          Enabled: true
+          Name: Localization
+        - Class: rviz_common/Group
+          Displays:
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 255; 138; 128
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 255; 138; 128
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 255; 138; 128
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 255; 138; 128
+              Name: Centerpoint(red1)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 255; 138; 128
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 255; 138; 128
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 255; 138; 128
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/centerpoint/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 255; 138; 128
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 255; 82; 82
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 255; 82; 82
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 255; 82; 82
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 255; 82; 82
+              Name: CenterpointROIFusion(red2)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 255; 82; 82
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 255; 82; 82
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 255; 82; 82
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 255; 82; 82
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 0
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 0
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 0
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 0
+              Name: CenterpointValidator(red3)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 0
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 0
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 0
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/centerpoint/validation/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 0
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 178; 255; 89
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 178; 255; 89
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 178; 255; 89
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 178; 255; 89
+              Name: PointPainting(light_green1)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 178; 255; 89
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 178; 255; 89
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 178; 255; 89
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/pointpainting/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 178; 255; 89
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 118; 255; 3
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 118; 255; 3
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 118; 255; 3
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 118; 255; 3
+              Name: PointPaintingROIFusion(light_green2)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 118; 255; 3
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 118; 255; 3
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 118; 255; 3
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 118; 255; 3
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 100; 221; 23
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 100; 221; 23
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 100; 221; 23
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 100; 221; 23
+              Name: PointPaintingValidator(light_green3)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 100; 221; 23
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 100; 221; 23
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 100; 221; 23
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/pointpainting/validation/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 100; 221; 23
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 255; 145; 0
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 255; 145; 0
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 255; 145; 0
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 255; 145; 0
+              Name: DetectionByTracker(orange)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 255; 145; 0
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 255; 145; 0
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 255; 145; 0
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/detection_by_tracker/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 255; 145; 0
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 249
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 249
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 249
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 249
+              Name: CameraLidarFusion(purple)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 249
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 249
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 249
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/clustering/camera_lidar_fusion/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 213; 0; 249
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 255; 255; 255
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 255; 255; 255
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 255; 255; 255
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 255; 255; 255
+              Name: RadarFarObjects(white)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 255; 255; 255
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 255; 255; 255
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 255; 255; 255
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/radar/far_objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 255; 255; 255
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 255; 234; 0
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 255; 234; 0
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 255; 234; 0
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 255; 234; 0
+              Name: Detection(yellow)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 255; 234; 0
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 255; 234; 0
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 255; 234; 0
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/detection/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 255; 234; 0
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 0; 230; 118
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 0; 230; 118
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 0; 230; 118
+              Class: autoware_perception_rviz_plugin/TrackedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Dynamic Status: All
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 0; 230; 118
+              Name: Tracking(green)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 0; 230; 118
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 0; 230; 118
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 0; 230; 118
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/tracking/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 0; 230; 118
+              Value: true
+              Visualization Type: Normal
+            - BUS:
+                Alpha: 0.9990000128746033
+                Color: 0; 176; 255
+              CAR:
+                Alpha: 0.9990000128746033
+                Color: 0; 176; 255
+              CYCLIST:
+                Alpha: 0.9990000128746033
+                Color: 0; 176; 255
+              Class: autoware_perception_rviz_plugin/PredictedObjects
+              Confidence Interval: 95%
+              Display Acceleration: true
+              Display Existence Probability: false
+              Display Label: true
+              Display Pose Covariance: true
+              Display Predicted Path Confidence: true
+              Display Predicted Paths: true
+              Display Twist: true
+              Display Twist Covariance: false
+              Display UUID: true
+              Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
+              Enabled: true
+              Line Width: 0.10000000149011612
+              MOTORCYCLE:
+                Alpha: 0.9990000128746033
+                Color: 0; 176; 255
+              Name: Prediction(light_blue)
+              Namespaces:
+                {}
+              Object Fill Type: skeleton
+              PEDESTRIAN:
+                Alpha: 0.9990000128746033
+                Color: 0; 176; 255
+              Polygon Type: 3d
+              TRAILER:
+                Alpha: 0.9990000128746033
+                Color: 0; 176; 255
+              TRUCK:
+                Alpha: 0.9990000128746033
+                Color: 0; 176; 255
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/object_recognition/objects
+              UNKNOWN:
+                Alpha: 0.9990000128746033
+                Color: 0; 176; 255
+              Value: true
+              Visualization Type: Normal
+          Enabled: true
+          Name: Perception
+        - Class: rviz_common/Group
+          Displays:
+            - Class: rviz_common/Group
+              Displays:
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: LaneChangeLeft
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/lane_change_left
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: LaneChangeRight
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/lane_change_right
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: AvoidanceLeft
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/static_obstacle_avoidance_left
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: AvoidanceRight
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/static_obstacle_avoidance_right
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: AvoidanceByLCLeft
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/avoidance_by_lc_left
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: AvoidanceByLCRight
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/avoidance_by_lc_right
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: StartPlanner
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/start_planner
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: GoalPlanner
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/goal_planner
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: Crosswalk
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/crosswalk
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: Intersection
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/intersection
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: BlindSpot
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/blind_spot
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: TrafficLight
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/traffic_light
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: DetectionArea
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/detection_area
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: NoStoppingArea
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/no_stopping_area
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: ObstacleCruise
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/obstacle_cruise_planner
+                  Value: true
+              Enabled: true
+              Name: Objects Of Interest
+          Enabled: true
+          Name: Planning
+        - Class: rviz_common/Group
+          Displays: ~
+          Enabled: true
+          Name: Control
+      Enabled: false
+      Name: Debug
+    - Class: rviz_common/Group
+      Displays:
         - Class: rviz_default_plugins/MarkerArray
           Enabled: true
           Name: Debug Marker
@@ -2821,7 +4272,7 @@ Visualization Manager:
           Enabled: true
           Name: Entity Marker
           Namespaces:
-            {}
+            ego: true
           Topic:
             Depth: 5
             Durability Policy: Volatile
@@ -2833,7 +4284,20 @@ Visualization Manager:
           Enabled: true
           Name: Lanelet Marker
           Namespaces:
-            {}
+            center_lane_line: true
+            center_line_arrows: true
+            crosswalk_lanelets: true
+            lane_start_bound: true
+            lanelet direction: true
+            lanelet_id: true
+            left_lane_bound: true
+            parking_lots: true
+            parking_space: true
+            right_lane_bound: true
+            road_lanelets: true
+            stop_lines: true
+            traffic_light: true
+            traffic_light_triangle: true
           Topic:
             Depth: 5
             Durability Policy: Transient Local
@@ -2921,15 +4385,21 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 119; 11; 32
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
+              Confidence Interval: 95%
               Display Acceleration: true
+              Display Existence Probability: false
               Display Label: true
-              Display PoseWithCovariance: true
+              Display Pose Covariance: true
               Display Predicted Path Confidence: true
               Display Predicted Paths: true
               Display Twist: true
+              Display Twist Covariance: false
               Display UUID: true
               Display Velocity: true
+              Display Yaw Covariance: false
+              Display Yaw Rate: false
+              Display Yaw Rate Covariance: false
               Enabled: true
               Line Width: 0.029999999329447746
               MOTORCYCLE:
@@ -2938,6 +4408,7 @@ Visualization Manager:
               Name: Detected Objects
               Namespaces:
                 {}
+              Object Fill Type: skeleton
               PEDESTRIAN:
                 Alpha: 0.9990000128746033
                 Color: 255; 192; 203
@@ -2986,7 +4457,7 @@ Visualization Manager:
       Name: Simulation
   Enabled: true
   Global Options:
-    Background Color: 10; 10; 10
+    Background Color: 15; 20; 23
     Fixed Frame: map
     Frame Rate: 30
   Name: root
@@ -3094,8 +4565,8 @@ Visualization Manager:
       Scale: 10
       Target Frame: entities
       Value: TopDownOrtho (rviz_default_plugins)
-      X: 0
-      Y: 0
+      X: 66.42724609375
+      Y: -19.859375
     Saved:
       - Class: rviz_default_plugins/ThirdPersonFollower
         Distance: 18
@@ -3139,12 +4610,12 @@ Window Geometry:
     collapsed: false
   Displays:
     collapsed: false
-  Height: 2096
+  Height: 1565
   Hide Left Dock: false
   Hide Right Dock: false
-  InitialPoseButtonPanel:
+  PointcloudOnCamera:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000002d5000007d6fc020000000ffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000005e2000000c900fffffffc00000625000001ee000000c10100001cfa000000010100000002fb0000000a0056006900650077007301000000000000033c0000010000fffffffb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000000ffffffff0000009d00fffffffb00000024004100750074006f00770061007200650053007400610074006500500061006e0065006c00000003e0000003300000017200fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d0065007200610100000682000000eb0000000000000000fb0000000a0049006d0061006700650100000505000002680000000000000000fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000006e00fffffffb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb00000030005200650063006f0067006e006900740069006f006e0052006500730075006c0074004f006e0049006d006100670065000000066c0000008f0000002800fffffffb0000002a004100750074006f0077006100720065004400610074006500540069006d006500500061006e0065006c00000006e8000001100000004100ffffff000000010000015f000006fffc0200000002fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000e7a0000005afc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e7a0000005afc0100000002fb0000000800540069006d0065010000000000000e7a0000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000bdf000007d600000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001ee000005c3fc020000000ffb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d0000037d000000c900fffffffc000003c000000240000000c10100001cfa000000020100000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000000ffffffff0000009d00fffffffb00000024004100750074006f00770061007200650053007400610074006500500061006e0065006c0100000000ffffffff000000c100fffffffb0000000a005600690065007700730100000000000001ee0000010000fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d0065007200610100000682000000eb0000000000000000fb0000000a0049006d0061006700650100000505000002680000000000000000fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb0000002c0049006e0069007400690061006c0050006f007300650042007500740074006f006e00500061006e0065006c000000068f000000de0000000000000000fb00000030005200650063006f0067006e006900740069006f006e0052006500730075006c0074004f006e0049006d006100670065000000047a000001860000002800fffffffb0000002a004100750074006f0077006100720065004400610074006500540069006d006500500061006e0065006c0000000332000000720000004100fffffffb000000240050006f0069006e00740063006c006f00750064004f006e00430061006d006500720061000000039d000000560000002800ffffff00000001000001ab000005c3fc0200000002fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000e7a0000005afc0100000001fb0000000a00560069006500770073030000004e00000080000002e1000001970000000300000e7a0000005afc0100000002fb0000000800540069006d0065010000000000000e7a0000000000000000fb0000000800540069006d0065010000000000000450000000000000000000000909000005c300000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   RecognitionResultOnImage:
     collapsed: false
   Selection:
@@ -3153,6 +4624,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: false
-  Width: 3770
-  X: 70
+  Width: 2813
+  X: 1510
   Y: 27


### PR DESCRIPTION
# Description

## Abstract

Updated the rviz config file based on [autoware.rviz](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/rviz/autoware.rviz) to display the latest Rviz plugin used by Autoware developers.
However, some modifications have been made so as not to disrupt the appearance of the previous scenario_simulator_v2 Rviz.


![Screenshot from 2025-01-06 11-27-04](https://github.com/user-attachments/assets/0c8c18da-0562-4e9b-8db0-edccd9c27187)

## Background

Continuation of https://github.com/tier4/scenario_simulator_v2/pull/1349

## References

https://github.com/tier4/scenario_simulator_v2/issues/1342

# Destructive Changes

This is a destructive change for rviz config file.
But, there are no effects for simulation and autoware behaviors even if some rviz plugins are missing.

# Known Limitations

None