### PR TITLE
Add missing debug marker for motion velocity planner

### DIFF
--- a/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
+++ b/simulation/traffic_simulator/config/scenario_simulator_v2.rviz
@@ -2807,6 +2807,42 @@ Visualization Manager:
                           Displays:
                             - Class: rviz_default_plugins/MarkerArray
                               Enabled: true
+                              Name: ObstacleStop
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop/debug_markers
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: ObstacleSlowDown
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down/debug_markers
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: ObstacleCruise
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_cruise/debug_markers
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
                               Name: OutOfLane
                               Namespaces:
                                 {}


### PR DESCRIPTION
# Description

## Abstract

Based on [autoware.rviz](https://github.com/tier4/autoware_launch/blob/bcff9538b250b185a35a6d0b0f1cb803da8e0880/autoware_launch/rviz/autoware.rviz#L2288-L2325), add debug markers for MotionVelocityPlanner to scenario_simulator_v2.rviz.

ref: https://github.com/autowarefoundation/autoware_launch/pull/1314

# Destructive Changes

None
 Rviz settings do not need to be backwards compatible.(HansRobo)

# Known Limitations

None