### PR TITLE
Change copyright date to 2015

### DIFF
--- a/rviz_plugins/real_time_factor_control_rviz_plugin/src/real_time_factor_slider.cpp
+++ b/rviz_plugins/real_time_factor_control_rviz_plugin/src/real_time_factor_slider.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Tier IV, Inc. All rights reserved.
+// Copyright 2015 Tier IV, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rviz_plugins/real_time_factor_control_rviz_plugin/src/real_time_factor_slider.hpp
+++ b/rviz_plugins/real_time_factor_control_rviz_plugin/src/real_time_factor_slider.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Tier IV, Inc. All rights reserved.
+// Copyright 2015 Tier IV, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc. All rights reserved.
+// Copyright 2015 TIER IV, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/follow_waypoint_controller.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/follow_waypoint_controller.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc. All rights reserved.
+// Copyright 2015 TIER IV, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/simulation/traffic_simulator/src/behavior/follow_waypoint_controller.cpp
+++ b/simulation/traffic_simulator/src/behavior/follow_waypoint_controller.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc. All rights reserved.
+// Copyright 2015 TIER IV, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description

## Abstract
This is the partial PR of the HdMapUtils refactor (PR 2/6) ( #1478 )

## Background

## Details

It has been noticed that in some files the copyright date is wrong (other than 2015), and the date has been fixed in those files where the incorrect copyright date was noticed.

## References

- #1478

# Destructive Changes
None.

# Known Limitations
None.

