### PR TITLE
Feature/simple sensor simulator/new noise model

### DIFF
--- a/docs/developer_guide/.pages
+++ b/docs/developer_guide/.pages
@@ -13,6 +13,7 @@ nav:
     - ManualOverrideWithFollowTrajectoryAction.md
     - NPCBehavior.md
     - OpenSCENARIOSupport.md
+    - Parameters.md
     - SimpleSensorSimulator.md
     - SimulationResultFormat.md
     - SystemArchitecture.md

--- a/docs/developer_guide/Parameters.md
+++ b/docs/developer_guide/Parameters.md
@@ -1,0 +1,439 @@
+# Parameters
+
+This section describes how to configure the topics that `scenario_simulator_v2`
+publishes to Autoware.
+
+## Overview
+
+The topics that `scenario_simulator_v2` publishes to Autoware are configurable
+from the ROS 2 parameter file given to the launch argument
+`parameter_file_path` of scenario_test_runner. The default value of
+`parameter_file_path` is the path to [a sample parameter
+file](https://github.com/tier4/scenario_simulator_v2/blob/master/test_runner/scenario_test_runner/config/parameters.yaml).
+
+All parameters that can be specified and their default values are shown in the
+sample parameter file. In practice, it is not necessary to specify all
+parameters except for some that are mandatory. In that case, the simulator will
+behave as if similar default values had been specified.
+
+There are currently two ways to configure some topics: an old way and a new way
+described on this page. The new way is backward compatible and is the
+recommended way. If you want to know how to use the old way, [see this
+page](https://tier4.github.io/scenario_simulator_v2-docs/developer_guide/ConfiguringPerceptionTopics/).
+
+## /perception/object_recognition/detection/objects
+
+### `version`
+
+An `int` type value in YYYYMMDD format, mandatory.
+Suffix of `scenario_test_runner` launch argument `architecture_type`, used to
+maintain backward compatibility of the simulator when changing the Autoware
+interface.
+
+### `seed`
+
+A positive `int` type value, default `0`.
+The seed value for the random number generator. If `0` is specified, a random
+seed value will be generated for each run.
+
+### `override_legacy_configuration`
+
+A `boolean` type value, default `false`.
+Some of the parameters described below can be configured in either the old or
+new way. This parameter is used to determine which value to use. That is, as
+long as this parameter is `false`, some of the following parameters will be
+ignored and the values set by the old method will be used. If you want to
+configure the new way, set it to `true`. For backward compatibility, the
+default value of this parameter is `false`.
+
+### `delay`
+
+A positive `double` type value, default `0.0`. The unit is seconds. It is an
+error if the value is negative.
+Delays the publication of the topic by the specified number of seconds. This
+parameter is used only if `override_legacy_configuration` is true. If it is
+false, the value of `detectedObjectPublishingDelay` in
+`ObjectController.Properties` in the scenario file is used.
+
+### `range`
+
+A positive `double` type value, default `300.0`. The unit is meters.
+The sensor detection range. This parameter is used only if
+`override_legacy_configuration` is true. If it is false, the value of
+`detectionSensorRange` in `ObjectController.Properties` in the scenario file is
+used.
+
+### `occlusionless`
+
+A `boolean` type value, default `false`.
+The message is a simulated object recognition result based on a pointcloud.
+Pointclouds are usually sensed by LiDAR, and scenario_simulator_v2 assumes this
+and simulates it, including LiDAR occlusion. If this parameter is `true`,
+object recognition is simulated as if there is no occlusion. In other words, it
+produces recognition results as if objects behind the object are also visible
+(even though they are in shadow and invisible in normal LiDAR).  This parameter
+is used only if `override_legacy_configuration` is true. If it is false, the
+value of `isClairvoyant` in `ObjectController.Properties` in the scenario file
+is used.
+
+### `noise.model.version`
+
+A positive `int` type value, default `1`. If a non-existent version is
+specified, it is an error.
+This parameter specifies the version of the noise model to be used. Currently,
+the following two noise models are implemented:
+- version: 1 - Simple noise model with position randomization
+- version: 2 - Elliptically approximated model of noise variation with distance
+  from the ego entity
+
+The parameters specific to the models are placed under `noise.v1.` and
+`noise.v2`, respectively.
+
+### `noise.v1.position.standard_deviation`
+
+A positive `double` type value, default `0.0`.
+Standard deviation used for randomization of the position of the vehicle in the
+message. This parameter is used only if the value of `noise.model.version` is
+`1`.
+
+### `noise.v1.missing_probability`
+
+A `double` type value between `0.0` and `1.0`, default `0.0`.
+Based on the probability specified by the value of this parameter, random
+vehicle data is removed from the message. This parameter is used only if the
+value of `noise.model.version` is `1`.
+
+### `noise.v2.ellipse_y_radii`
+
+Array of positive double type values, default `[10.0, 20.0, 40.0, 60.0, 80.0,
+120.0, 150.0, 180.0, 1000.0]`. Units are in meters. The size of the array is
+arbitrary, but must be the same size as the array described later.
+This parameter is used only if the value of `noise.model.version` is `2`.
+
+### `noise.v2.distance.autocorrelation_coefficient.amplitude`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of
+distance noise. The autocorrelation coefficient $\phi$ is calculated by the
+following equation: $$\phi(\varDelta t) = \mathtt{amplitude} *
+\exp(-\mathtt{decay} * \varDelta t) + \mathtt{offset}$$ The noise models the
+time series as AR(1) model. The autocorrelation coefficient $\phi$ is used in
+the model to calculate the position noise $X_\mathrm{distance}$: as follows:
+$$X_\mathrm{distance}(t) = \mathtt{mean} + \phi * (X_\mathrm{distance}(t-1) -
+\mathtt{mean}) + \mathcal{N}(0, 1 - \phi^2) * \mathtt{standard\_deviation}$$
+This parameter is used only if the value of `noise.model.version` is `2`.
+
+### `noise.v2.distance.autocorrelation_coefficient.decay`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of
+distance noise. The autocorrelation coefficient $\phi$ is calculated by the
+following equation: $$\phi(\varDelta t) = \mathtt{amplitude} *
+\exp(-\mathtt{decay} * \varDelta t) + \mathtt{offset}$$ The noise models the
+time series as AR(1) model. The autocorrelation coefficient $\phi$ is used in
+the model to calculate the position noise $X_\mathrm{distance}$: as follows:
+$$X_\mathrm{distance}(t) = \mathtt{mean} + \phi * (X_\mathrm{distance}(t -
+\varDelta t) - \mathtt{mean}) + \mathcal{N}(0, 1 - \phi^2) *
+\mathtt{standard\_deviation}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.distance.autocorrelation_coefficient.offset`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of
+distance noise. The autocorrelation coefficient $\phi$ is calculated by the
+following equation: $$\phi(\varDelta t) = \mathtt{amplitude} *
+\exp(-\mathtt{decay} * \varDelta t) + \mathtt{offset}$$ The noise models the
+time series as AR(1) model. The autocorrelation coefficient $\phi$ is used in
+the model to calculate the position noise $X_\mathrm{distance}$: as follows:
+$$X_\mathrm{distance}(t) = \mathtt{mean} + \phi * (X_\mathrm{distance}(t -
+\varDelta t) - \mathtt{mean}) + \mathcal{N}(0, 1 - \phi^2) *
+\mathtt{standard\_deviation}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.distance.mean.ellipse_normalized_x_radius`
+
+A positive `double` type value, default `0.0`.
+The noise models the space as an elliptical model. This parameter is the ratio
+of the radius of the x-axis to the radius of the y-axis of that ellipse. The
+coordinate system is a right-handed local coordinate system, where the x-axis
+is the longitudinal direction of the ego entity and the y-axis is its lateral
+direction. The value of this parameter is used to calculate the distance $d$
+between the ego entity and the other vehicle using the following equation: $$d
+= \sqrt[2]{(\varDelta x / \mathtt{ellipse\_normalized\_x\_radius})^2 +
+\varDelta y^2}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.distance.mean.values`
+
+Array of positive double type values, default `[0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+0.0, 0.0, 0.0]`.
+Each element of the array is a mean of normal distribution. The first element
+with a value greater than $d$ is searched from `ellipse_y_radii` and the
+elements with the same index are referenced from `values`. Therefore, the array
+size of this parameter must be the same as `ellipse_y_radii`. Otherwise, it is
+an error. This parameter is used only if the value of `noise.model.version` is
+`2`.
+
+### `noise.v2.distance.standard_deviation.ellipse_normalized_x_radius`
+
+A positive `double` type value, default `0.0`.
+The noise models the space as an elliptical model. This parameter is the ratio
+of the radius of the x-axis to the radius of the y-axis of that ellipse. The
+coordinate system is a right-handed local coordinate system, where the x-axis
+is the longitudinal direction of the ego entity and the y-axis is its lateral
+direction. The value of this parameter is used to calculate the distance $d$
+between the ego entity and the other vehicle using the following equation: $$d
+= \sqrt[2]{(\varDelta x / \mathtt{ellipse\_normalized\_x\_radius})^2 +
+\varDelta y^2}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.distance.standard_deviation.values`
+
+Array of positive double type values, default `[0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+0.0, 0.0, 0.0]`.
+Each element of the array is a standard deviation of normal distribution. The
+first element with a value greater than $d$ is searched from `ellipse_y_radii`
+and the elements with the same index are referenced from `values`. Therefore,
+the array size of this parameter must be the same as `ellipse_y_radii`.
+Otherwise, it is an error. This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.yaw.autocorrelation_coefficient.amplitude`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of yaw
+noise. The autocorrelation coefficient $\phi$ is calculated by the following
+equation: $$ \phi(\varDelta t) = \mathtt{amplitude} * \exp(-\mathtt{decay} *
+\varDelta t) + \mathtt{offset}$$ The noise models the time series as AR(1)
+model. The autocorrelation coefficient $\phi$ is used in the model to calculate
+the yaw noise $X_\mathrm{yaw}$: as follows: $$ X_\mathrm{yaw}(t) =
+\mathtt{mean} + \phi * (X_\mathrm{yaw}(t - \varDelta t) - \mathtt{mean}) +
+\mathcal{N}(0, 1 - \phi^2) * \mathtt{standard\_deviation}$$ This parameter is
+used only if the value of `noise.model.version` is `2`.
+
+### `noise.v2.yaw.autocorrelation_coefficient.decay`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of yaw
+noise. The autocorrelation coefficient $\phi$ is calculated by the following
+equation: $$ \phi(\varDelta t) = \mathtt{amplitude} * \exp(-\mathtt{decay} *
+\varDelta t) + \mathtt{offset}$$ The noise models the time series as AR(1)
+model. The autocorrelation coefficient $\phi$ is used in the model to calculate
+the yaw noise $X_\mathrm{yaw}$: as follows: $$ X_\mathrm{yaw}(t) =
+\mathtt{mean} + \phi * (X_\mathrm{yaw}(t - \varDelta t) - \mathtt{mean}) +
+\mathcal{N}(0, 1 - \phi^2) * \mathtt{standard\_deviation}$$ This parameter is
+used only if the value of `noise.model.version` is `2`.
+
+### `noise.v2.yaw.autocorrelation_coefficient.offset`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of yaw
+noise. The autocorrelation coefficient $\phi$ is calculated by the following
+equation: $$ \phi(\varDelta t) = \mathtt{amplitude} * \exp(-\mathtt{decay} *
+\varDelta t) + \mathtt{offset}$$ The noise models the time series as AR(1)
+model. The autocorrelation coefficient $\phi$ is used in the model to calculate
+the yaw noise $X_\mathrm{yaw}$: as follows: $$ X_\mathrm{yaw}(t) =
+\mathtt{mean} + \phi * (X_\mathrm{yaw}(t - \varDelta t) - \mathtt{mean}) +
+\mathcal{N}(0, 1 - \phi^2) * \mathtt{standard\_deviation}$$ This parameter is
+used only if the value of `noise.model.version` is `2`.
+
+### `noise.v2.yaw.mean.ellipse_normalized_x_radius`
+
+A positive `double` type value, default `0.0`.
+The noise models the space as an elliptical model. This parameter is the ratio
+of the radius of the x-axis to the radius of the y-axis of that ellipse. The
+coordinate system is a right-handed local coordinate system, where the x-axis
+is the longitudinal direction of the ego entity and the y-axis is its lateral
+direction. The value of this parameter is used to calculate the distance $d$
+between the ego entity and the other vehicle using the following equation: $$d
+= \sqrt[2]{(\varDelta x / \mathtt{ellipse\_normalized\_x\_radius})^2 +
+\varDelta y^2}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.yaw.mean.values`
+
+Array of positive double type values, default `[0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+0.0, 0.0, 0.0]`.
+Each element of the array is a mean of normal distribution. The first element
+with a value greater than $d$ is searched from `ellipse_y_radii` and the
+elements with the same index are referenced from `values`. Therefore, the array
+size of this parameter must be the same as `ellipse_y_radii`. Otherwise, it is
+an error. This parameter is used only if the value of `noise.model.version` is
+`2`.
+
+### `noise.v2.yaw.standard_deviation.ellipse_normalized_x_radius`
+
+A positive `double` type value, default `0.0`.
+The noise models the space as an elliptical model. This parameter is the ratio
+of the radius of the x-axis to the radius of the y-axis of that ellipse. The
+coordinate system is a right-handed local coordinate system, where the x-axis
+is the longitudinal direction of the ego entity and the y-axis is its lateral
+direction. The value of this parameter is used to calculate the distance $d$
+between the ego entity and the other vehicle using the following equation: $$d
+= \sqrt[2]{(\varDelta x / \mathtt{ellipse\_normalized\_x\_radius})^2 +
+\varDelta y^2}$$. This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.yaw.standard_deviation.values`
+
+Array of positive double type values, default `[0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+0.0, 0.0, 0.0]`.
+Each element of the array is a standard deviation of normal distribution. The
+first element with a value greater than $d$ is searched from `ellipse_y_radii`
+and the elements with the same index are referenced from `values`. Therefore,
+the array size of this parameter must be the same as `ellipse_y_radii`.
+Otherwise, it is an error. This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.yaw_flip.autocorrelation_coefficient.amplitude`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of
+yaw-flip noise. The autocorrelation coefficient $\phi$ is calculated by the
+following equation: $$\phi(\varDelta t) = \mathtt{amplitude} *
+\exp(-\mathtt{decay} * \varDelta t) + \mathtt{offset}$$ The noise models the
+time series as Markov process. The autocorrelation coefficient $\phi$ is used
+in the model to calculate the yaw-flip noise with following transition matrix:
+$$ \begin{bmatrix} p_{0,0} & p_{0,1} \\ p_{1,0} & p_{1,1} \end{bmatrix} =
+\begin{bmatrix} \pi_0 + \phi \pi_1 && \pi_1 (1 - \phi) \\ \pi_0 (1 - \phi) &&
+\pi_1 - \phi \pi_0 \end{bmatrix}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.yaw_flip.autocorrelation_coefficient.decay`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of
+yaw-flip noise. The autocorrelation coefficient $\phi$ is calculated by the
+following equation: $$\phi(\varDelta t) = \mathtt{amplitude} *
+\exp(-\mathtt{decay} * \varDelta t) + \mathtt{offset}$$ The noise models the
+time series as Markov process. The autocorrelation coefficient $\phi$ is used
+in the model to calculate the yaw-flip noise with following transition matrix:
+$$ \begin{bmatrix} p_{0,0} & p_{0,1} \\ p_{1,0} & p_{1,1} \end{bmatrix} =
+\begin{bmatrix} \pi_0 + \phi \pi_1 && \pi_1 (1 - \phi) \\ \pi_0 (1 - \phi) &&
+\pi_1 - \phi \pi_0 \end{bmatrix}$$  This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.yaw_flip.autocorrelation_coefficient.offset`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of
+yaw-flip noise. The autocorrelation coefficient $\phi$ is calculated by the
+following equation: $$\phi(\varDelta t) = \mathtt{amplitude} *
+\exp(-\mathtt{decay} * \varDelta t) + \mathtt{offset}$$ The noise models the
+time series as Markov process. The autocorrelation coefficient $\phi$ is used
+in the model to calculate the yaw-flip noise with following transition matrix:
+$$ \begin{bmatrix} p_{0,0} & p_{0,1} \\ p_{1,0} & p_{1,1} \end{bmatrix} =
+\begin{bmatrix} \pi_0 + \phi \pi_1 && \pi_1 (1 - \phi) \\ \pi_0 (1 - \phi) &&
+\pi_1 - \phi \pi_0 \end{bmatrix}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.yaw_flip.speed_threshold`
+
+A positive `double` type value, default `0.1`.
+When the absolute speed of one other vehicle is less than the value of this
+parameter, it is determined whether yaw-flip occurs or not based on the `rate`
+described below. This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.yaw_flip.rate`
+
+A positive `double` type value, default `0.0`.
+Vehicles whose absolute speed is below the aforementioned `speed_threshold`
+will have yaw-flip noise applied with the probability of the value of this
+parameter. This parameter is used only if the value of `noise.model.version` is
+`2`.
+
+### `noise.v2.true_positive.autocorrelation_coefficient.amplitude`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of
+random-mask noise. The autocorrelation coefficient $\phi$ is calculated by the
+following equation: $$\phi(\varDelta t) = \mathtt{amplitude} *
+\exp(-\mathtt{decay} * \varDelta t) + \mathtt{offset}$$ The noise models the
+time series as Markov process. The autocorrelation coefficient $\phi$ is used
+in the model to calculate the random-mask noise with following transition
+matrix: $$ \begin{bmatrix} p_{0,0} & p_{0,1} \\ p_{1,0} & p_{1,1} \end{bmatrix}
+= \begin{bmatrix} \pi_0 + \phi \pi_1 && \pi_1 (1 - \phi) \\ \pi_0 (1 - \phi) &&
+\pi_1 - \phi \pi_0 \end{bmatrix}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.true_positive.autocorrelation_coefficient.decay`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of
+random-mask noise. The autocorrelation coefficient $\phi$ is calculated by the
+following equation: $$\phi(\varDelta t) = \mathtt{amplitude} *
+\exp(-\mathtt{decay} * \varDelta t) + \mathtt{offset}$$ The noise models the
+time series as Markov process. The autocorrelation coefficient $\phi$ is used
+in the model to calculate the random-mask noise with following transition
+matrix: $$ \begin{bmatrix} p_{0,0} & p_{0,1} \\ p_{1,0} & p_{1,1} \end{bmatrix}
+= \begin{bmatrix} \pi_0 + \phi \pi_1 && \pi_1 (1 - \phi) \\ \pi_0 (1 - \phi) &&
+\pi_1 - \phi \pi_0 \end{bmatrix}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.true_positive.autocorrelation_coefficient.offset`
+
+A positive `double` type value, default `0.0`.
+The parameter of the autocorrelation coefficient used in the generation of
+random-mask noise. The autocorrelation coefficient $\phi$ is calculated by the
+following equation: $$\phi(\varDelta t) = \mathtt{amplitude} *
+\exp(-\mathtt{decay} * \varDelta t) + \mathtt{offset}$$ The noise models the
+time series as Markov process. The autocorrelation coefficient $\phi$ is used
+in the model to calculate the random-mask noise with following transition
+matrix: $$ \begin{bmatrix} p_{0,0} & p_{0,1} \\ p_{1,0} & p_{1,1} \end{bmatrix}
+= \begin{bmatrix} \pi_0 + \phi \pi_1 && \pi_1 (1 - \phi) \\ \pi_0 (1 - \phi) &&
+\pi_1 - \phi \pi_0 \end{bmatrix}$$ This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.true_positive.rate.ellipse_normalized_x_radius`
+
+A positive `double` type value, default `0.0`.
+The noise models the space as an elliptical model. This parameter is the ratio
+of the radius of the x-axis to the radius of the y-axis of that ellipse. The
+coordinate system is a right-handed local coordinate system, where the x-axis
+is the longitudinal direction of the ego entity and the y-axis is its lateral
+direction. The value of this parameter is used to calculate the distance $d$
+between the ego entity and the other vehicle using the following equation: $$d
+= \sqrt[2]{(\varDelta x / \mathtt{ellipse\_normalized\_x\_radius})^2 +
+\varDelta y^2}$$. This parameter is used only if the value of
+`noise.model.version` is `2`.
+
+### `noise.v2.true_positive.rate.values`
+
+Array of positive double type values, default `[1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0]`.
+Each element of this array is the probability that the value will be output
+correctly (true positive rate). The first element with a value greater than $d$
+is searched from `ellipse_y_radii` and the elements with the same index are
+referenced from `values`. Therefore, the array size of this parameter must be
+the same as `ellipse_y_radii`. Otherwise, it is an error. This parameter is
+used only if the value of `noise.model.version` is `2`.
+
+## /perception/object_recognition/ground_truth/objects
+
+### `version`
+
+An `int` type value in YYYYMMDD format, mandatory.
+Suffix of `scenario_test_runner` launch argument `architecture_type`, used to
+maintain backward compatibility of the simulator when changing the Autoware
+interface.
+
+### `override_legacy_configuration`
+
+A `boolean` type value, default `false`.
+Some of the parameters described below can be configured in either the old or
+new way. This parameter is used to determine which value to use. That is, as
+long as this parameter is `false`, some of the following parameters will be
+ignored and the values set by the old method will be used. If you want to
+configure the new way, set it to `true`. For backward compatibility, the
+default value of this parameter is `false`.
+
+### `delay`
+
+A positive `double` type value, default `0.0`. The unit is seconds. It is an
+error if the value is negative.
+Delays the publication of the topic by the specified number of seconds. This
+parameter is used only if `override_legacy_configuration` is true. If it is
+false, the value of `detectedObjectGroundTruthPublishingDelay` in
+`ObjectController.Properties` in the scenario file is used.

--- a/docs/developer_guide/Parameters.md
+++ b/docs/developer_guide/Parameters.md
@@ -3,6 +3,9 @@
 This section describes how to configure the topics that `scenario_simulator_v2`
 publishes to Autoware.
 
+<!-- cspell: ignore mathtt -->
+<!-- cspell: ignore occlusionless -->
+
 ## Overview
 
 The topics that `scenario_simulator_v2` publishes to Autoware are configurable

--- a/external/concealer/include/concealer/get_parameter.hpp
+++ b/external/concealer/include/concealer/get_parameter.hpp
@@ -35,15 +35,7 @@ auto getParameter(
 template <typename T>
 auto getParameter(const std::string & name, T value = {})
 {
-  /*
-     The parameter file should be
-
-     <namespace-name>:
-       <node-name>:
-         ros__parameters:
-           ...
-  */
-  static auto node = rclcpp::Node("AutowareUniverse", "simulation");
+  static auto node = rclcpp::Node("getParameter", "simulation");
   return getParameter(node.get_node_parameters_interface(), name, value);
 }
 }  // namespace concealer

--- a/external/concealer/include/concealer/get_parameter.hpp
+++ b/external/concealer/include/concealer/get_parameter.hpp
@@ -35,7 +35,15 @@ auto getParameter(
 template <typename T>
 auto getParameter(const std::string & name, T value = {})
 {
-  auto node = rclcpp::Node("get_parameter", "simulation");
+  /*
+     The parameter file should be
+
+     <namespace-name>:
+       <node-name>:
+         ros__parameters:
+           ...
+  */
+  static auto node = rclcpp::Node("AutowareUniverse", "simulation");
   return getParameter(node.get_node_parameters_interface(), name, value);
 }
 }  // namespace concealer

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -85,7 +85,7 @@ class DetectionSensor : public DetectionSensorBase
   {
     double simulation_time, distance_noise, yaw_noise;
 
-    bool tp, flip;
+    bool true_positive, flip;
 
     explicit NoiseOutput(double simulation_time = 0.0) : simulation_time(simulation_time) {}
   };

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -95,6 +95,61 @@ class DetectionSensor : public DetectionSensorBase
 
   std::unordered_map<std::string, NoiseOutput> noise_outputs;
 
+  template <typename Message, typename std::enable_if_t<std::is_same_v<Message, T>, int> = 0>
+  auto delay() const
+  {
+    static const auto override_legacy_configuration = concealer::getParameter<bool>(
+      detected_objects_publisher->get_topic_name() + std::string(".override_legacy_configuration"));
+    if (override_legacy_configuration) {
+      static const auto delay = concealer::getParameter<double>(
+        detected_objects_publisher->get_topic_name() + std::string(".delay"));
+      return delay;
+    } else {
+      return configuration_.object_recognition_delay();
+    }
+  }
+
+  template <typename Message, typename std::enable_if_t<std::is_same_v<Message, U>, int> = 0>
+  auto delay() const
+  {
+    static const auto override_legacy_configuration = concealer::getParameter<bool>(
+      ground_truth_objects_publisher->get_topic_name() +
+      std::string(".override_legacy_configuration"));
+    if (override_legacy_configuration) {
+      static const auto delay = concealer::getParameter<double>(
+        ground_truth_objects_publisher->get_topic_name() + std::string(".delay"));
+      return delay;
+    } else {
+      return configuration_.object_recognition_ground_truth_delay();
+    }
+  }
+
+  auto range() const
+  {
+    static const auto override_legacy_configuration = concealer::getParameter<bool>(
+      detected_objects_publisher->get_topic_name() + std::string(".override_legacy_configuration"));
+    if (override_legacy_configuration) {
+      static const auto range = concealer::getParameter<double>(
+        detected_objects_publisher->get_topic_name() + std::string(".range"), 300.0);
+      return range;
+    } else {
+      return configuration_.range();
+    }
+  }
+
+  auto detect_all_objects_in_range() const
+  {
+    static const auto override_legacy_configuration = concealer::getParameter<bool>(
+      detected_objects_publisher->get_topic_name() + std::string(".override_legacy_configuration"));
+    if (override_legacy_configuration) {
+      static const auto clairvoyant = concealer::getParameter<bool>(
+        detected_objects_publisher->get_topic_name() + std::string(".clairvoyant"));
+      return clairvoyant;
+    } else {
+      return configuration_.detect_all_objects_in_range();
+    }
+  }
+
 public:
   explicit DetectionSensor(
     const double current_simulation_time,

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -142,9 +142,9 @@ class DetectionSensor : public DetectionSensorBase
     static const auto override_legacy_configuration = concealer::getParameter<bool>(
       detected_objects_publisher->get_topic_name() + std::string(".override_legacy_configuration"));
     if (override_legacy_configuration) {
-      static const auto clairvoyant = concealer::getParameter<bool>(
-        detected_objects_publisher->get_topic_name() + std::string(".clairvoyant"));
-      return clairvoyant;
+      static const auto occlusionless = concealer::getParameter<bool>(
+        detected_objects_publisher->get_topic_name() + std::string(".occlusionless"));
+      return occlusionless;
     } else {
       return configuration_.detect_all_objects_in_range();
     }

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -25,6 +25,7 @@
 #include <random>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -78,6 +79,17 @@ class DetectionSensor : public DetectionSensorBase
 
   std::queue<std::pair<std::vector<traffic_simulator_msgs::EntityStatus>, double>>
     unpublished_detected_entities, unpublished_ground_truth_entities;
+
+  struct NoiseOutput
+  {
+    double simulation_time, distance_noise, yaw_noise;
+
+    bool mask, flip;
+
+    explicit NoiseOutput(double simulation_time = 0.0) : simulation_time(simulation_time) {}
+  };
+
+  std::unordered_map<std::string, NoiseOutput> noise_outputs;
 
 public:
   explicit DetectionSensor(

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -17,6 +17,7 @@
 
 #include <simulation_api_schema.pb.h>
 
+#include <concealer/get_parameter.hpp>
 #include <geometry/plane.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <memory>
@@ -91,6 +92,8 @@ class DetectionSensor : public DetectionSensorBase
 
   std::unordered_map<std::string, NoiseOutput> noise_outputs;
 
+  int noise_model_version;
+
 public:
   explicit DetectionSensor(
     const double current_simulation_time,
@@ -100,7 +103,9 @@ public:
   : DetectionSensorBase(current_simulation_time, configuration),
     detected_objects_publisher(publisher),
     ground_truth_objects_publisher(ground_truth_publisher),
-    random_engine_(configuration.random_seed())
+    random_engine_(configuration.random_seed()),
+    noise_model_version(concealer::getParameter<int>(
+      detected_objects_publisher->get_topic_name() + std::string(".noise.model.version")))
   {
   }
 

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -139,6 +139,7 @@ class DetectionSensor : public DetectionSensorBase
 
   auto detect_all_objects_in_range() const
   {
+    // cspell: ignore occlusionless
     static const auto override_legacy_configuration = concealer::getParameter<bool>(
       detected_objects_publisher->get_topic_name() + std::string(".override_legacy_configuration"));
     if (override_legacy_configuration) {

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -85,7 +85,7 @@ class DetectionSensor : public DetectionSensorBase
   {
     double simulation_time, distance_noise, yaw_noise;
 
-    bool mask, flip;
+    bool tp, flip;
 
     explicit NoiseOutput(double simulation_time = 0.0) : simulation_time(simulation_time) {}
   };

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
@@ -343,7 +343,7 @@ auto DetectionSensor<autoware_perception_msgs::msg::DetectedObjects>::update(
           detected_entity.pose().position().x() - ego_entity_status->pose().position().x();
         const auto y =
           detected_entity.pose().position().y() - ego_entity_status->pose().position().y();
-        const auto velocity = std::hypot(
+        const auto speed = std::hypot(
           detected_entity.action_status().twist().linear().x(),
           detected_entity.action_status().twist().linear().y());
         const auto interval =
@@ -454,9 +454,9 @@ auto DetectionSensor<autoware_perception_msgs::msg::DetectedObjects>::update(
         }();
 
         noise_output->second.flip = [&]() {
-          static const auto velocity_threshold = parameter("yaw_flip.velocity_threshold");
+          static const auto speed_threshold = parameter("yaw_flip.speed_threshold");
           static const auto rate = parameter("yaw_flip.rate");
-          return velocity < velocity_threshold and
+          return speed < speed_threshold and
                  markov_process_noise(
                    noise_output->second.flip, rate, autocorrelation_coefficient("yaw_flip"));
         }();

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
@@ -396,10 +396,10 @@ auto DetectionSensor<autoware_perception_msgs::msg::DetectedObjects>::update(
              | p_10 p_11 | == | p0 (1 - phi)    p1 - phi * p0 |
         */
         auto markov_process_noise =
-          [this](bool previous_noise, auto p1, auto autocorrelation_coefficient) {
-            const auto rate = (previous_noise ? 1.0 : 0.0) * autocorrelation_coefficient +
-                              (1 - autocorrelation_coefficient) * p1;
-            return std::uniform_real_distribution<double>()(random_engine_) < rate;
+          [this](bool previous_noise, auto rate, auto autocorrelation_coefficient) {
+            return std::uniform_real_distribution<double>()(random_engine_) <
+                   (previous_noise ? 1.0 : 0.0) * autocorrelation_coefficient +
+                     (1 - autocorrelation_coefficient) * rate;
           };
 
         /*

--- a/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
+++ b/simulation/simple_sensor_simulator/src/sensor_simulation/detection_sensor/detection_sensor.cpp
@@ -363,6 +363,7 @@ auto DetectionSensor<autoware_perception_msgs::msg::DetectedObjects>::update(
 
              noise(prev_noise) = mean + phi * (prev_noise - mean) + N(0, 1 - phi^2) * standard_deviation
         */
+        // cspell: ignore autoregressive
         auto autoregressive_noise = [this](
                                       auto previous_noise, auto mean, auto standard_deviation,
                                       auto autocorrelation_coefficient) {

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -140,21 +140,23 @@ simulation:
                 amplitude: 0.32
                 decay: 0.45
                 offset: 0.26
-              ellipse_normalized_x_radius:
-                mean: 1.1
-                standard_deviation: 1.0
-              means: [-0.06, -0.04, -0.04, -0.07, -0.26, -0.56, -1.02, -1.05, 0.0]
-              standard_deviations: [0.17, 0.20, 0.27, 0.40, 0.67, 0.94, 1.19, 1.17, 0.0]
+              mean:
+                ellipse_normalized_x_radius: 1.1
+                values: [-0.06, -0.04, -0.04, -0.07, -0.26, -0.56, -1.02, -1.05, 0.0]
+              standard_deviation:
+                ellipse_normalized_x_radius: 1.0
+                values: [0.17, 0.20, 0.27, 0.40, 0.67, 0.94, 1.19, 1.17, 0.0]
             yaw:
               autocorrelation_coefficient:
                 amplitude: 0.22
                 decay: 0.52
                 offset: 0.21
-              ellipse_normalized_x_radius:
-                mean: 1.9
-                standard_deviation: 0.8
-              means: [0.0, 0.01, 0.0, 0.0, 0.0, -0.07, 0.18, 0.06, 0.0]
-              standard_deviations: [0.09, 0.15, 0.21, 0.18, 0.17, 0.19, 0.39, 0.15, 0.0]
+              mean:
+                ellipse_normalized_x_radius: 1.9
+                values: [0.0, 0.01, 0.0, 0.0, 0.0, -0.07, 0.18, 0.06, 0.0]
+              standard_deviation:
+                ellipse_normalized_x_radius: 0.8
+                values: [0.09, 0.15, 0.21, 0.18, 0.17, 0.19, 0.39, 0.15, 0.0]
             yaw_flip:
               autocorrelation_coefficient:
                 amplitude: 0.29
@@ -167,5 +169,6 @@ simulation:
                 amplitude: 0.32
                 decay: 0.26
                 offset: 0.40
-              ellipse_normalized_x_radius: 0.7
-              rates: [0.96, 0.78, 0.57, 0.48, 0.27, 0.07, 0.01, 0.0, 0.0]
+              rate:
+                ellipse_normalized_x_radius: 0.7
+                values: [0.96, 0.78, 0.57, 0.48, 0.27, 0.07, 0.01, 0.0, 0.0]

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -1,188 +1,187 @@
 # cspell: ignore occlusionless
 
-simulation:
-  AutowareUniverse:
-    ros__parameters:
-      /localization/kinematic_state:
-        version: 20240605 # architecture_type suffix (mandatory)
-        seed: 0 # If 0 is specified, a random seed value will be generated for each run.
-        nav_msgs::msg::Odometry:
+/**:
+  ros__parameters:
+    /localization/kinematic_state:
+      version: 20240605 # architecture_type suffix (mandatory)
+      seed: 0 # If 0 is specified, a random seed value will be generated for each run.
+      nav_msgs::msg::Odometry:
+        pose:
           pose:
-            pose:
-              position:
-                # The data members of geometry_msgs::msg::Pose.position are x,
-                # y, z, which are world coordinates in
-                # `/localization/kinematic_state`. However, applying error to a
-                # position in world coordinates is unintuitive and tricky, so
-                # we accept the parameters as the entity's local coordinates.
-                # local_x, local_y, local_z express that. The simulator
-                # calculates the error in the local coordinates. It then
-                # transforms the error to the world coordinates, adds the error
-                # to the true position (world coordinates), and publishes it as
-                # `/localization/kinematic_state`.
-                local_x:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                local_y:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                local_z:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-              orientation:
-                # The type of geometry_msgs::msg::Pose.orientation is
-                # Quaternion, and the actual orientation data members are x, y,
-                # z, and w. However, applying error to Quaternions can be
-                # unintuitive and tricky, so we accept the parameters as Euler
-                # angles here. The simulator internally converts Quaternion to
-                # Euler angles and applies the error to them. It then converts
-                # the error-applied Euler angles back to Quaternion and
-                # publishes them as `/localization/kinematic_state`.
-                r:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                p:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                y:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-          twist:
-            twist:
-              linear:
-                x:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                y:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                z:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-              angular:
-                x:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                y:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                z:
-                  error:
-                    additive:
-                      mean: 0.0
-                      standard_deviation: 0.0
-                    multiplicative:
-                      mean: 0.0
-                      standard_deviation: 0.0
-      /perception/object_recognition/detection/objects:
-        version: 20240605 # architecture_type suffix (mandatory)
-        seed: 0 # If 0 is specified, a random seed value will be generated for each run.
-        override_legacy_configuration: false
-        delay: 0.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPublishingDelay` in `ObjectController.Properties` in the scenario file is used.
-        range: 300.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectionSensorRange` in `ObjectController.Properties` in the scenario file is used.
-        occlusionless: false # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `isClairvoyant` in `ObjectController.Properties` in the scenario file is used.
-        noise:
-          model:
-            version: 1 # Any of [1, 2].
-          v1: # This clause is used only if `model.version` is 1.
             position:
-              standard_deviation: 0.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPositionStandardDeviation` in `ObjectController.Properties` in the scenario file is used.
-            missing_probability: 0.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectMissingProbability` in `ObjectController.Properties` in the scenario file is used.
-          v2: # This clause is used only if `model.version` is 2.
-            ellipse_y_radii: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
-            distance:
-              autocorrelation_coefficient:
-                amplitude: 0.0
-                decay: 0.0
-                offset: 0.0
-              mean:
-                ellipse_normalized_x_radius: 1.0
-                values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-              standard_deviation:
-                ellipse_normalized_x_radius: 1.0
-                values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-            yaw:
-              autocorrelation_coefficient:
-                amplitude: 0.0
-                decay: 0.0
-                offset: 0.0
-              mean:
-                ellipse_normalized_x_radius: 1.0
-                values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-              standard_deviation:
-                ellipse_normalized_x_radius: 1.0
-                values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-            yaw_flip:
-              autocorrelation_coefficient:
-                amplitude: 0.0
-                decay: 0.0
-                offset: 0.0
-              speed_threshold: 0.1
-              rate: 0.0
-            true_positive:
-              autocorrelation_coefficient:
-                amplitude: 0.0
-                decay: 0.0
-                offset: 0.0
-              rate:
-                ellipse_normalized_x_radius: 1.0
-                values: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
-      /perception/object_recognition/ground_truth/objects:
-        version: 20240605 # architecture_type suffix (mandatory)
-        override_legacy_configuration: false
-        delay: 0.0  # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectGroundTruthPublishingDelay` in `ObjectController.Properties` in the scenario file is used.
+              # The data members of geometry_msgs::msg::Pose.position are x, y,
+              # z, which are world coordinates in
+              # `/localization/kinematic_state`. However, applying error to a
+              # position in world coordinates is unintuitive and tricky, so we
+              # accept the parameters as the entity's local coordinates.
+              # local_x, local_y, local_z express that. The simulator
+              # calculates the error in the local coordinates. It then
+              # transforms the error to the world coordinates, adds the error
+              # to the true position (world coordinates), and publishes it as
+              # `/localization/kinematic_state`.
+              local_x:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+              local_y:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+              local_z:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+            orientation:
+              # The type of geometry_msgs::msg::Pose.orientation is Quaternion,
+              # and the actual orientation data members are x, y, z, and w.
+              # However, applying error to Quaternions can be unintuitive and
+              # tricky, so we accept the parameters as Euler angles here. The
+              # simulator internally converts Quaternion to Euler angles and
+              # applies the error to them. It then converts the error-applied
+              # Euler angles back to Quaternion and publishes them as
+              # `/localization/kinematic_state`.
+              r:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+              p:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+              y:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+        twist:
+          twist:
+            linear:
+              x:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+              y:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+              z:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+            angular:
+              x:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+              y:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+              z:
+                error:
+                  additive:
+                    mean: 0.0
+                    standard_deviation: 0.0
+                  multiplicative:
+                    mean: 0.0
+                    standard_deviation: 0.0
+    /perception/object_recognition/detection/objects:
+      version: 20240605 # architecture_type suffix (mandatory)
+      seed: 0 # If 0 is specified, a random seed value will be generated for each run.
+      override_legacy_configuration: false
+      delay: 0.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPublishingDelay` in `ObjectController.Properties` in the scenario file is used.
+      range: 300.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectionSensorRange` in `ObjectController.Properties` in the scenario file is used.
+      occlusionless: false # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `isClairvoyant` in `ObjectController.Properties` in the scenario file is used.
+      noise:
+        model:
+          version: 1 # Any of [1, 2].
+        v1: # This clause is used only if `model.version` is 1.
+          position:
+            standard_deviation: 0.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPositionStandardDeviation` in `ObjectController.Properties` in the scenario file is used.
+          missing_probability: 0.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectMissingProbability` in `ObjectController.Properties` in the scenario file is used.
+        v2: # This clause is used only if `model.version` is 2.
+          ellipse_y_radii: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
+          distance:
+            autocorrelation_coefficient:
+              amplitude: 0.0
+              decay: 0.0
+              offset: 0.0
+            mean:
+              ellipse_normalized_x_radius: 1.0
+              values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+            standard_deviation:
+              ellipse_normalized_x_radius: 1.0
+              values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+          yaw:
+            autocorrelation_coefficient:
+              amplitude: 0.0
+              decay: 0.0
+              offset: 0.0
+            mean:
+              ellipse_normalized_x_radius: 1.0
+              values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+            standard_deviation:
+              ellipse_normalized_x_radius: 1.0
+              values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+          yaw_flip:
+            autocorrelation_coefficient:
+              amplitude: 0.0
+              decay: 0.0
+              offset: 0.0
+            speed_threshold: 0.1
+            rate: 0.0
+          true_positive:
+            autocorrelation_coefficient:
+              amplitude: 0.0
+              decay: 0.0
+              offset: 0.0
+            rate:
+              ellipse_normalized_x_radius: 1.0
+              values: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+    /perception/object_recognition/ground_truth/objects:
+      version: 20240605 # architecture_type suffix (mandatory)
+      override_legacy_configuration: false
+      delay: 0.0  # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectGroundTruthPublishingDelay` in `ObjectController.Properties` in the scenario file is used.

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -136,7 +136,7 @@ simulation:
           v2:
             ellipse_y_radii: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
             distance:
-              phi:
+              autocorrelation_coefficient:
                 amplitude: 0.32
                 decay: 0.45
                 offset: 0.26
@@ -146,7 +146,7 @@ simulation:
               means: [-0.06, -0.04, -0.04, -0.07, -0.26, -0.56, -1.02, -1.05, 0.0]
               standard_deviations: [0.17, 0.20, 0.27, 0.40, 0.67, 0.94, 1.19, 1.17, 0.0]
             yaw:
-              phi:
+              autocorrelation_coefficient:
                 amplitude: 0.22
                 decay: 0.52
                 offset: 0.21
@@ -156,14 +156,14 @@ simulation:
               means: [0.0, 0.01, 0.0, 0.0, 0.0, -0.07, 0.18, 0.06, 0.0]
               standard_deviations: [0.09, 0.15, 0.21, 0.18, 0.17, 0.19, 0.39, 0.15, 0.0]
             yaw_flip:
-              phi:
+              autocorrelation_coefficient:
                 amplitude: 0.29
                 decay: 0.12
                 offset: 0.49
               velocity_threshold: 0.1
               rate: 0.12
             true_positive:
-              phi:
+              autocorrelation_coefficient:
                 amplitude: 0.32
                 decay: 0.26
                 offset: 0.40

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -1,3 +1,5 @@
+# cspell: ignore occlusionless
+
 simulation:
   AutowareUniverse:
     ros__parameters:

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -132,8 +132,8 @@ simulation:
         seed: 0 # If 0 is specified, a random seed value will be generated for each run.
         noise:
           model:
-            version: 1 # Any of [0, 1]
-          v1:
+            version: 2 # Any of [1, 2].
+          v2:
             correlation_for_delta_t: 0.5
             ellipse_y_radiuses: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
             distance:
@@ -153,7 +153,7 @@ simulation:
             yaw_flip:
               delta_t: 0.1
               velocity_threshold: 0.1
-              rate_for_stop_objects: 0.3
+              stop_rate: 0.3
             mask:
               delta_t: 0.3
               ellipse_normalized_x_radius: 0.6

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -131,16 +131,16 @@ simulation:
         version: 20240605 # architecture_type suffix (mandatory)
         seed: 0 # If 0 is specified, a random seed value will be generated for each run.
         override_legacy_configuration: false
-        delay: 0.0 # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPublishingDelay` in `ObjectController.Properties` in the scenario file is used.
-        range: 300.0 # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectionSensorRange` in `ObjectController.Properties` in the scenario file is used.
-        clairvoyant: false # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `isClairvoyant` in `ObjectController.Properties` in the scenario file is used.
+        delay: 0.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPublishingDelay` in `ObjectController.Properties` in the scenario file is used.
+        range: 300.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectionSensorRange` in `ObjectController.Properties` in the scenario file is used.
+        occlusionless: false # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `isClairvoyant` in `ObjectController.Properties` in the scenario file is used.
         noise:
           model:
             version: 1 # Any of [1, 2].
           v1: # This clause is used only if `model.version` is 1.
             position:
-              standard_deviation: 0.0 # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPositionStandardDeviation` in `ObjectController.Properties` in the scenario file is used.
-            missing_probability: 0.0 # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectMissingProbability` in `ObjectController.Properties` in the scenario file is used.
+              standard_deviation: 0.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPositionStandardDeviation` in `ObjectController.Properties` in the scenario file is used.
+            missing_probability: 0.0 # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectMissingProbability` in `ObjectController.Properties` in the scenario file is used.
           v2: # This clause is used only if `model.version` is 2.
             ellipse_y_radii: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
             distance:
@@ -183,4 +183,4 @@ simulation:
       /perception/object_recognition/ground_truth/objects:
         version: 20240605 # architecture_type suffix (mandatory)
         override_legacy_configuration: false
-        delay: 0.0  # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectGroundTruthPublishingDelay` in `ObjectController.Properties` in the scenario file is used.
+        delay: 0.0  # This parameter is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectGroundTruthPublishingDelay` in `ObjectController.Properties` in the scenario file is used.

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -162,7 +162,7 @@ simulation:
                 offset: 0.49
               velocity_threshold: 0.1
               rate: 0.12
-            tp:
+            true_positive:
               phi:
                 amplitude: 0.32
                 decay: 0.26

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -134,27 +134,34 @@ simulation:
           model:
             version: 2 # Any of [1, 2].
           v2:
-            correlation_for_delta_t: 0.5
             ellipse_y_radii: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
             distance:
-              delta_t: 0.5
+              phi_amplitude: 0.32
+              phi_decay: 0.45
+              phi_offset: 0.26
               ellipse_normalized_x_radius:
-                mean: 1.8
-                standard_deviation: 1.8
-              means: [0.25, 0.27, 0.44, 0.67, 1.00, 3.00, 4.09, 3.40, 0.00]
-              standard_deviations: [0.35, 0.54, 0.83, 1.14, 1.60, 3.56, 4.31, 3.61, 0.00]
+                mean: 1.1
+                standard_deviation: 1.0
+              means: [-0.06, -0.04, -0.04, -0.07, -0.26, -0.56, -1.02, -1.05, 0.0]
+              standard_deviations: [0.17, 0.20, 0.27, 0.40, 0.67, 0.94, 1.19, 1.17, 0.0]
             yaw:
-              delta_t: 0.3
+              phi_amplitude: 0.22
+              phi_decay: 0.52
+              phi_offset: 0.21
               ellipse_normalized_x_radius:
-                mean: 0.6
-                standard_deviation: 1.6
-              means: [0.01, 0.01, 0.00, 0.03, 0.04, 0.00, 0.01, 0.00, 0.00]
-              standard_deviations: [0.05, 0.1, 0.15, 0.15, 0.2, 0.2, 0.3, 0.4, 0.5]
+                mean: 1.9
+                standard_deviation: 0.8
+              means: [0.0, 0.01, 0.0, 0.0, 0.0, -0.07, 0.18, 0.06, 0.0]
+              standard_deviations: [0.09, 0.15, 0.21, 0.18, 0.17, 0.19, 0.39, 0.15, 0.0]
             yaw_flip:
-              delta_t: 0.1
+              phi_amplitude: 0.29
+              phi_decay: 0.12
+              phi_offset: 0.49
               velocity_threshold: 0.1
-              stop_rate: 0.3
-            mask:
-              delta_t: 0.3
-              ellipse_normalized_x_radius: 0.6
-              unmask_rates: [0.92, 0.77, 0.74, 0.66, 0.57, 0.28, 0.09, 0.03, 0.00]
+              flip_rate: 0.12
+            tp:
+              phi_amplitude: 0.32
+              phi_decay: 0.26
+              phi_offset: 0.40
+              ellipse_normalized_x_radius: 0.7
+              tp_rates: [0.96, 0.78, 0.57, 0.48, 0.27, 0.07, 0.01, 0.0, 0.0]

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -136,32 +136,36 @@ simulation:
           v2:
             ellipse_y_radii: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
             distance:
-              phi_amplitude: 0.32
-              phi_decay: 0.45
-              phi_offset: 0.26
+              phi:
+                amplitude: 0.32
+                decay: 0.45
+                offset: 0.26
               ellipse_normalized_x_radius:
                 mean: 1.1
                 standard_deviation: 1.0
               means: [-0.06, -0.04, -0.04, -0.07, -0.26, -0.56, -1.02, -1.05, 0.0]
               standard_deviations: [0.17, 0.20, 0.27, 0.40, 0.67, 0.94, 1.19, 1.17, 0.0]
             yaw:
-              phi_amplitude: 0.22
-              phi_decay: 0.52
-              phi_offset: 0.21
+              phi:
+                amplitude: 0.22
+                decay: 0.52
+                offset: 0.21
               ellipse_normalized_x_radius:
                 mean: 1.9
                 standard_deviation: 0.8
               means: [0.0, 0.01, 0.0, 0.0, 0.0, -0.07, 0.18, 0.06, 0.0]
               standard_deviations: [0.09, 0.15, 0.21, 0.18, 0.17, 0.19, 0.39, 0.15, 0.0]
             yaw_flip:
-              phi_amplitude: 0.29
-              phi_decay: 0.12
-              phi_offset: 0.49
+              phi:
+                amplitude: 0.29
+                decay: 0.12
+                offset: 0.49
               velocity_threshold: 0.1
-              flip_rate: 0.12
+              rate: 0.12
             tp:
-              phi_amplitude: 0.32
-              phi_decay: 0.26
-              phi_offset: 0.40
+              phi:
+                amplitude: 0.32
+                decay: 0.26
+                offset: 0.40
               ellipse_normalized_x_radius: 0.7
-              tp_rates: [0.96, 0.78, 0.57, 0.48, 0.27, 0.07, 0.01, 0.0, 0.0]
+              rates: [0.96, 0.78, 0.57, 0.48, 0.27, 0.07, 0.01, 0.0, 0.0]

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -139,22 +139,22 @@ simulation:
             distance:
               delta_t: 0.5
               ellipse_normalized_x_radius:
-                mean: 1.0
-                standard_deviation: 1.0
-              means: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-              standard_deviations: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+                mean: 1.8
+                standard_deviation: 1.8
+              means: [0.25, 0.27, 0.44, 0.67, 1.00, 3.00, 4.09, 3.40, 0.00]
+              standard_deviations: [0.35, 0.54, 0.83, 1.14, 1.60, 3.56, 4.31, 3.61, 0.00]
             yaw:
               delta_t: 0.3
               ellipse_normalized_x_radius:
-                mean: 1.0
-                standard_deviation: 1.0
-              means: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-              standard_deviations: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+                mean: 0.6
+                standard_deviation: 1.6
+              means: [0.01, 0.01, 0.00, 0.03, 0.04, 0.00, 0.01, 0.00, 0.00]
+              standard_deviations: [0.05, 0.1, 0.15, 0.15, 0.2, 0.2, 0.3, 0.4, 0.5]
             yaw_flip:
               delta_t: 0.1
               velocity_threshold: 0.1
-              rate_for_stop_objects: 0.0
+              rate_for_stop_objects: 0.3
             mask:
               delta_t: 0.3
-              ellipse_normalized_x_radius: 1.0
-              rates: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+              ellipse_normalized_x_radius: 0.6
+              unmask_rates: [0.92, 0.77, 0.74, 0.66, 0.57, 0.28, 0.09, 0.03, 0.00]

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -130,10 +130,18 @@ simulation:
       /perception/object_recognition/detection/objects:
         version: 20240605 # architecture_type suffix (mandatory)
         seed: 0 # If 0 is specified, a random seed value will be generated for each run.
+        override_legacy_configuration: false
+        delay: 0.0 # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPublishingDelay` in `ObjectController.Properties` in the scenario file is used.
+        range: 300.0 # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectionSensorRange` in `ObjectController.Properties` in the scenario file is used.
+        clairvoyant: false # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `isClairvoyant` in `ObjectController.Properties` in the scenario file is used.
         noise:
           model:
             version: 2 # Any of [1, 2].
-          v2:
+          v1: # This clause is used only if `model.version` is 1.
+            position:
+              standard_deviation: 0.0 # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPositionStandardDeviation` in `ObjectController.Properties` in the scenario file is used.
+            missing_probability: 0.0 # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectMissingProbability` in `ObjectController.Properties` in the scenario file is used.
+          v2: # This clause is used only if `model.version` is 2.
             ellipse_y_radii: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
             distance:
               autocorrelation_coefficient:
@@ -172,3 +180,7 @@ simulation:
               rate:
                 ellipse_normalized_x_radius: 0.7
                 values: [0.96, 0.78, 0.57, 0.48, 0.27, 0.07, 0.01, 0.0, 0.0]
+      /perception/object_recognition/ground_truth/objects:
+        version: 20240605 # architecture_type suffix (mandatory)
+        override_legacy_configuration: false
+        delay: 0.0  # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectGroundTruthPublishingDelay` in `ObjectController.Properties` in the scenario file is used.

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -135,7 +135,7 @@ simulation:
             version: 2 # Any of [1, 2].
           v2:
             correlation_for_delta_t: 0.5
-            ellipse_y_radiuses: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
+            ellipse_y_radii: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
             distance:
               delta_t: 0.5
               ellipse_normalized_x_radius:

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -127,3 +127,33 @@ simulation:
                     multiplicative:
                       mean: 0.0
                       standard_deviation: 0.0
+      /perception/object_recognition/detection/objects:
+        version: 20240605 # architecture_type suffix (mandatory)
+        seed: 0 # If 0 is specified, a random seed value will be generated for each run.
+        noise:
+          model:
+            version: 1 # Any of [0, 1]
+          v1:
+            correlation_for_delta_t: 0.5
+            distance:
+              delta_t: 0.5
+              ellipse_normalized_x_radius:
+                mean: 1.0
+                standard_deviation: 1.0
+              means: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+              standard_deviations: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+            yaw:
+              delta_t: 0.3
+              ellipse_normalized_x_radius:
+                mean: 1.0
+                standard_deviation: 1.0
+              means: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+              standard_deviations: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+            yaw_flip:
+              delta_t: 0.1
+              velocity_threshold: 0.1
+              rate_for_stop_objects: 0.0
+            mask:
+              delta_t: 0.3
+              ellipse_normalized_x_radius: 1.0
+              rates: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -136,7 +136,7 @@ simulation:
         clairvoyant: false # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `isClairvoyant` in `ObjectController.Properties` in the scenario file is used.
         noise:
           model:
-            version: 2 # Any of [1, 2].
+            version: 1 # Any of [1, 2].
           v1: # This clause is used only if `model.version` is 1.
             position:
               standard_deviation: 0.0 # This value is used only if `override_legacy_configuration` is true. If it is false, the value of `detectedObjectPositionStandardDeviation` in `ObjectController.Properties` in the scenario file is used.
@@ -145,41 +145,41 @@ simulation:
             ellipse_y_radii: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
             distance:
               autocorrelation_coefficient:
-                amplitude: 0.32
-                decay: 0.45
-                offset: 0.26
+                amplitude: 0.0
+                decay: 0.0
+                offset: 0.0
               mean:
-                ellipse_normalized_x_radius: 1.1
-                values: [-0.06, -0.04, -0.04, -0.07, -0.26, -0.56, -1.02, -1.05, 0.0]
+                ellipse_normalized_x_radius: 1.0
+                values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
               standard_deviation:
                 ellipse_normalized_x_radius: 1.0
-                values: [0.17, 0.20, 0.27, 0.40, 0.67, 0.94, 1.19, 1.17, 0.0]
+                values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
             yaw:
               autocorrelation_coefficient:
-                amplitude: 0.22
-                decay: 0.52
-                offset: 0.21
+                amplitude: 0.0
+                decay: 0.0
+                offset: 0.0
               mean:
-                ellipse_normalized_x_radius: 1.9
-                values: [0.0, 0.01, 0.0, 0.0, 0.0, -0.07, 0.18, 0.06, 0.0]
+                ellipse_normalized_x_radius: 1.0
+                values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
               standard_deviation:
-                ellipse_normalized_x_radius: 0.8
-                values: [0.09, 0.15, 0.21, 0.18, 0.17, 0.19, 0.39, 0.15, 0.0]
+                ellipse_normalized_x_radius: 1.0
+                values: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
             yaw_flip:
               autocorrelation_coefficient:
-                amplitude: 0.29
-                decay: 0.12
-                offset: 0.49
-              velocity_threshold: 0.1
-              rate: 0.12
+                amplitude: 0.0
+                decay: 0.0
+                offset: 0.0
+              speed_threshold: 0.1
+              rate: 0.0
             true_positive:
               autocorrelation_coefficient:
-                amplitude: 0.32
-                decay: 0.26
-                offset: 0.40
+                amplitude: 0.0
+                decay: 0.0
+                offset: 0.0
               rate:
-                ellipse_normalized_x_radius: 0.7
-                values: [0.96, 0.78, 0.57, 0.48, 0.27, 0.07, 0.01, 0.0, 0.0]
+                ellipse_normalized_x_radius: 1.0
+                values: [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
       /perception/object_recognition/ground_truth/objects:
         version: 20240605 # architecture_type suffix (mandatory)
         override_legacy_configuration: false

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -135,6 +135,7 @@ simulation:
             version: 1 # Any of [0, 1]
           v1:
             correlation_for_delta_t: 0.5
+            ellipse_y_radiuses: [10.0, 20.0, 40.0, 60.0, 80.0, 120.0, 150.0, 180.0, 1000.0]
             distance:
               delta_t: 0.5
               ellipse_normalized_x_radius:


### PR DESCRIPTION
# Description

## Abstract

- Added new noise model `noise_v2` to DetectionSensor in simple_sensor_simulator
- Renamed the existing noise model from `noise` to `noise_v1`

## Background

The noise models provided in the past were very simple, using a normal distribution and applying random noise to the positions of non-ego entities. However, this was too simple to be useful in the development of Autoware's planner. Therefore, we added a more realistic noise model provided by the planner development team.

## Details

Please refer to the document [`Parameters.md`](https://github.com/tier4/scenario_simulator_v2/blob/8f919211d80108260e452ce92875942ef9b9c00c/docs/developer_guide/Parameters.md) for the specification and configuration method of the newly added noise model `noise_v2`.

Also, the previous noise model `noise_v1` was configured via a scenario file, but now the configuration method has been changed to be configured via a ROS 2 parameter file as well as the new noise model. However, for backward compatibility, the previous configuration method is still supported for `noise_v1`. You can configure `noise_v1` in either the old or the new way, but the old way is basically prioritized (see `override_legacy_configuration` in the documentation).

## References

None.

# Destructive Changes

None.

# Known Limitations

None.
