### PR TITLE
add comment about respawn_ego scenario

### DIFF
--- a/mock/cpp_mock_scenarios/CMakeLists.txt
+++ b/mock/cpp_mock_scenarios/CMakeLists.txt
@@ -58,6 +58,7 @@ if(BUILD_CPP_MOCK_SCENARIOS)
   add_subdirectory(src/synchronized_action)
   add_subdirectory(src/traffic_sink)
   add_subdirectory(src/traffic_source)
+  # The scenarios recorded in this directory are commented out as they require EgoEntity and cannot be used for CI.
   # add_subdirectory(src/respawn_ego)
 
 endif()


### PR DESCRIPTION
# Description

## Abstract

Added comments on scenarios that have been excluded from the test.

## Background

The respawn_ego scenario cannot be executed with GitHub Actions as it requires EgoEntity for execution.

## Details

Add a comment about it to the CMakeLists.txt.

## References

N/A

# Destructive Changes

N/A

# Known Limitations

N/A