### PR TITLE
feat: implement rosbag storage switching

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/openscenario_interpreter.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/openscenario_interpreter.hpp
@@ -64,6 +64,8 @@ class Interpreter : public rclcpp_lifecycle::LifecycleNode,
 
   bool record;
 
+  String record_storage_id;
+
   std::shared_ptr<OpenScenario> script;
 
   std::list<std::shared_ptr<ScenarioDefinition>> scenarios;

--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -43,7 +43,7 @@ Interpreter::Interpreter(const rclcpp::NodeOptions & options)
   output_directory("/tmp"),
   publish_empty_context(false),
   record(false),
-  record_storage_id("sqlite3")
+  record_storage_id("")
 {
   DECLARE_PARAMETER(local_frame_rate);
   DECLARE_PARAMETER(local_real_time_factor);
@@ -221,9 +221,14 @@ auto Interpreter::on_activate(const rclcpp_lifecycle::State &) -> Result
       },
       [&]() {
         if (record) {
-          record::start(
-            "-a", "-s", record_storage_id, "-o",
-            boost::filesystem::path(osc_path).replace_extension("").string());
+          if (record_storage_id == "") {
+            record::start(
+              "-a", "-o", boost::filesystem::path(osc_path).replace_extension("").string());
+          } else {
+            record::start(
+              "-a", "-o", boost::filesystem::path(osc_path).replace_extension("").string(), "-s",
+              record_storage_id);
+          }
         }
 
         SimulatorCore::activate(

--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -42,7 +42,8 @@ Interpreter::Interpreter(const rclcpp::NodeOptions & options)
   osc_path(""),
   output_directory("/tmp"),
   publish_empty_context(false),
-  record(false)
+  record(false),
+  record_storage_id("sqlite3")
 {
   DECLARE_PARAMETER(local_frame_rate);
   DECLARE_PARAMETER(local_real_time_factor);
@@ -50,6 +51,7 @@ Interpreter::Interpreter(const rclcpp::NodeOptions & options)
   DECLARE_PARAMETER(output_directory);
   DECLARE_PARAMETER(publish_empty_context);
   DECLARE_PARAMETER(record);
+  DECLARE_PARAMETER(record_storage_id);
 
   declare_parameter<std::string>("speed_condition", "legacy");
   SpeedCondition::compatibility =
@@ -111,6 +113,7 @@ auto Interpreter::on_configure(const rclcpp_lifecycle::State &) -> Result
       GET_PARAMETER(output_directory);
       GET_PARAMETER(publish_empty_context);
       GET_PARAMETER(record);
+      GET_PARAMETER(record_storage_id);
 
       script = std::make_shared<OpenScenario>(osc_path);
 
@@ -219,7 +222,8 @@ auto Interpreter::on_activate(const rclcpp_lifecycle::State &) -> Result
       [&]() {
         if (record) {
           record::start(
-            "-a", "-o", boost::filesystem::path(osc_path).replace_extension("").string());
+            "-a", "-s", record_storage_id, "-o",
+            boost::filesystem::path(osc_path).replace_extension("").string());
         }
 
         SimulatorCore::activate(

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -86,6 +86,7 @@ def launch_setup(context, *args, **kwargs):
     port                                = LaunchConfiguration("port",                                   default=5555)
     publish_empty_context               = LaunchConfiguration("publish_empty_context",                  default=False)
     record                              = LaunchConfiguration("record",                                 default=True)
+    record_storage_id                   = LaunchConfiguration("record_storage_id",                      default="sqlite3")
     rviz_config                         = LaunchConfiguration("rviz_config",                            default=default_rviz_config_file())
     scenario                            = LaunchConfiguration("scenario",                               default=Path("/dev/null"))
     sensor_model                        = LaunchConfiguration("sensor_model",                           default="")
@@ -112,6 +113,7 @@ def launch_setup(context, *args, **kwargs):
     print(f"port                                := {port.perform(context)}")
     print(f"publish_empty_context               := {publish_empty_context.perform(context)}")
     print(f"record                              := {record.perform(context)}")
+    print(f"record_storage_id                   := {record_storage_id.perform(context)}")
     print(f"rviz_config                         := {rviz_config.perform(context)}")
     print(f"scenario                            := {scenario.perform(context)}")
     print(f"sensor_model                        := {sensor_model.perform(context)}")
@@ -139,6 +141,7 @@ def launch_setup(context, *args, **kwargs):
             {"port": port},
             {"publish_empty_context" : publish_empty_context},
             {"record": record},
+            {"record_storage_id": record_storage_id},
             {"rviz_config": rviz_config},
             {"sensor_model": sensor_model},
             {"sigterm_timeout": sigterm_timeout},

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -86,7 +86,7 @@ def launch_setup(context, *args, **kwargs):
     port                                = LaunchConfiguration("port",                                   default=5555)
     publish_empty_context               = LaunchConfiguration("publish_empty_context",                  default=False)
     record                              = LaunchConfiguration("record",                                 default=True)
-    record_storage_id                   = LaunchConfiguration("record_storage_id",                      default="sqlite3")
+    record_storage_id                   = LaunchConfiguration("record_storage_id",                      default="")
     rviz_config                         = LaunchConfiguration("rviz_config",                            default=default_rviz_config_file())
     scenario                            = LaunchConfiguration("scenario",                               default=Path("/dev/null"))
     sensor_model                        = LaunchConfiguration("sensor_model",                           default="")


### PR DESCRIPTION
# Description

## Abstract

This pull-request adds `record_storage_id` launch file argument.
It is passed to argument `-s` (`--storage`) of `ros2 bag record` command.

## Background

We want to use mcap format for rosbag.
But, it is not default format in ROS 2 Humble.

## Details

If you don't specify `record_storage_id` argument, the default format in `ros2 bag record` command is used. ( same behavior to previous version )
In ROS 2 Humble, `sqlite3` is used, and `mcap` in ROS 2 Jazzy

## References

[No Regression](https://github.com/tier4/sim_evaluation_tools/issues/459)

# Destructive Changes

None

# Known Limitations

None