### PR TITLE
[WIP] Use ubuntu-22.04-arm for ARM64 testing / building

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro: [humble]
-        runs_on: [ubuntu-22.04] # macos-14 is added for arm support. See also https://x.com/github/status/1752458943245189120?s=20
+        runs_on: [ubuntu-22.04, ubuntu-22.04-arm] # macos-14 is added for arm support. See also https://x.com/github/status/1752458943245189120?s=20
         cmake_build_type: [RelWithDebInfo, Release] # Debug build type is currently unavailable. @TODO Fix problem and add Debug build.
     steps:
       - name: Suppress warnings


### PR DESCRIPTION
# Description
## Abstract

This PR will enable ARM64 CI support.

## Background

[Linux arm64 hosted runners now available for free in public repositories](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)
