### PR TITLE
fix: the noises are not initialized in detection_sensor's noise_v2

### DIFF
--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -90,7 +90,12 @@ class DetectionSensor : public DetectionSensorBase
 
     bool true_positive, flip;
 
-    explicit NoiseOutput(double simulation_time = 0.0) : simulation_time(simulation_time) {}
+    explicit NoiseOutput(double simulation_time = 0.0) : simulation_time(simulation_time) {
+      distance_noise=0.0;
+      yaw_noise=0.0;
+      true_positive=true;
+      flip=false;
+    }
   };
 
   std::unordered_map<std::string, NoiseOutput> noise_outputs;

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -86,16 +86,19 @@ class DetectionSensor : public DetectionSensorBase
 
   struct NoiseOutput
   {
-    double simulation_time, distance_noise, yaw_noise;
+    double simulation_time;
+    double distance_noise;
+    double yaw_noise;
+    bool true_positive;
+    bool flip;
 
-    bool true_positive, flip;
-
-    explicit NoiseOutput(double simulation_time = 0.0) : simulation_time(simulation_time)
+    constexpr NoiseOutput(double simulation_time = 0.0)
+    : simulation_time(simulation_time),
+      distance_noise(0.0),
+      yaw_noise(0.0),
+      true_positive(true),
+      flip(false)
     {
-      distance_noise = 0.0;
-      yaw_noise = 0.0;
-      true_positive = true;
-      flip = false;
     }
   };
 

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -86,13 +86,11 @@ class DetectionSensor : public DetectionSensorBase
 
   struct NoiseOutput
   {
-    double simulation_time;
-    double distance_noise;
-    double yaw_noise;
-    bool true_positive;
-    bool flip;
+    double simulation_time, distance_noise, yaw_noise;
 
-    constexpr NoiseOutput(double simulation_time = 0.0)
+    bool true_positive, flip;
+
+    explicit NoiseOutput(double simulation_time = 0.0)
     : simulation_time(simulation_time),
       distance_noise(0.0),
       yaw_noise(0.0),

--- a/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
+++ b/simulation/simple_sensor_simulator/include/simple_sensor_simulator/sensor_simulation/detection_sensor/detection_sensor.hpp
@@ -90,11 +90,12 @@ class DetectionSensor : public DetectionSensorBase
 
     bool true_positive, flip;
 
-    explicit NoiseOutput(double simulation_time = 0.0) : simulation_time(simulation_time) {
-      distance_noise=0.0;
-      yaw_noise=0.0;
-      true_positive=true;
-      flip=false;
+    explicit NoiseOutput(double simulation_time = 0.0) : simulation_time(simulation_time)
+    {
+      distance_noise = 0.0;
+      yaw_noise = 0.0;
+      true_positive = true;
+      flip = false;
     }
   };
 


### PR DESCRIPTION
# Description
This PR fix a bug in the [PR](https://github.com/tier4/scenario_simulator_v2/pull/1532) that the perception noises are not initialized

## Abstract
The perception noises are not initialized in the detection_sensor's noise_v2, which results in undefined noise values.

## Background

None.

## Details
Check the published pose in `/localization/kinematic_state`:

before:
```bash
header:
  stamp:
    sec: 1741165999
    nanosec: 608598102
  frame_id: map
objects:
- existence_probability: 0.0
  classification:
  - label: 3
    probability: 1.0
  kinematics:
    pose_with_covariance:
      pose:
        position:
          x: 1.6319554146606627e+130
          y: 2.8510855737315343e+131
          z: 101.25
        orientation:
          x: 0.0
          y: 0.0
          z: 0.5684897847198799
          w: -0.8226903212443578
```

after:
```bash
---
header:
  stamp:
    sec: 1741168200
    nanosec: 879934861
  frame_id: map
objects:
- existence_probability: 0.0
  classification:
  - label: 3
    probability: 1.0
  kinematics:
    pose_with_covariance:
      pose:
        position:
          x: 117.30633413377262
          y: 289.8219850335379
          z: 101.25
        orientation:
          x: 0.0
          y: 0.0
          z: 0.7342859116860377
          w: 0.6788403346144103
```

## References

None.

# Destructive Changes

None.

# Known Limitations

None.

