### PR TITLE
HdMapUtils refactor lanelet_wrapper::lanelet_map::leftBound rightBound

### DIFF
--- a/mock/cpp_mock_scenarios/src/measurement/get_distance_to_lane_bound.cpp
+++ b/mock/cpp_mock_scenarios/src/measurement/get_distance_to_lane_bound.cpp
@@ -46,8 +46,7 @@ private:
     }
     auto & ego_entity = api_.getEntity("ego");
     const auto distance = traffic_simulator::distance::distanceToLaneBound(
-      ego_entity.getMapPose(), ego_entity.getBoundingBox(), ego_entity.getRouteLanelets(),
-      api_.getHdmapUtils());
+      ego_entity.getMapPose(), ego_entity.getBoundingBox(), ego_entity.getRouteLanelets());
     // LCOV_EXCL_START
     if (distance <= 0.4 && distance >= 0.52) {
       stop(cpp_mock_scenarios::Result::FAILURE);

--- a/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
@@ -179,8 +179,6 @@ public:
     const traffic_simulator::RoutingConfiguration & routing_configuration =
       traffic_simulator::RoutingConfiguration()) const -> std::optional<double>;
 
-  auto getLeftBound(const lanelet::Id) const -> std::vector<geometry_msgs::msg::Point>;
-
   auto getLongitudinalDistance(
     const traffic_simulator_msgs::msg::LaneletPose & from_pose,
     const traffic_simulator_msgs::msg::LaneletPose & to_pose,
@@ -199,8 +197,6 @@ public:
     const lanelet::Id, const double backward_horizon = 100,
     const traffic_simulator::RoutingGraphType type =
       traffic_simulator::RoutingConfiguration().routing_graph_type) const -> lanelet::Ids;
-
-  auto getRightBound(const lanelet::Id) const -> std::vector<geometry_msgs::msg::Point>;
 
   auto getRightOfWayLaneletIds(const lanelet::Ids &) const
     -> std::unordered_map<lanelet::Id, lanelet::Ids>;

--- a/simulation/traffic_simulator/include/traffic_simulator/lanelet_wrapper/lanelet_map.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/lanelet_wrapper/lanelet_map.hpp
@@ -89,6 +89,9 @@ auto previousLaneletIds(
 auto previousLaneletIds(
   const lanelet::Ids & lanelet_ids, std::string_view turn_direction,
   const RoutingGraphType type = RoutingConfiguration().routing_graph_type) -> lanelet::Ids;
+
+// Polygons
+auto toPolygon(const lanelet::ConstLineString3d & line_string) -> std::vector<Point>;
 }  // namespace lanelet_map
 }  // namespace lanelet_wrapper
 }  // namespace traffic_simulator

--- a/simulation/traffic_simulator/include/traffic_simulator/lanelet_wrapper/lanelet_map.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/lanelet_wrapper/lanelet_map.hpp
@@ -90,6 +90,11 @@ auto previousLaneletIds(
   const lanelet::Ids & lanelet_ids, std::string_view turn_direction,
   const RoutingGraphType type = RoutingConfiguration().routing_graph_type) -> lanelet::Ids;
 
+// Bounds
+auto leftBound(const lanelet::Id lanelet_id) -> std::vector<Point>;
+
+auto rightBound(const lanelet::Id lanelet_id) -> std::vector<Point>;
+
 // Polygons
 auto toPolygon(const lanelet::ConstLineString3d & line_string) -> std::vector<Point>;
 }  // namespace lanelet_map

--- a/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
@@ -74,13 +74,13 @@ auto boundingBoxLaneLongitudinalDistance(
 // Bounds
 auto distanceToLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, lanelet::Id lanelet_id,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Id lanelet_id)
+  -> double;
 
 auto distanceToLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids)
+  -> double;
 
 auto distanceToLeftLaneBound(
   const geometry_msgs::msg::Pose & map_pose,

--- a/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
@@ -84,23 +84,23 @@ auto distanceToLaneBound(
 
 auto distanceToLeftLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, lanelet::Id lanelet_id,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Id lanelet_id)
+  -> double;
 
 auto distanceToLeftLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids)
+  -> double;
 
 auto distanceToRightLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, lanelet::Id lanelet_id,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Id lanelet_id)
+  -> double;
 
 auto distanceToRightLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids)
+  -> double;
 
 // Other objects
 auto distanceToCrosswalk(

--- a/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
+++ b/simulation/traffic_simulator/src/hdmap_utils/hdmap_utils.cpp
@@ -740,18 +740,6 @@ auto HdMapUtils::getTrafficLightBulbPosition(
   return std::nullopt;
 }
 
-auto HdMapUtils::getLeftBound(const lanelet::Id lanelet_id) const
-  -> std::vector<geometry_msgs::msg::Point>
-{
-  return toPolygon(lanelet_map_ptr_->laneletLayer.get(lanelet_id).leftBound());
-}
-
-auto HdMapUtils::getRightBound(const lanelet::Id lanelet_id) const
-  -> std::vector<geometry_msgs::msg::Point>
-{
-  return toPolygon(lanelet_map_ptr_->laneletLayer.get(lanelet_id).rightBound());
-}
-
 auto HdMapUtils::getLaneChangeTrajectory(
   const traffic_simulator_msgs::msg::LaneletPose & from_pose,
   const traffic_simulator::lane_change::Parameter & lane_change_parameter) const

--- a/simulation/traffic_simulator/src/lanelet_wrapper/lanelet_map.cpp
+++ b/simulation/traffic_simulator/src/lanelet_wrapper/lanelet_map.cpp
@@ -235,6 +235,17 @@ auto previousLaneletIds(
   }
   return lanelet::Ids(previous_lanelet_ids_set.begin(), previous_lanelet_ids_set.end());
 }
+
+// Polygons
+auto toPolygon(const lanelet::ConstLineString3d & line_string) -> std::vector<Point>
+{
+  std::vector<Point> points;
+  points.reserve(line_string.size());
+  for (const auto & point : line_string) {
+    points.push_back(geometry_msgs::build<Point>().x(point.x()).y(point.y()).z(point.z()));
+  }
+  return points;
+}
 }  // namespace lanelet_map
 }  // namespace lanelet_wrapper
 }  // namespace traffic_simulator

--- a/simulation/traffic_simulator/src/lanelet_wrapper/lanelet_map.cpp
+++ b/simulation/traffic_simulator/src/lanelet_wrapper/lanelet_map.cpp
@@ -236,6 +236,17 @@ auto previousLaneletIds(
   return lanelet::Ids(previous_lanelet_ids_set.begin(), previous_lanelet_ids_set.end());
 }
 
+// Bounds
+auto leftBound(const lanelet::Id lanelet_id) -> std::vector<Point>
+{
+  return toPolygon(LaneletWrapper::map()->laneletLayer.get(lanelet_id).leftBound());
+}
+
+auto rightBound(const lanelet::Id lanelet_id) -> std::vector<Point>
+{
+  return toPolygon(LaneletWrapper::map()->laneletLayer.get(lanelet_id).rightBound());
+}
+
 // Polygons
 auto toPolygon(const lanelet::ConstLineString3d & line_string) -> std::vector<Point>
 {

--- a/simulation/traffic_simulator/src/utils/distance.cpp
+++ b/simulation/traffic_simulator/src/utils/distance.cpp
@@ -201,8 +201,8 @@ auto boundingBoxLaneLongitudinalDistance(
 // Bounds
 auto distanceToLeftLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, lanelet::Id lanelet_id,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Id lanelet_id)
+  -> double
 {
   if (const auto bound = lanelet_wrapper::lanelet_map::leftBound(lanelet_id); bound.empty()) {
     THROW_SEMANTIC_ERROR(
@@ -218,24 +218,26 @@ auto distanceToLeftLaneBound(
 
 auto distanceToLeftLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids)
+  -> double
 {
   if (lanelet_ids.empty()) {
     THROW_SEMANTIC_ERROR("Failing to calculate distanceToLeftLaneBound given an empty vector.");
   }
-  std::vector<double> distances;
-  std::transform(
-    lanelet_ids.begin(), lanelet_ids.end(), std::back_inserter(distances), [&](auto lanelet_id) {
-      return distanceToLeftLaneBound(map_pose, bounding_box, lanelet_id, hdmap_utils_ptr);
-    });
-  return *std::min_element(distances.begin(), distances.end());
+  double min_distance = std::numeric_limits<double>::max();
+  for (const auto & lanelet_id : lanelet_ids) {
+    const auto distance = distanceToLeftLaneBound(map_pose, bounding_box, lanelet_id);
+    if (distance < min_distance) {
+      min_distance = distance;
+    }
+  }
+  return min_distance;
 }
 
 auto distanceToRightLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, lanelet::Id lanelet_id,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Id lanelet_id)
+  -> double
 {
   if (const auto & bound = lanelet_wrapper::lanelet_map::rightBound(lanelet_id); bound.empty()) {
     THROW_SEMANTIC_ERROR(
@@ -252,18 +254,20 @@ auto distanceToRightLaneBound(
 
 auto distanceToRightLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids)
+  -> double
 {
   if (lanelet_ids.empty()) {
     THROW_SEMANTIC_ERROR("Failing to calculate distanceToRightLaneBound for given empty vector.");
   }
-  std::vector<double> distances;
-  std::transform(
-    lanelet_ids.begin(), lanelet_ids.end(), std::back_inserter(distances), [&](auto lanelet_id) {
-      return distanceToRightLaneBound(map_pose, bounding_box, lanelet_id, hdmap_utils_ptr);
-    });
-  return *std::min_element(distances.begin(), distances.end());
+  double min_distance = std::numeric_limits<double>::max();
+  for (const auto & lanelet_id : lanelet_ids) {
+    const double distance = distanceToRightLaneBound(map_pose, bounding_box, lanelet_id);
+    if (distance < min_distance) {
+      min_distance = distance;
+    }
+  }
+  return min_distance;
 }
 
 auto distanceToLaneBound(
@@ -272,8 +276,8 @@ auto distanceToLaneBound(
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
 {
   return std::min(
-    distanceToLeftLaneBound(map_pose, bounding_box, lanelet_id, hdmap_utils_ptr),
-    distanceToRightLaneBound(map_pose, bounding_box, lanelet_id, hdmap_utils_ptr));
+    distanceToLeftLaneBound(map_pose, bounding_box, lanelet_id),
+    distanceToRightLaneBound(map_pose, bounding_box, lanelet_id));
 }
 
 auto distanceToLaneBound(
@@ -282,8 +286,8 @@ auto distanceToLaneBound(
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
 {
   return std::min(
-    distanceToLeftLaneBound(map_pose, bounding_box, lanelet_ids, hdmap_utils_ptr),
-    distanceToRightLaneBound(map_pose, bounding_box, lanelet_ids, hdmap_utils_ptr));
+    distanceToLeftLaneBound(map_pose, bounding_box, lanelet_ids),
+    distanceToRightLaneBound(map_pose, bounding_box, lanelet_ids));
 }
 
 auto distanceToCrosswalk(

--- a/simulation/traffic_simulator/src/utils/distance.cpp
+++ b/simulation/traffic_simulator/src/utils/distance.cpp
@@ -272,8 +272,8 @@ auto distanceToRightLaneBound(
 
 auto distanceToLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, lanelet::Id lanelet_id,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Id lanelet_id)
+  -> double
 {
   return std::min(
     distanceToLeftLaneBound(map_pose, bounding_box, lanelet_id),
@@ -282,8 +282,8 @@ auto distanceToLaneBound(
 
 auto distanceToLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
-  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
+  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, const lanelet::Ids & lanelet_ids)
+  -> double
 {
   return std::min(
     distanceToLeftLaneBound(map_pose, bounding_box, lanelet_ids),

--- a/simulation/traffic_simulator/src/utils/distance.cpp
+++ b/simulation/traffic_simulator/src/utils/distance.cpp
@@ -15,6 +15,7 @@
 #include <geometry/bounding_box.hpp>
 #include <geometry/distance.hpp>
 #include <geometry/transform.hpp>
+#include <traffic_simulator/lanelet_wrapper/lanelet_map.hpp>
 #include <traffic_simulator/lanelet_wrapper/pose.hpp>
 #include <traffic_simulator/utils/distance.hpp>
 #include <traffic_simulator_msgs/msg/waypoints_array.hpp>
@@ -197,12 +198,13 @@ auto boundingBoxLaneLongitudinalDistance(
   return std::nullopt;
 }
 
+// Bounds
 auto distanceToLeftLaneBound(
   const geometry_msgs::msg::Pose & map_pose,
   const traffic_simulator_msgs::msg::BoundingBox & bounding_box, lanelet::Id lanelet_id,
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
 {
-  if (const auto bound = hdmap_utils_ptr->getLeftBound(lanelet_id); bound.empty()) {
+  if (const auto bound = lanelet_wrapper::lanelet_map::leftBound(lanelet_id); bound.empty()) {
     THROW_SEMANTIC_ERROR(
       "Failed to calculate left bounds of lanelet_id : ", lanelet_id, " please check lanelet map.");
   } else if (const auto polygon =
@@ -235,7 +237,7 @@ auto distanceToRightLaneBound(
   const traffic_simulator_msgs::msg::BoundingBox & bounding_box, lanelet::Id lanelet_id,
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double
 {
-  if (const auto bound = hdmap_utils_ptr->getRightBound(lanelet_id); bound.empty()) {
+  if (const auto & bound = lanelet_wrapper::lanelet_map::rightBound(lanelet_id); bound.empty()) {
     THROW_SEMANTIC_ERROR(
       "Failed to calculate right bounds of lanelet_id : ", lanelet_id,
       " please check lanelet map.");

--- a/simulation/traffic_simulator/test/src/utils/test_distance.cpp
+++ b/simulation/traffic_simulator/test/src/utils/test_distance.cpp
@@ -593,57 +593,57 @@ TEST_F(distanceTest_StandardMap, distanceToLeftLaneBound_single)
   {
     const auto pose = makePose(3818.33, 73726.18, 0.0, 30.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToLeftLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 0.5, tolerance);
   }
   {
     const auto pose = makePose(3816.89, 73723.09, 0.0, 30.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToLeftLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 2.6, tolerance);
   }
   {
     const auto pose = makePose(3813.42, 73721.11, 0.0, 30.0);
     const auto bounding_box = makeCustom2DBoundingBox(3.0, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToLeftLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 2.7, tolerance);
   }
   {
     const auto pose = makePose(3813.42, 73721.11, 0.0, 120.0);
     const auto bounding_box = makeCustom2DBoundingBox(3.0, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToLeftLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 1.3, tolerance);
   }
   {
     const auto pose = makePose(3810.99, 73721.40, 0.0, 30.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 1.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToLeftLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 1.4, tolerance);
   }
   {
     const auto pose = makePose(3810.99, 73721.40, 0.0, 30.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, -1.0);
-    const double result = traffic_simulator::distance::distanceToLeftLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 2.4, tolerance);
   }
   {
     const auto pose = makePose(3680.81, 73757.27, 0.0, 30.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToLeftLaneBound(
-      pose, bounding_box, 34684L, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, 34684L);
     EXPECT_NEAR(result, 5.1, tolerance);
   }
   {
     const auto pose = makePose(3692.79, 73753.00, 0.0, 30.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToLeftLaneBound(
-      pose, bounding_box, 34684L, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, 34684L);
     EXPECT_NEAR(result, 7.2, tolerance);
   }
 }
@@ -661,11 +661,10 @@ TEST_F(distanceTest_StandardMap, distanceToLeftLaneBound_multipleVector)
     lanelet_ids.cbegin(), lanelet_ids.cend(), std::numeric_limits<double>::max(),
     [](const double lhs, const double rhs) { return std::min(lhs, rhs); },
     [&pose, &bounding_box, this](const lanelet::Id lanelet_id) {
-      return traffic_simulator::distance::distanceToLeftLaneBound(
-        pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+      return traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet_id);
     });
-  const double result_distance = traffic_simulator::distance::distanceToLeftLaneBound(
-    pose, bounding_box, lanelet_ids, hdmap_utils_ptr);
+  const double result_distance =
+    traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet_ids);
   EXPECT_NEAR(actual_distance, result_distance, std::numeric_limits<double>::epsilon());
   EXPECT_NEAR(result_distance, 1.4, 0.1);
 }
@@ -679,10 +678,10 @@ TEST_F(distanceTest_StandardMap, distanceToLeftLaneBound_singleVector)
   constexpr lanelet::Id lanelet_id = 34426L;
   const auto pose = makePose(3693.34, 73738.37, 0.0, 300.0);
   const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-  const double actual_distance = traffic_simulator::distance::distanceToLeftLaneBound(
-    pose, bounding_box, lanelet_id, hdmap_utils_ptr);
-  const double result_distance = traffic_simulator::distance::distanceToLeftLaneBound(
-    pose, bounding_box, {lanelet_id}, hdmap_utils_ptr);
+  const double actual_distance =
+    traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet_id);
+  const double result_distance =
+    traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, {lanelet_id});
   EXPECT_NEAR(actual_distance, result_distance, std::numeric_limits<double>::epsilon());
   EXPECT_NEAR(result_distance, 1.8, 0.1);
 }
@@ -695,8 +694,7 @@ TEST_F(distanceTest_StandardMap, distanceToLeftLaneBound_emptyVector)
   const auto pose = makePose(3825.87, 73773.08, 0.0, 135.0);
   const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
   EXPECT_THROW(
-    traffic_simulator::distance::distanceToLeftLaneBound(
-      pose, bounding_box, lanelet::Ids{}, hdmap_utils_ptr),
+    traffic_simulator::distance::distanceToLeftLaneBound(pose, bounding_box, lanelet::Ids{}),
     common::SemanticError);
 }
 
@@ -710,57 +708,57 @@ TEST_F(distanceTest_IntersectionMap, distanceToRightLaneBound_single)
   {
     const auto pose = makePose(86651.84, 44941.47, 0.0, 135.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToRightLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 4.1, tolerance);
   }
   {
     const auto pose = makePose(86653.05, 44946.74, 0.0, 135.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToRightLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 0.6, tolerance);
   }
   {
     const auto pose = makePose(86651.47, 44941.07, 0.0, 120.0);
     const auto bounding_box = makeCustom2DBoundingBox(3.0, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToRightLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 4.3, tolerance);
   }
   {
     const auto pose = makePose(86651.47, 44941.07, 0.0, 210.0);
     const auto bounding_box = makeCustom2DBoundingBox(3.0, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToRightLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 3.1, tolerance);
   }
   {
     const auto pose = makePose(86644.10, 44951.86, 0.0, 150.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 1.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToRightLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 2.0, tolerance);
   }
   {
     const auto pose = makePose(86644.10, 44951.86, 0.0, 150.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, -1.0);
-    const double result = traffic_simulator::distance::distanceToRightLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 1.1, tolerance);
   }
   {
     const auto pose = makePose(86644.11, 44941.21, 0.0, 0.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToRightLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 11.2, tolerance);
   }
   {
     const auto pose = makePose(86656.83, 44946.96, 0.0, 0.0);
     const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-    const double result = traffic_simulator::distance::distanceToRightLaneBound(
-      pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+    const double result =
+      traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
     EXPECT_NEAR(result, 2.6, tolerance);
   }
 }
@@ -778,11 +776,10 @@ TEST_F(distanceTest_IntersectionMap, distanceToRightLaneBound_multipleVector)
     lanelet_ids.cbegin(), lanelet_ids.cend(), std::numeric_limits<double>::max(),
     [](const double lhs, const double rhs) { return std::min(lhs, rhs); },
     [&pose, &bounding_box, this](const lanelet::Id lanelet_id) {
-      return traffic_simulator::distance::distanceToRightLaneBound(
-        pose, bounding_box, lanelet_id, hdmap_utils_ptr);
+      return traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
     });
-  const double result_distance = traffic_simulator::distance::distanceToRightLaneBound(
-    pose, bounding_box, lanelet_ids, hdmap_utils_ptr);
+  const double result_distance =
+    traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_ids);
   EXPECT_NEAR(actual_distance, result_distance, std::numeric_limits<double>::epsilon());
   EXPECT_NEAR(result_distance, 2.7, 0.1);
 }
@@ -796,10 +793,10 @@ TEST_F(distanceTest_IntersectionMap, distanceToRightLaneBound_singleVector)
   constexpr lanelet::Id lanelet_id = 654L;
   const auto pose = makePose(86702.79, 44929.05, 0.0, 150.0);
   const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
-  const double actual_distance = traffic_simulator::distance::distanceToRightLaneBound(
-    pose, bounding_box, lanelet_id, hdmap_utils_ptr);
-  const double result_distance = traffic_simulator::distance::distanceToRightLaneBound(
-    pose, bounding_box, {lanelet_id}, hdmap_utils_ptr);
+  const double actual_distance =
+    traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet_id);
+  const double result_distance =
+    traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, {lanelet_id});
   EXPECT_NEAR(actual_distance, result_distance, std::numeric_limits<double>::epsilon());
   EXPECT_NEAR(result_distance, 2.4, 0.1);
 }
@@ -812,7 +809,6 @@ TEST_F(distanceTest_IntersectionMap, distanceToRightLaneBound_emptyVector)
   const auto pose = makePose(3825.87, 73773.08, 0.0, 135.0);
   const auto bounding_box = makeCustom2DBoundingBox(0.1, 0.1, 0.0, 0.0);
   EXPECT_THROW(
-    traffic_simulator::distance::distanceToRightLaneBound(
-      pose, bounding_box, lanelet::Ids{}, hdmap_utils_ptr),
+    traffic_simulator::distance::distanceToRightLaneBound(pose, bounding_box, lanelet::Ids{}),
     common::SemanticError);
 }


### PR DESCRIPTION
# Description

## Abstract

This is the partial PR of the HdMapUtils refactor (PR 2/6) ( https://github.com/tier4/scenario_simulator_v2/pull/1478 )

## Details

Replace usage of HdMapUtils::getLeftBound and getRightBound with non-member function lanelet_wrapper::lanelet_map::leftBound, rightBound

## References

- #1478

# Destructive Changes

The hdmap_utils_ptr parameter has been removed from the following functions:

- `traffic_simulator::distance::distanceToLaneBound`
- `traffic_simulator::distance::distanceToLeftLaneBound`
- `traffic_simulator::distance::distanceToRightLaneBound`

For the rationale behind this change, see #1478.

## Migration Guide
### Before (Old Signature)
``` 
auto distanceToLaneBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  lanelet::Id lanelet_id,
  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;

auto distanceToLaneBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  const lanelet::Ids & lanelet_ids,
  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;

auto distanceToLeftBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  lanelet::Id lanelet_id,
  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;

auto distanceToLeftBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  const lanelet::Ids & lanelet_ids,
  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;

auto distanceToRightBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  lanelet::Id lanelet_id,
  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;

auto distanceToRightBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  const lanelet::Ids & lanelet_ids,
  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> double;
```

### After (New Signature)
``` 
auto distanceToLaneBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  lanelet::Id lanelet_id) -> double;

auto distanceToLaneBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  const lanelet::Ids & lanelet_ids) -> double;

auto distanceToLeftBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  lanelet::Id lanelet_id) -> double;

auto distanceToLeftBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  const lanelet::Ids & lanelet_ids) -> double;

auto distanceToRightBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  lanelet::Id lanelet_id) -> double;

auto distanceToRightBound(
  const geometry_msgs::msg::Pose & map_pose,
  const traffic_simulator_msgs::msg::BoundingBox & bounding_box, 
  const lanelet::Ids & lanelet_ids) -> double;
```
The fourth parameter, `const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr`, has been removed.
Remove the `hdmap_utils_ptr` argument from call to `distanceToLaneBound`, `distanceToLeftBound`, `distanceToRightBound`.


# Known Limitations
None.