### PR TITLE
chore: use `AS` instead of `as` in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ROS_DISTRO="humble"
-FROM ros:${ROS_DISTRO} as build-stage
+FROM ros:${ROS_DISTRO} AS build-stage
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NOWARNINGS=yes

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -3,7 +3,7 @@ ARG ROS_DISTRO="humble"
 # cspell: ignore impactaky deno BUILDPLATFORM TARGETARCH
 
 FROM --platform=${BUILDPLATFORM} impactaky/mc-ubuntu22.04-${TARGETARCH}-host:2.1.0 AS mimic-host
-FROM ros:${ROS_DISTRO} as build-stage
+FROM ros:${ROS_DISTRO} AS build-stage
 
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.traffic_simulator
+++ b/Dockerfile.traffic_simulator
@@ -1,5 +1,5 @@
 ARG ROS_DISTRO="humble"
-FROM ros:${ROS_DISTRO} as build-stage
+FROM ros:${ROS_DISTRO} AS build-stage
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NOWARNINGS=yes


### PR DESCRIPTION
# Description

## Abstract

use `AS` instead of `as` in Dockerfiles

## Background

The lower-case `as` is pointed out by GitHub in every pull-request.
![image](https://github.com/user-attachments/assets/8e81d5ef-7c60-43cd-b0d1-665709f13944)


## Details

None

## References

None

# Destructive Changes

None

# Known Limitations

None