### PR TITLE
fix: remove double applied orientation for visualization entity triangle marker

### DIFF
--- a/simulation/traffic_simulator/src/visualization/visualization_component.cpp
+++ b/simulation/traffic_simulator/src/visualization/visualization_component.cpp
@@ -357,7 +357,6 @@ const visualization_msgs::msg::MarkerArray VisualizationComponent::generateMarke
   pr = math::geometry::transformPoint(status.pose, pr);
   arrow.points = {pf, pl, pr};
   arrow.colors = {color};
-  arrow.pose.orientation = status.pose.orientation;
   arrow.type = visualization_msgs::msg::Marker::TRIANGLE_LIST;
   arrow.scale.x = 1.0;
   arrow.scale.y = 1.0;


### PR DESCRIPTION
# Description

## Abstract

This pull-request removes double applied orientation for visualization entity triangle marker

## Background

Previously, there was a triangle marker in front of the entity, like the screenshot in document site.
https://tier4.github.io/scenario_simulator_v2-docs/user_guide/ScenarioTips/#lane-change
![image](https://github.com/user-attachments/assets/f1604222-bb16-45ac-8e9d-e6d288a9c7a2)

But, at some point, this triangle stopped appearing in the correct place.

## Details

Before (no triangle)
![image](https://github.com/user-attachments/assets/9dee5758-150e-4d68-9e45-1f14c38a9bd0)

After (triangle in front of entity)
![image](https://github.com/user-attachments/assets/079edf4d-6d32-43a0-a280-cc22794c322a)


## References

Maybe, #1238 introduced this bug.

# Destructive Changes

None

# Known Limitations

None