### PR TITLE
chore: delete unnecessary target branch filter in workflow trigger

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -8,8 +8,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   generate:

--- a/.github/workflows/InterfaceUpdateNotification.yaml
+++ b/.github/workflows/InterfaceUpdateNotification.yaml
@@ -1,8 +1,6 @@
 name: Interface update notification
 on:
   pull_request:
-    branches:
-      - master
     paths:
       - openscenario/openscenario_interpreter_msgs/msg/*.msg
       - simulation/traffic_simulator_msgs/msg/*.msg

--- a/.github/workflows/PostCheckList.yaml
+++ b/.github/workflows/PostCheckList.yaml
@@ -1,8 +1,6 @@
 name: Post check list
 on:
   pull_request:
-    branches:
-      - master
     types: [opened, reopened]
 
 jobs:

--- a/.github/workflows/SpellCheck.yaml
+++ b/.github/workflows/SpellCheck.yaml
@@ -3,8 +3,6 @@ name: Spell check
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - master
 
 jobs:
   spell-check:


### PR DESCRIPTION
# Description

## Abstract

This pull-request is deleting unnecessary target branch filter in workflow trigger

## Background

When adding new features or refactorings that require multiple pull requests, the target branch is often set to something other than master.
There is no reason to exclude such cases from CI.

## Details

This pull-request does not change any code.
So, no regression tests are executed.

The workflows below are not fixed because it makes sense to narrow down the target branch to master.
- .github/workflows/CheckBranchUpToDate.yaml
- .github/workflows/CheckLabel.yaml
- .github/workflows/Release.yaml

## References

None

# Destructive Changes

None

# Known Limitations

None
