### PR TITLE
chore: change junit inline namespace to normal namespace

### DIFF
--- a/common/simple_junit/include/simple_junit/junit5.hpp
+++ b/common/simple_junit/include/simple_junit/junit5.hpp
@@ -28,7 +28,7 @@ using string = std::string;
 
 namespace common
 {
-inline namespace junit
+namespace junit
 {
 struct Pass
 {

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/openscenario_interpreter.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/openscenario_interpreter.hpp
@@ -70,7 +70,7 @@ class Interpreter : public rclcpp_lifecycle::LifecycleNode,
 
   std::shared_ptr<rclcpp::TimerBase> timer;
 
-  common::JUnit5 results;
+  common::junit::JUnit5 results;
 
   boost::variant<common::junit::Pass, common::junit::Failure, common::junit::Error> result;
 

--- a/test_runner/random_test_runner/include/random_test_runner/file_interactions/junit_xml_reporter.hpp
+++ b/test_runner/random_test_runner/include/random_test_runner/file_interactions/junit_xml_reporter.hpp
@@ -29,7 +29,9 @@
 class JunitXmlReporterTestCase
 {
 public:
-  explicit JunitXmlReporterTestCase(common::SimpleTestCase & testcase) : testcase_(testcase) {}
+  explicit JunitXmlReporterTestCase(common::junit::SimpleTestCase & testcase) : testcase_(testcase)
+  {
+  }
 
   void reportCollision(const NPCDescription & npc, double time)
   {
@@ -52,7 +54,7 @@ private:
     testcase_.error.push_back(result);
   }
 
-  common::SimpleTestCase & testcase_;
+  common::junit::SimpleTestCase & testcase_;
 };
 
 class JunitXmlReporter
@@ -77,7 +79,7 @@ public:
   }
 
 private:
-  common::JUnit5 results_;
+  common::junit::JUnit5 results_;
   std::string output_directory_;
   rclcpp::Logger logger_;
 };


### PR DESCRIPTION
# Description

## Abstract

Change the `junit` inline namespace to a normal namespace to avoid `common::Error` being ambiguous.

## Background

There are two `Error` classes in `common` namespace.
- `common::junit::Error`
- `common::scenario_simulator_exception::Error`

But, the both of second level namespace, `junit` and `scenario_simulator_exception` are inline namespace.
Therefore, `common::Error` is a valid expression for both of `Error` classes, and in an environment where both are valid, it will cause the following compilation error:

```
 error: reference to ‘Error’ is ambiguous
  |     throw common::Error(
```


## Details

Mostly, `common::Error` means `common::scenario_simulator_exception::Error`.
Therefore, I modified `common::Error` to mean only `common::scenario_simulator_exception::Error`.

## References

[RegressionTest: WIP]()

# Destructive Changes

If external code that uses `common::Error` for `common::junit::Error` is present, it will occur compilation error.
Note: This is a possibility, and as far as I know, such a code has never actually existed.

# Known Limitations

None
