### PR TITLE
chore: update `actions/upload-artifact` in Documentation.yaml

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -68,7 +68,7 @@ jobs:
         run: doxygen Doxyfile
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: api_documentation_site
           path: html


### PR DESCRIPTION
# Description

## Abstract

This pull-request is updating `actions/upload-artifact` from v3 to v4  in Documentation.yaml

## Background

Since January 30th, `actions/upload-artifact@v3` was no longer be able to use and preffered to use v4.
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

![image](https://github.com/user-attachments/assets/62d74f5a-d384-48bf-be29-e5499071ab92)


## Details

None

## References

The fixed workflow works fine!
https://github.com/tier4/scenario_simulator_v2/actions/runs/13064313151/job/36453875184?pr=1520

# Destructive Changes

None

# Known Limitations

None