### PR TITLE
feat(simple_sensor_simulator): use vel state for acc state calculation of SimModelDelaySteerVel 

### DIFF
--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/vehicle_simulation/vehicle_model/sim_model_delay_steer_vel.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/vehicle_simulation/vehicle_model/sim_model_delay_steer_vel.hpp
@@ -72,7 +72,6 @@ private:
   const double steer_lim_;       //!< @brief steering limit [rad]
   const double steer_rate_lim_;  //!< @brief steering angular velocity limit [rad/s]
   const double wheelbase_;       //!< @brief vehicle wheelbase length [m]
-  double prev_vx_ = 0.0;
   double current_ax_ = 0.0;
 
   std::deque<double> vx_input_queue_;     //!< @brief buffer for velocity command

--- a/simulation/simple_sensor_simulator/src/vehicle_simulation/vehicle_model/sim_model_delay_steer_vel.cpp
+++ b/simulation/simple_sensor_simulator/src/vehicle_simulation/vehicle_model/sim_model_delay_steer_vel.cpp
@@ -57,9 +57,9 @@ void SimModelDelaySteerVel::update(const double & dt)
   delayed_input(IDX_U::STEER_DES) = steer_input_queue_.front();
   steer_input_queue_.pop_front();
   // do not use deadzone_delta_steer (Steer IF does not exist in this model)
+  const double prev_vx = state_(IDX::VX);
   updateRungeKutta(dt, delayed_input);
-  current_ax_ = (input_(IDX_U::VX_DES) - prev_vx_) / dt;
-  prev_vx_ = input_(IDX_U::VX_DES);
+  current_ax_ = (state_(IDX::VX) - prev_vx) / dt;
 }
 
 void SimModelDelaySteerVel::initializeInputQueue(const double & dt)


### PR DESCRIPTION
# Description

## Abstract

porting https://github.com/autowarefoundation/autoware.universe/pull/10030.
use vel state for acc state calculation of SimModelDelaySteerVel

## Background

fix the scenario fails in https://tier4.atlassian.net/browse/RT1-9039
this caused by introducing acc condtion

96/98([2025/01/14](https://evaluation.tier4.jp/evaluation/reports/948cae29-225e-5196-84f2-7219c4002e76/?project_id=prd_jt)) -> 64/98([2025/01/15](https://evaluation.tier4.jp/evaluation/reports/ba6e34c5-38d5-55c9-9bc3-a75f91218c80/?project_id=prd_jt)) (degraded!!)


## Details

Currently, the **vel input** control is used to calculate the acc state. However, the input values can fluctuate, sometimes resulting in a large acc state.
In this PR, I’ve changed the calculation method so that the acc state is now based on the **vel state**, which is computed using a first-order lag filter.

before 

![image](https://github.com/user-attachments/assets/c84ebb4e-76ba-4d37-a9bb-aa09c650fac9)


after

![image](https://github.com/user-attachments/assets/abfb237c-d881-445f-8120-825e6063376a)



## References

- https://github.com/autowarefoundation/autoware.universe/pull/10030

## How was this PR tested?

- print the acc value in scenario simulator v2

- 96/98([2025/01/14](https://evaluation.tier4.jp/evaluation/reports/948cae29-225e-5196-84f2-7219c4002e76/?project_id=prd_jt)) -> 64/98([2025/01/15](https://evaluation.tier4.jp/evaluation/reports/ba6e34c5-38d5-55c9-9bc3-a75f91218c80/?project_id=prd_jt)) (degraded!! introduce acc fail condition) -> 
96/98 ([2025/01/28](https://evaluation.tier4.jp/evaluation/reports/19785c8e-7ef7-5025-9b3c-9ef81bf7712f/?project_id=prd_jt) (with https://github.com/tier4/scenario_simulator_v2/pull/1516)


# Destructive Changes

# Known Limitations
