### PR TITLE
Support message type `autoware_internal_planning_msgs::msg::PathWithLaneId`

### DIFF
--- a/external/concealer/CMakeLists.txt
+++ b/external/concealer/CMakeLists.txt
@@ -18,6 +18,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/execute.cpp
   src/field_operator_application.cpp
   src/is_package_exists.cpp
+  src/path_with_lane_id.cpp
   src/task_queue.cpp)
 
 target_link_libraries(${PROJECT_NAME}

--- a/external/concealer/include/concealer/autoware_universe.hpp
+++ b/external/concealer/include/concealer/autoware_universe.hpp
@@ -15,12 +15,6 @@
 #ifndef CONCEALER__AUTOWARE_UNIVERSE_HPP_
 #define CONCEALER__AUTOWARE_UNIVERSE_HPP_
 
-#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
-#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
-#else
-#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
-#endif
-
 #include <atomic>
 #include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
@@ -32,6 +26,7 @@
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 #include <autoware_vehicle_msgs/srv/control_mode_command.hpp>
 #include <concealer/continuous_transform_broadcaster.hpp>
+#include <concealer/path_with_lane_id.hpp>
 #include <concealer/publisher.hpp>
 #include <concealer/subscriber.hpp>
 #include <concealer/visibility.hpp>
@@ -55,21 +50,16 @@ public:
   using GearCommand                 = autoware_vehicle_msgs::msg::GearCommand;
   using GearReport                  = autoware_vehicle_msgs::msg::GearReport;
   using Odometry                    = nav_msgs::msg::Odometry;
-#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
-  using PathWithLaneId              = autoware_internal_planning_msgs::msg::PathWithLaneId;
-#else
-  using PathWithLaneId              = tier4_planning_msgs::msg::PathWithLaneId;
-#endif
   using PoseWithCovarianceStamped   = geometry_msgs::msg::PoseWithCovarianceStamped;
   using SteeringReport              = autoware_vehicle_msgs::msg::SteeringReport;
   using TurnIndicatorsCommand       = autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
   using TurnIndicatorsReport        = autoware_vehicle_msgs::msg::TurnIndicatorsReport;
   using VelocityReport              = autoware_vehicle_msgs::msg::VelocityReport;
 
-  Subscriber<Control>               getCommand;
-  Subscriber<GearCommand>           getGearCommand;
-  Subscriber<TurnIndicatorsCommand> getTurnIndicatorsCommand;
-  Subscriber<PathWithLaneId>        getPathWithLaneId;
+  Subscriber<Control>                  getCommand;
+  Subscriber<GearCommand>              getGearCommand;
+  Subscriber<TurnIndicatorsCommand>    getTurnIndicatorsCommand;
+  Subscriber<priority::PathWithLaneId> getPathWithLaneId;
 
   Publisher<AccelWithCovarianceStamped> setAcceleration;
   Publisher<Odometry>                   setOdometry;

--- a/external/concealer/include/concealer/autoware_universe.hpp
+++ b/external/concealer/include/concealer/autoware_universe.hpp
@@ -15,6 +15,12 @@
 #ifndef CONCEALER__AUTOWARE_UNIVERSE_HPP_
 #define CONCEALER__AUTOWARE_UNIVERSE_HPP_
 
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
+#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
+#else
+#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
+#endif
+
 #include <atomic>
 #include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
@@ -34,7 +40,6 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 
 namespace concealer
 {
@@ -50,7 +55,11 @@ public:
   using GearCommand                 = autoware_vehicle_msgs::msg::GearCommand;
   using GearReport                  = autoware_vehicle_msgs::msg::GearReport;
   using Odometry                    = nav_msgs::msg::Odometry;
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
+  using PathWithLaneId              = autoware_internal_planning_msgs::msg::PathWithLaneId;
+#else
   using PathWithLaneId              = tier4_planning_msgs::msg::PathWithLaneId;
+#endif
   using PoseWithCovarianceStamped   = geometry_msgs::msg::PoseWithCovarianceStamped;
   using SteeringReport              = autoware_vehicle_msgs::msg::SteeringReport;
   using TurnIndicatorsCommand       = autoware_vehicle_msgs::msg::TurnIndicatorsCommand;

--- a/external/concealer/include/concealer/available.hpp
+++ b/external/concealer/include/concealer/available.hpp
@@ -20,7 +20,8 @@
 namespace concealer
 {
 template <typename T>
-constexpr auto available(const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool
+constexpr auto available(const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &)
+  -> bool
 {
   return true;
 }

--- a/external/concealer/include/concealer/available.hpp
+++ b/external/concealer/include/concealer/available.hpp
@@ -15,13 +15,10 @@
 #ifndef CONCEALER__AVAILABLE_HPP_
 #define CONCEALER__AVAILABLE_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-
 namespace concealer
 {
 template <typename T>
-constexpr auto available(const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &)
-  -> bool
+constexpr auto available() -> bool
 {
   return true;
 }

--- a/external/concealer/include/concealer/available.hpp
+++ b/external/concealer/include/concealer/available.hpp
@@ -1,0 +1,29 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONCEALER__AVAILABLE_HPP_
+#define CONCEALER__AVAILABLE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace concealer
+{
+template <typename T>
+constexpr auto available(const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool
+{
+  return true;
+}
+}  // namespace concealer
+
+#endif  // CONCEALER__AVAILABLE_HPP_

--- a/external/concealer/include/concealer/convert.hpp
+++ b/external/concealer/include/concealer/convert.hpp
@@ -1,0 +1,27 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONCEALER__CONVERT_HPP_
+#define CONCEALER__CONVERT_HPP_
+
+namespace concealer
+{
+template <typename To, typename From>
+auto convert(const From & from) -> To
+{
+  return std::forward<decltype(from)>(from);
+}
+}  // namespace concealer
+
+#endif  // CONCEALER__CONVERT_HPP_

--- a/external/concealer/include/concealer/field_operator_application.hpp
+++ b/external/concealer/include/concealer/field_operator_application.hpp
@@ -21,12 +21,6 @@
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #endif
 
-#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
-#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
-#else
-#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
-#endif
-
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
 #include <autoware_adapi_v1_msgs/srv/clear_route.hpp>
@@ -37,6 +31,7 @@
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <concealer/autoware_universe.hpp>
+#include <concealer/path_with_lane_id.hpp>
 #include <concealer/publisher.hpp>
 #include <concealer/service.hpp>
 #include <concealer/subscriber.hpp>
@@ -83,11 +78,6 @@ struct FieldOperatorApplication : public rclcpp::Node,
   using Emergency                       = tier4_external_api_msgs::msg::Emergency;
   using LocalizationInitializationState = autoware_adapi_v1_msgs::msg::LocalizationInitializationState;
   using MrmState                        = autoware_adapi_v1_msgs::msg::MrmState;
-#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
-  using PathWithLaneId                  = autoware_internal_planning_msgs::msg::PathWithLaneId;
-#else
-  using PathWithLaneId                  = tier4_planning_msgs::msg::PathWithLaneId;
-#endif
   using Trajectory                      = tier4_planning_msgs::msg::Trajectory;
   using TurnIndicatorsCommand           = autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 
@@ -107,10 +97,10 @@ struct FieldOperatorApplication : public rclcpp::Node,
 #if __has_include(<autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>)
   Subscriber<LocalizationInitializationState> getLocalizationState;
 #endif
-  Subscriber<MrmState>                        getMrmState;
-  Subscriber<PathWithLaneId>                  getPathWithLaneId;
-  Subscriber<Trajectory>                      getTrajectory;
-  Subscriber<TurnIndicatorsCommand>           getTurnIndicatorsCommand;
+  Subscriber<MrmState>                 getMrmState;
+  Subscriber<priority::PathWithLaneId> getPathWithLaneId;
+  Subscriber<Trajectory>               getTrajectory;
+  Subscriber<TurnIndicatorsCommand>    getTurnIndicatorsCommand;
 
   Service<ClearRoute>             requestClearRoute;
   Service<CooperateCommands>      requestCooperateCommands;

--- a/external/concealer/include/concealer/field_operator_application.hpp
+++ b/external/concealer/include/concealer/field_operator_application.hpp
@@ -21,6 +21,12 @@
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #endif
 
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
+#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
+#else
+#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
+#endif
+
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
 #include <autoware_adapi_v1_msgs/srv/clear_route.hpp>
@@ -44,7 +50,6 @@
 #include <tier4_external_api_msgs/msg/emergency.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
 #include <tier4_external_api_msgs/srv/set_velocity_limit.hpp>
-#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 #include <tier4_planning_msgs/msg/trajectory.hpp>
 #include <tier4_rtc_msgs/msg/cooperate_status_array.hpp>
 #include <tier4_rtc_msgs/srv/auto_mode_with_module.hpp>
@@ -78,7 +83,11 @@ struct FieldOperatorApplication : public rclcpp::Node,
   using Emergency                       = tier4_external_api_msgs::msg::Emergency;
   using LocalizationInitializationState = autoware_adapi_v1_msgs::msg::LocalizationInitializationState;
   using MrmState                        = autoware_adapi_v1_msgs::msg::MrmState;
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
+  using PathWithLaneId                  = autoware_internal_planning_msgs::msg::PathWithLaneId;
+#else
   using PathWithLaneId                  = tier4_planning_msgs::msg::PathWithLaneId;
+#endif
   using Trajectory                      = tier4_planning_msgs::msg::Trajectory;
   using TurnIndicatorsCommand           = autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 

--- a/external/concealer/include/concealer/get_parameter.hpp
+++ b/external/concealer/include/concealer/get_parameter.hpp
@@ -1,0 +1,34 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONCEALER__GET_PARAMETER_HPP_
+#define CONCEALER__GET_PARAMETER_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace concealer
+{
+template <typename T>
+auto getParameter(
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node,
+  const std::string & name, T value = {})
+{
+  if (not node->has_parameter(name)) {
+    node->declare_parameter(name, rclcpp::ParameterValue(value));
+  }
+  return node->get_parameter(name).get_value<T>();
+}
+}  // namespace concealer
+
+#endif  // CONCEALER__GET_PARAMETER_HPP_

--- a/external/concealer/include/concealer/get_parameter.hpp
+++ b/external/concealer/include/concealer/get_parameter.hpp
@@ -19,6 +19,8 @@
 
 namespace concealer
 {
+static constexpr auto default_architecture_type = "awf/universe/20240605";
+
 template <typename T>
 auto getParameter(
   const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node,

--- a/external/concealer/include/concealer/get_parameter.hpp
+++ b/external/concealer/include/concealer/get_parameter.hpp
@@ -29,6 +29,13 @@ auto getParameter(
   }
   return node->get_parameter(name).get_value<T>();
 }
+
+template <typename T>
+auto getParameter(const std::string & name, T value = {})
+{
+  auto node = rclcpp::Node("get_parameter", "simulation");
+  return getParameter(node.get_node_parameters_interface(), name, value);
+}
 }  // namespace concealer
 
 #endif  // CONCEALER__GET_PARAMETER_HPP_

--- a/external/concealer/include/concealer/path_with_lane_id.hpp
+++ b/external/concealer/include/concealer/path_with_lane_id.hpp
@@ -1,0 +1,55 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONCEALER__PATH_WITH_LANE_ID_HPP_
+#define CONCEALER__PATH_WITH_LANE_ID_HPP_
+
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
+#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
+#endif
+
+#if __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
+#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
+#endif
+
+#include <concealer/convert.hpp>
+
+namespace concealer
+{
+namespace priority
+{
+using PathWithLaneId = decltype(std::tuple_cat(
+  std::declval<std::tuple<
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
+    autoware_internal_planning_msgs::msg::PathWithLaneId
+#endif
+    > >(),
+  std::declval<std::tuple<
+#if __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
+    tier4_planning_msgs::msg::PathWithLaneId
+#endif
+    > >()));
+
+static_assert(0 < std::tuple_size_v<PathWithLaneId>);
+}  // namespace priority
+
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>) and \
+    __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
+template <>
+auto convert(const tier4_planning_msgs::msg::PathWithLaneId & from)
+  -> autoware_internal_planning_msgs::msg::PathWithLaneId;
+#endif
+}  // namespace concealer
+
+#endif  // CONCEALER__PATH_WITH_LANE_ID_HPP_

--- a/external/concealer/include/concealer/path_with_lane_id.hpp
+++ b/external/concealer/include/concealer/path_with_lane_id.hpp
@@ -23,6 +23,7 @@
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 #endif
 
+#include <concealer/available.hpp>
 #include <concealer/convert.hpp>
 
 namespace concealer
@@ -43,6 +44,16 @@ using PathWithLaneId = decltype(std::tuple_cat(
 
 static_assert(0 < std::tuple_size_v<PathWithLaneId>);
 }  // namespace priority
+
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
+template <>
+auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>(const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool;
+#endif
+
+#if __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
+template <>
+auto available<tier4_planning_msgs::msg::PathWithLaneId>(const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool;
+#endif
 
 #if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>) and \
     __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)

--- a/external/concealer/include/concealer/path_with_lane_id.hpp
+++ b/external/concealer/include/concealer/path_with_lane_id.hpp
@@ -47,12 +47,14 @@ static_assert(0 < std::tuple_size_v<PathWithLaneId>);
 
 #if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
 template <>
-auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>(const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool;
+auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>(
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool;
 #endif
 
 #if __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
 template <>
-auto available<tier4_planning_msgs::msg::PathWithLaneId>(const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool;
+auto available<tier4_planning_msgs::msg::PathWithLaneId>(
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool;
 #endif
 
 #if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>) and \

--- a/external/concealer/include/concealer/path_with_lane_id.hpp
+++ b/external/concealer/include/concealer/path_with_lane_id.hpp
@@ -47,14 +47,12 @@ static_assert(0 < std::tuple_size_v<PathWithLaneId>);
 
 #if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
 template <>
-auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>(
-  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool;
+auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>() -> bool;
 #endif
 
 #if __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
 template <>
-auto available<tier4_planning_msgs::msg::PathWithLaneId>(
-  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr &) -> bool;
+auto available<tier4_planning_msgs::msg::PathWithLaneId>() -> bool;
 #endif
 
 #if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>) and \

--- a/external/concealer/include/concealer/subscriber.hpp
+++ b/external/concealer/include/concealer/subscriber.hpp
@@ -38,23 +38,30 @@ struct Subscriber<Message>
   explicit Subscriber(
     const std::string & topic, const rclcpp::QoS & quality_of_service, Autoware & autoware,
     const Callback & callback)
-  : subscription(available<Message>(autoware.get_node_parameters_interface()) ? autoware.template create_subscription<Message>(
-      topic, quality_of_service,
-      [this, callback](const typename Message::ConstSharedPtr & message) {
-        if (std::atomic_store(&current_value, message); current_value) {
-          callback((*this)());
-        }
-      }) : throw common::scenario_simulator_exception::Error("no viable message type for topic ", std::quoted(topic)))
+  : subscription(
+      available<Message>(autoware.get_node_parameters_interface())
+        ? autoware.template create_subscription<Message>(
+            topic, quality_of_service,
+            [this, callback](const typename Message::ConstSharedPtr & message) {
+              if (std::atomic_store(&current_value, message); current_value) {
+                callback((*this)());
+              }
+            })
+        : nullptr)
   {
   }
 
   template <typename Autoware>
   explicit Subscriber(
     const std::string & topic, const rclcpp::QoS & quality_of_service, Autoware & autoware)
-  : subscription(available<Message>(autoware.get_node_parameters_interface()) ? autoware.template create_subscription<Message>(
-      topic, quality_of_service, [this](const typename Message::ConstSharedPtr & message) {
-        std::atomic_store(&current_value, message);
-      }) : nullptr)
+  : subscription(
+      available<Message>(autoware.get_node_parameters_interface())
+        ? autoware.template create_subscription<Message>(
+            topic, quality_of_service,
+            [this](const typename Message::ConstSharedPtr & message) {
+              std::atomic_store(&current_value, message);
+            })
+        : nullptr)
   {
   }
 };
@@ -80,13 +87,16 @@ struct Subscriber<Message, T, Ts...> : public Subscriber<T, Ts...>
     const std::string & topic, const rclcpp::QoS & quality_of_service, Autoware & autoware,
     const Callback & callback)
   : Subscriber<T, Ts...>(topic, quality_of_service, autoware, callback),
-    subscription(available<Message>(autoware.get_node_parameters_interface()) ? autoware.template create_subscription<Message>(
-      topic, quality_of_service,
-      [this, callback](const typename Message::ConstSharedPtr & message) {
-        if (std::atomic_store(&current_value, message); current_value) {
-          callback((*this)());
-        }
-      }) : nullptr)
+    subscription(
+      available<Message>(autoware.get_node_parameters_interface())
+        ? autoware.template create_subscription<Message>(
+            topic, quality_of_service,
+            [this, callback](const typename Message::ConstSharedPtr & message) {
+              if (std::atomic_store(&current_value, message); current_value) {
+                callback((*this)());
+              }
+            })
+        : nullptr)
   {
   }
 
@@ -94,10 +104,14 @@ struct Subscriber<Message, T, Ts...> : public Subscriber<T, Ts...>
   explicit Subscriber(
     const std::string & topic, const rclcpp::QoS & quality_of_service, Autoware & autoware)
   : Subscriber<T, Ts...>(topic, quality_of_service, autoware),
-    subscription(available<Message>(autoware.get_node_parameters_interface()) ? autoware.template create_subscription<Message>(
-      topic, quality_of_service, [this](const typename Message::ConstSharedPtr & message) {
-        std::atomic_store(&current_value, message);
-      }) : nullptr)
+    subscription(
+      available<Message>(autoware.get_node_parameters_interface())
+        ? autoware.template create_subscription<Message>(
+            topic, quality_of_service,
+            [this](const typename Message::ConstSharedPtr & message) {
+              std::atomic_store(&current_value, message);
+            })
+        : nullptr)
   {
   }
 };

--- a/external/concealer/include/concealer/subscriber.hpp
+++ b/external/concealer/include/concealer/subscriber.hpp
@@ -15,13 +15,17 @@
 #ifndef CONCEALER__SUBSCRIBER_HPP_
 #define CONCEALER__SUBSCRIBER_HPP_
 
+#include <concealer/convert.hpp>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 
 namespace concealer
 {
+template <typename...>
+struct Subscriber;
+
 template <typename Message>
-struct Subscriber
+struct Subscriber<Message>
 {
   typename Message::ConstSharedPtr current_value = std::make_shared<const Message>();
 
@@ -52,6 +56,55 @@ struct Subscriber
       }))
   {
   }
+};
+
+template <typename Message, typename T, typename... Ts>
+struct Subscriber<Message, T, Ts...> : public Subscriber<T, Ts...>
+{
+  typename Message::ConstSharedPtr current_value = nullptr;
+
+  typename rclcpp::Subscription<Message>::SharedPtr subscription;
+
+  auto operator()() const -> Message
+  {
+    if (auto value = std::atomic_load(&current_value)) {
+      return *value;
+    } else {
+      return convert<Message>(Subscriber<T, Ts...>::operator()());
+    }
+  }
+
+  template <typename Autoware, typename Callback>
+  explicit Subscriber(
+    const std::string & topic, const rclcpp::QoS & quality_of_service, Autoware & autoware,
+    const Callback & callback)
+  : Subscriber<T, Ts...>(topic, quality_of_service, autoware, callback),
+    subscription(autoware.template create_subscription<Message>(
+      topic, quality_of_service,
+      [this, callback](const typename Message::ConstSharedPtr & message) {
+        if (std::atomic_store(&current_value, message); current_value) {
+          callback((*this)());
+        }
+      }))
+  {
+  }
+
+  template <typename Autoware>
+  explicit Subscriber(
+    const std::string & topic, const rclcpp::QoS & quality_of_service, Autoware & autoware)
+  : Subscriber<T, Ts...>(topic, quality_of_service, autoware),
+    subscription(autoware.template create_subscription<Message>(
+      topic, quality_of_service, [this](const typename Message::ConstSharedPtr & message) {
+        std::atomic_store(&current_value, message);
+      }))
+  {
+  }
+};
+
+template <typename... Ts>
+struct Subscriber<std::tuple<Ts...>> : public Subscriber<Ts...>
+{
+  using Subscriber<Ts...>::Subscriber;
 };
 }  // namespace concealer
 

--- a/external/concealer/package.xml
+++ b/external/concealer/package.xml
@@ -13,6 +13,7 @@
   <!-- Autoware.Universe -->
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_control_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_system_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>

--- a/external/concealer/src/autoware_universe.cpp
+++ b/external/concealer/src/autoware_universe.cpp
@@ -16,7 +16,13 @@
 
 namespace concealer
 {
-AutowareUniverse::AutowareUniverse(bool simulate_localization)
+/*
+   clang-format seems not to understand the constructor function try-block: it
+   misidentifies the try as a jump label and the formatting afterwards falls
+   apart.
+*/
+// clang-format off
+AutowareUniverse::AutowareUniverse(bool simulate_localization) try
 : rclcpp::Node("concealer", "simulation"),
   getCommand("/control/command/control_cmd", rclcpp::QoS(1), *this),
   getGearCommand("/control/command/gear_cmd", rclcpp::QoS(1), *this),
@@ -161,6 +167,12 @@ AutowareUniverse::AutowareUniverse(bool simulate_localization)
   }))
 {
 }
+catch (...)
+{
+  thrown = std::current_exception();
+  is_thrown.store(true);
+}
+// clang-format on
 
 AutowareUniverse::~AutowareUniverse()
 {

--- a/external/concealer/src/autoware_universe.cpp
+++ b/external/concealer/src/autoware_universe.cpp
@@ -17,7 +17,7 @@
 namespace concealer
 {
 AutowareUniverse::AutowareUniverse(bool simulate_localization)
-: rclcpp::Node("concealer", "simulation", rclcpp::NodeOptions().use_global_arguments(false)),
+: rclcpp::Node("concealer", "simulation"),
   getCommand("/control/command/control_cmd", rclcpp::QoS(1), *this),
   getGearCommand("/control/command/gear_cmd", rclcpp::QoS(1), *this),
   getTurnIndicatorsCommand("/control/command/turn_indicators_cmd", rclcpp::QoS(1), *this),

--- a/external/concealer/src/path_with_lane_id.cpp
+++ b/external/concealer/src/path_with_lane_id.cpp
@@ -19,10 +19,9 @@ namespace concealer
 {
 #if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
 template <>
-auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>(
-  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node) -> bool
+auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>() -> bool
 {
-  if (const auto architecture_type = getParameter<std::string>(node, "architecture_type");
+  if (const auto architecture_type = getParameter<std::string>("architecture_type");
       architecture_type.find("awf/universe") != std::string::npos) {
     return "awf/universe/20250130" <= architecture_type;
   } else {
@@ -33,10 +32,9 @@ auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>(
 
 #if __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
 template <>
-auto available<tier4_planning_msgs::msg::PathWithLaneId>(
-  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node) -> bool
+auto available<tier4_planning_msgs::msg::PathWithLaneId>() -> bool
 {
-  if (const auto architecture_type = getParameter<std::string>(node, "architecture_type");
+  if (const auto architecture_type = getParameter<std::string>("architecture_type");
       architecture_type.find("awf/universe") != std::string::npos) {
     return architecture_type < "awf/universe/20250130";
   } else {

--- a/external/concealer/src/path_with_lane_id.cpp
+++ b/external/concealer/src/path_with_lane_id.cpp
@@ -1,0 +1,38 @@
+// Copyright 2015 TIER IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <concealer/path_with_lane_id.hpp>
+
+namespace concealer
+{
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>) and \
+    __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
+template <>
+auto convert(const tier4_planning_msgs::msg::PathWithLaneId & from)
+  -> autoware_internal_planning_msgs::msg::PathWithLaneId
+{
+  auto to = autoware_internal_planning_msgs::msg::PathWithLaneId();
+  to.header = from.header;
+  for (const auto & from_point : from.points) {
+    auto to_point = decltype(to.points)::value_type();
+    to_point.point = from_point.point;
+    to_point.lane_ids = from_point.lane_ids;
+    to.points.push_back(to_point);
+  }
+  to.left_bound = from.left_bound;
+  to.right_bound = from.right_bound;
+  return to;
+}
+#endif
+}  // namespace concealer

--- a/external/concealer/src/path_with_lane_id.cpp
+++ b/external/concealer/src/path_with_lane_id.cpp
@@ -21,7 +21,8 @@ namespace concealer
 template <>
 auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>() -> bool
 {
-  if (const auto architecture_type = getParameter<std::string>("architecture_type");
+  if (const auto architecture_type =
+        getParameter<std::string>("architecture_type", default_architecture_type);
       architecture_type.find("awf/universe") != std::string::npos) {
     return "awf/universe/20250130" <= architecture_type;
   } else {
@@ -34,7 +35,8 @@ auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>() -> bool
 template <>
 auto available<tier4_planning_msgs::msg::PathWithLaneId>() -> bool
 {
-  if (const auto architecture_type = getParameter<std::string>("architecture_type");
+  if (const auto architecture_type =
+        getParameter<std::string>("architecture_type", default_architecture_type);
       architecture_type.find("awf/universe") != std::string::npos) {
     return architecture_type < "awf/universe/20250130";
   } else {

--- a/external/concealer/src/path_with_lane_id.cpp
+++ b/external/concealer/src/path_with_lane_id.cpp
@@ -12,10 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <concealer/get_parameter.hpp>
 #include <concealer/path_with_lane_id.hpp>
 
 namespace concealer
 {
+#if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>)
+template <>
+auto available<autoware_internal_planning_msgs::msg::PathWithLaneId>(
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node) -> bool
+{
+  if (const auto architecture_type = getParameter<std::string>(node, "architecture_type");
+      architecture_type.find("awf/universe") != std::string::npos) {
+    return "awf/universe/20250130" <= architecture_type;
+  } else {
+    return false;
+  }
+}
+#endif
+
+#if __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
+template <>
+auto available<tier4_planning_msgs::msg::PathWithLaneId>(
+  const rclcpp::node_interfaces::NodeParametersInterface::SharedPtr & node) -> bool
+{
+  if (const auto architecture_type = getParameter<std::string>(node, "architecture_type");
+      architecture_type.find("awf/universe") != std::string::npos) {
+    return architecture_type < "awf/universe/20250130";
+  } else {
+    return false;
+  }
+}
+#endif
+
 #if __has_include(<autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>) and \
     __has_include(<tier4_planning_msgs/msg/path_with_lane_id.hpp>)
 template <>

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -35,7 +35,8 @@ from scenario_test_runner.shutdown_once import ShutdownOnce
 def architecture_types():
     # awf/universe/20230906: autoware_perception_msgs/TrafficSignalArray for traffic lights
     # awf/universe/20240605: autoware_perception_msgs/TrafficLightGroupArray for traffic lights
-    return ["awf/universe/20230906", "awf/universe/20240605"]
+    # awf/universe/20250130: [Pilot.Auto >= 0.41.1] autoware_internal_planning_msgs/msg/PathWithLaneId for concealer
+    return ["awf/universe/20230906", "awf/universe/20240605", "awf/universe/20250130"]
 
 
 def default_autoware_launch_package_of(architecture_type):
@@ -46,6 +47,7 @@ def default_autoware_launch_package_of(architecture_type):
     return {
         "awf/universe/20230906": "autoware_launch",
         "awf/universe/20240605": "autoware_launch",
+        "awf/universe/20250130": "autoware_launch",
     }[architecture_type]
 
 
@@ -57,6 +59,7 @@ def default_autoware_launch_file_of(architecture_type):
     return {
         "awf/universe/20230906": "planning_simulator.launch.xml",
         "awf/universe/20240605": "planning_simulator.launch.xml",
+        "awf/universe/20250130": "planning_simulator.launch.xml",
     }[architecture_type]
 
 


### PR DESCRIPTION
# Description

## Abstract

Support message type `autoware_internal_planning_msgs::msg::PathWithLaneId`.

## Background

From Pilot.Auto 0.41.0, `autoware_internal_planning_msgs` has been added. Due to the addition of this message type, `tier4_planning_msgs::msg::PathWithLaneId` will be replaced by `autoware_internal_planning_msgs::msg::PathWithLaneId` from Pilot.Auto 0.41.1 onwards. In other words, Pilot.Auto 0.41.0 is a version to give time for the message type change, and while `tier4_planning_msgs::msg::PathWithLaneId` and `autoware_internal_planning_msgs::msg::PathWithLaneId` coexist, `tier4_planning_msgs::msg::PathWithLaneId` is the one that is used.

To accommodate this change, scenario_simulator_v2 needs to support both message types and be able to switch which one to use. This pull request does this.

## Details

The current default `architecture_type` is `awf/unvierse/20240605` and this pull request does not change it. (We need to consider how to manage the default `architecture_type` in the future.)

- If `architecture_type` is `awf/universe/20250130` or later, `autoware_internal_planning_msgs::msg::PathWithLaneId` subscribers are instantiated.
- Otherwise, `tier4_planning_msgs::msg::PathWithLaneId` subscribers are instantiated.

To achieve the above switch, the class template `Subscriber` has been updated, and some auxiliary class templates have been added for it.

## References

None.

# Destructive Changes

None.

# Known Limitations

None.
