### PR TITLE
feat: disable the localization noises when ego speed is slow

### DIFF
--- a/external/concealer/include/concealer/publisher.hpp
+++ b/external/concealer/include/concealer/publisher.hpp
@@ -49,6 +49,8 @@ struct NormalDistribution<nav_msgs::msg::Odometry>
 
   std::mt19937_64 engine;
 
+  double speed_threshold;
+
   struct Error
   {
     std::normal_distribution<double> additive, multiplicative;

--- a/external/concealer/src/publisher.cpp
+++ b/external/concealer/src/publisher.cpp
@@ -52,51 +52,52 @@ NormalDistribution<nav_msgs::msg::Odometry>::NormalDistribution(
 auto NormalDistribution<nav_msgs::msg::Odometry>::operator()(nav_msgs::msg::Odometry odometry)
   -> nav_msgs::msg::Odometry
 {
-  const Eigen::Quaterniond orientation = Eigen::Quaterniond(
-    odometry.pose.pose.orientation.w, odometry.pose.pose.orientation.x,
-    odometry.pose.pose.orientation.y, odometry.pose.pose.orientation.z);
+  if (const double speed = std::hypot(
+        odometry.twist.twist.linear.x, odometry.twist.twist.linear.y,
+        odometry.twist.twist.linear.z);
+      speed < speed_threshold) {
+    return odometry;
+  } else {
+    const Eigen::Quaterniond orientation = Eigen::Quaterniond(
+      odometry.pose.pose.orientation.w, odometry.pose.pose.orientation.x,
+      odometry.pose.pose.orientation.y, odometry.pose.pose.orientation.z);
 
-  const double speed = std::hypot(
-    odometry.twist.twist.linear.x, odometry.twist.twist.linear.y, odometry.twist.twist.linear.z);
-  if (speed < speed_threshold) {
+    Eigen::Vector3d local_position = Eigen::Vector3d(0.0, 0.0, 0.0);
+
+    local_position.x() = position_local_x_error.apply(engine, local_position.x());
+    local_position.y() = position_local_y_error.apply(engine, local_position.y());
+    local_position.z() = position_local_z_error.apply(engine, local_position.z());
+
+    const Eigen::Vector3d world_position = orientation.toRotationMatrix() * local_position;
+
+    odometry.pose.pose.position.x += world_position.x();
+    odometry.pose.pose.position.y += world_position.y();
+    odometry.pose.pose.position.z += world_position.z();
+
+    Eigen::Vector3d euler = orientation.matrix().eulerAngles(0, 1, 2);
+
+    euler.x() = orientation_r_error.apply(engine, euler.x());
+    euler.y() = orientation_p_error.apply(engine, euler.y());
+    euler.z() = orientation_y_error.apply(engine, euler.z());
+
+    const Eigen::Quaterniond q = Eigen::AngleAxisd(euler.x(), Eigen::Vector3d::UnitX()) *
+                                 Eigen::AngleAxisd(euler.y(), Eigen::Vector3d::UnitY()) *
+                                 Eigen::AngleAxisd(euler.z(), Eigen::Vector3d::UnitZ());
+
+    odometry.pose.pose.orientation.x = q.x();
+    odometry.pose.pose.orientation.y = q.y();
+    odometry.pose.pose.orientation.z = q.z();
+    odometry.pose.pose.orientation.w = q.w();
+
+    odometry.twist.twist.linear.x = linear_x_error.apply(engine, odometry.twist.twist.linear.x);
+    odometry.twist.twist.linear.y = linear_y_error.apply(engine, odometry.twist.twist.linear.y);
+    odometry.twist.twist.linear.z = linear_z_error.apply(engine, odometry.twist.twist.linear.z);
+
+    odometry.twist.twist.angular.x = angular_x_error.apply(engine, odometry.twist.twist.angular.x);
+    odometry.twist.twist.angular.y = angular_y_error.apply(engine, odometry.twist.twist.angular.y);
+    odometry.twist.twist.angular.z = angular_z_error.apply(engine, odometry.twist.twist.angular.z);
+
     return odometry;
   }
-
-  Eigen::Vector3d local_position = Eigen::Vector3d(0.0, 0.0, 0.0);
-
-  local_position.x() = position_local_x_error.apply(engine, local_position.x());
-  local_position.y() = position_local_y_error.apply(engine, local_position.y());
-  local_position.z() = position_local_z_error.apply(engine, local_position.z());
-
-  const Eigen::Vector3d world_position = orientation.toRotationMatrix() * local_position;
-
-  odometry.pose.pose.position.x += world_position.x();
-  odometry.pose.pose.position.y += world_position.y();
-  odometry.pose.pose.position.z += world_position.z();
-
-  Eigen::Vector3d euler = orientation.matrix().eulerAngles(0, 1, 2);
-
-  euler.x() = orientation_r_error.apply(engine, euler.x());
-  euler.y() = orientation_p_error.apply(engine, euler.y());
-  euler.z() = orientation_y_error.apply(engine, euler.z());
-
-  const Eigen::Quaterniond q = Eigen::AngleAxisd(euler.x(), Eigen::Vector3d::UnitX()) *
-                               Eigen::AngleAxisd(euler.y(), Eigen::Vector3d::UnitY()) *
-                               Eigen::AngleAxisd(euler.z(), Eigen::Vector3d::UnitZ());
-
-  odometry.pose.pose.orientation.x = q.x();
-  odometry.pose.pose.orientation.y = q.y();
-  odometry.pose.pose.orientation.z = q.z();
-  odometry.pose.pose.orientation.w = q.w();
-
-  odometry.twist.twist.linear.x = linear_x_error.apply(engine, odometry.twist.twist.linear.x);
-  odometry.twist.twist.linear.y = linear_y_error.apply(engine, odometry.twist.twist.linear.y);
-  odometry.twist.twist.linear.z = linear_z_error.apply(engine, odometry.twist.twist.linear.z);
-
-  odometry.twist.twist.angular.x = angular_x_error.apply(engine, odometry.twist.twist.angular.x);
-  odometry.twist.twist.angular.y = angular_y_error.apply(engine, odometry.twist.twist.angular.y);
-  odometry.twist.twist.angular.z = angular_z_error.apply(engine, odometry.twist.twist.angular.z);
-
-  return odometry;
 }
 }  // namespace concealer

--- a/external/concealer/src/publisher.cpp
+++ b/external/concealer/src/publisher.cpp
@@ -33,6 +33,7 @@ NormalDistribution<nav_msgs::msg::Odometry>::NormalDistribution(
     }
   }()),
   engine(seed ? seed : device()),
+  speed_threshold(getParameter<double>(node, topic + ".nav_msgs::msg::Odometry.speed_threshold")),
   position_local_x_error(node, topic + ".nav_msgs::msg::Odometry.pose.pose.position.local_x.error"),
   position_local_y_error(node, topic + ".nav_msgs::msg::Odometry.pose.pose.position.local_y.error"),
   position_local_z_error(node, topic + ".nav_msgs::msg::Odometry.pose.pose.position.local_z.error"),
@@ -54,10 +55,10 @@ auto NormalDistribution<nav_msgs::msg::Odometry>::operator()(nav_msgs::msg::Odom
   const Eigen::Quaterniond orientation = Eigen::Quaterniond(
     odometry.pose.pose.orientation.w, odometry.pose.pose.orientation.x,
     odometry.pose.pose.orientation.y, odometry.pose.pose.orientation.z);
-  // calculate the speed 
+
   const double speed =  std::hypot(
     odometry.twist.twist.linear.x, odometry.twist.twist.linear.y, odometry.twist.twist.linear.z);
-  if (speed < 0.1) {
+  if (speed < speed_threshold) {
     return odometry;
   }
 

--- a/external/concealer/src/publisher.cpp
+++ b/external/concealer/src/publisher.cpp
@@ -54,6 +54,12 @@ auto NormalDistribution<nav_msgs::msg::Odometry>::operator()(nav_msgs::msg::Odom
   const Eigen::Quaterniond orientation = Eigen::Quaterniond(
     odometry.pose.pose.orientation.w, odometry.pose.pose.orientation.x,
     odometry.pose.pose.orientation.y, odometry.pose.pose.orientation.z);
+  // calculate the speed 
+  const double speed =  std::hypot(
+    odometry.twist.twist.linear.x, odometry.twist.twist.linear.y, odometry.twist.twist.linear.z);
+  if (speed < 0.1) {
+    return odometry;
+  }
 
   Eigen::Vector3d local_position = Eigen::Vector3d(0.0, 0.0, 0.0);
 

--- a/external/concealer/src/publisher.cpp
+++ b/external/concealer/src/publisher.cpp
@@ -56,7 +56,7 @@ auto NormalDistribution<nav_msgs::msg::Odometry>::operator()(nav_msgs::msg::Odom
     odometry.pose.pose.orientation.w, odometry.pose.pose.orientation.x,
     odometry.pose.pose.orientation.y, odometry.pose.pose.orientation.z);
 
-  const double speed =  std::hypot(
+  const double speed = std::hypot(
     odometry.twist.twist.linear.x, odometry.twist.twist.linear.y, odometry.twist.twist.linear.z);
   if (speed < speed_threshold) {
     return odometry;

--- a/test_runner/scenario_test_runner/config/parameters.yaml
+++ b/test_runner/scenario_test_runner/config/parameters.yaml
@@ -6,6 +6,7 @@
       version: 20240605 # architecture_type suffix (mandatory)
       seed: 0 # If 0 is specified, a random seed value will be generated for each run.
       nav_msgs::msg::Odometry:
+        speed_threshold: 0.1
         pose:
           pose:
             position:


### PR DESCRIPTION
# Description
Put a limit on the localization noise: disable noise when the ego speed < `speed_threshold`

## Abstract
Put a limit on the localization noise: when the ego speed < `speed_threshold`, the localization noises are not applied. 

## Background
The ego can't engage when [enable_keep_stopped_until_steer_convergence](https://github.com/tier4/autoware_launch/blob/bcff9538b250b185a35a6d0b0f1cb803da8e0880/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml#L9C5-L9C48) is `true` and the localization noises are applied.

## Details
In a real environment, the ego can engage because the localization noises stabilize at a fixed value if the vehicle stops.
So we also want to stop localization noises when the ego stops.

Test results in the basic planning scenarios: 
Before: [3792/3815 (pass/all)](https://evaluation.tier4.jp/evaluation/reports/fbd4944c-0402-581c-9937-f87f802f8a35?project_id=prd_jt)
After: [3817/3820 (pass/all)](https://evaluation.tier4.jp/evaluation/reports/3288e452-5b38-5e95-94cc-70802d5052a0?project_id=prd_jt)

## References
None


# Destructive Changes
None 

# Known Limitations
None