### PR TITLE
HdMapUtils refactor `lanelet_wrapper::distance::lateralDistance`

### DIFF
--- a/mock/cpp_mock_scenarios/src/measurement/get_distance_in_lane_coordinate_distance.cpp
+++ b/mock/cpp_mock_scenarios/src/measurement/get_distance_in_lane_coordinate_distance.cpp
@@ -49,8 +49,7 @@ private:
     if (from_entity.isInLanelet() && to_entity.isInLanelet()) {
       return traffic_simulator::distance::lateralDistance(
         from_entity.getCanonicalizedLaneletPose().value(),
-        to_entity.getCanonicalizedLaneletPose().value(), traffic_simulator::RoutingConfiguration(),
-        api_.getHdmapUtils());
+        to_entity.getCanonicalizedLaneletPose().value(), traffic_simulator::RoutingConfiguration());
     }
     return std::nullopt;
   };
@@ -66,7 +65,7 @@ private:
     if (from_entity_lanelet_pose && to_entity_lanelet_pose) {
       return traffic_simulator::distance::lateralDistance(
         from_entity_lanelet_pose.value(), to_entity_lanelet_pose.value(),
-        traffic_simulator::RoutingConfiguration(), api_.getHdmapUtils());
+        traffic_simulator::RoutingConfiguration());
     }
     return std::nullopt;
   };

--- a/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/hdmap_utils/hdmap_utils.hpp
@@ -165,12 +165,6 @@ public:
 
   auto getLanelets(const lanelet::Ids &) const -> lanelet::Lanelets;
 
-  auto getLateralDistance(
-    const traffic_simulator_msgs::msg::LaneletPose & from,
-    const traffic_simulator_msgs::msg::LaneletPose & to,
-    const traffic_simulator::RoutingConfiguration & routing_configuration =
-      traffic_simulator::RoutingConfiguration()) const -> std::optional<double>;
-
   auto getLongitudinalDistance(
     const traffic_simulator_msgs::msg::LaneletPose & from_pose,
     const traffic_simulator_msgs::msg::LaneletPose & to_pose,

--- a/simulation/traffic_simulator/include/traffic_simulator/lanelet_wrapper/distance.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/lanelet_wrapper/distance.hpp
@@ -26,6 +26,11 @@ namespace lanelet_wrapper
 {
 namespace distance
 {
+auto lateralDistance(
+  const LaneletPose & from, const LaneletPose & to,
+  const RoutingConfiguration & routing_configuration = RoutingConfiguration())
+  -> std::optional<double>;
+
 // StopLine
 auto distanceToStopLine(const lanelet::Ids & route_lanelets, const SplineInterface & route_spline)
   -> std::optional<double>;

--- a/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
@@ -27,13 +27,12 @@ inline namespace distance
 // Lateral
 auto lateralDistance(
   const CanonicalizedLaneletPose & from, const CanonicalizedLaneletPose & to,
-  const traffic_simulator::RoutingConfiguration & routing_configuration,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>;
+  const RoutingConfiguration & routing_configuration) -> std::optional<double>;
 
 auto lateralDistance(
   const CanonicalizedLaneletPose & from, const CanonicalizedLaneletPose & to,
-  double matching_distance, const traffic_simulator::RoutingConfiguration & routing_configuration,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>;
+  const double matching_distance, const RoutingConfiguration & routing_configuration)
+  -> std::optional<double>;
 
 // Lateral (unit: lanes)
 auto countLaneChanges(

--- a/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/utils/distance.hpp
@@ -60,8 +60,7 @@ auto boundingBoxLaneLateralDistance(
   const traffic_simulator_msgs::msg::BoundingBox & from_bounding_box,
   const CanonicalizedLaneletPose & to,
   const traffic_simulator_msgs::msg::BoundingBox & to_bounding_box,
-  const traffic_simulator::RoutingConfiguration & routing_configuration,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>;
+  const RoutingConfiguration & routing_configuration) -> std::optional<double>;
 
 auto boundingBoxLaneLongitudinalDistance(
   const CanonicalizedLaneletPose & from,

--- a/simulation/traffic_simulator/src/utils/distance.cpp
+++ b/simulation/traffic_simulator/src/utils/distance.cpp
@@ -28,8 +28,7 @@ inline namespace distance
 {
 auto lateralDistance(
   const CanonicalizedLaneletPose & from, const CanonicalizedLaneletPose & to,
-  const traffic_simulator::RoutingConfiguration & routing_configuration,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>
+  const RoutingConfiguration & routing_configuration) -> std::optional<double>
 {
   return lanelet_wrapper::distance::lateralDistance(
     static_cast<LaneletPose>(from), static_cast<LaneletPose>(to), routing_configuration);
@@ -37,13 +36,13 @@ auto lateralDistance(
 
 auto lateralDistance(
   const CanonicalizedLaneletPose & from, const CanonicalizedLaneletPose & to,
-  double matching_distance, const traffic_simulator::RoutingConfiguration & routing_configuration,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>
+  double matching_distance, const RoutingConfiguration & routing_configuration)
+  -> std::optional<double>
 {
   if (
     std::abs(static_cast<LaneletPose>(from).offset) <= matching_distance &&
     std::abs(static_cast<LaneletPose>(to).offset) <= matching_distance) {
-    return lateralDistance(from, to, routing_configuration, hdmap_utils_ptr);
+    return lateralDistance(from, to, routing_configuration);
   } else {
     return std::nullopt;
   }
@@ -150,8 +149,7 @@ auto boundingBoxLaneLateralDistance(
   const traffic_simulator::RoutingConfiguration & routing_configuration,
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>
 {
-  if (const auto lateral_distance =
-        lateralDistance(from, to, routing_configuration, hdmap_utils_ptr);
+  if (const auto lateral_distance = lateralDistance(from, to, routing_configuration);
       lateral_distance) {
     const auto from_bounding_box_distances =
       math::geometry::getDistancesFromCenterToEdge(from_bounding_box);

--- a/simulation/traffic_simulator/src/utils/distance.cpp
+++ b/simulation/traffic_simulator/src/utils/distance.cpp
@@ -16,6 +16,7 @@
 #include <geometry/distance.hpp>
 #include <geometry/transform.hpp>
 #include <traffic_simulator/helper/helper.hpp>
+#include <traffic_simulator/lanelet_wrapper/distance.hpp>
 #include <traffic_simulator/lanelet_wrapper/lanelet_map.hpp>
 #include <traffic_simulator/lanelet_wrapper/pose.hpp>
 #include <traffic_simulator/utils/distance.hpp>
@@ -30,7 +31,7 @@ auto lateralDistance(
   const traffic_simulator::RoutingConfiguration & routing_configuration,
   const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>
 {
-  return hdmap_utils_ptr->getLateralDistance(
+  return lanelet_wrapper::distance::lateralDistance(
     static_cast<LaneletPose>(from), static_cast<LaneletPose>(to), routing_configuration);
 }
 

--- a/simulation/traffic_simulator/src/utils/distance.cpp
+++ b/simulation/traffic_simulator/src/utils/distance.cpp
@@ -146,8 +146,7 @@ auto boundingBoxLaneLateralDistance(
   const traffic_simulator_msgs::msg::BoundingBox & from_bounding_box,
   const CanonicalizedLaneletPose & to,
   const traffic_simulator_msgs::msg::BoundingBox & to_bounding_box,
-  const traffic_simulator::RoutingConfiguration & routing_configuration,
-  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>
+  const RoutingConfiguration & routing_configuration) -> std::optional<double>
 {
   if (const auto lateral_distance = lateralDistance(from, to, routing_configuration);
       lateral_distance) {

--- a/simulation/traffic_simulator/src/utils/pose.cpp
+++ b/simulation/traffic_simulator/src/utils/pose.cpp
@@ -299,9 +299,7 @@ auto relativeLaneletPose(
       hdmap_utils_ptr)) {
     position.s = longitudinal_distance.value();
   }
-  if (
-    const auto lateral_distance =
-      lateralDistance(from, to, routing_configuration, hdmap_utils_ptr)) {
+  if (const auto lateral_distance = distance::lateralDistance(from, to, routing_configuration)) {
     position.offset = lateral_distance.value();
   }
   return position;

--- a/simulation/traffic_simulator/src/utils/pose.cpp
+++ b/simulation/traffic_simulator/src/utils/pose.cpp
@@ -327,8 +327,8 @@ auto boundingBoxRelativeLaneletPose(
     position.s = longitudinal_bounding_box_distance.value();
   }
   if (
-    const auto lateral_bounding_box_distance = boundingBoxLaneLateralDistance(
-      from, from_bounding_box, to, to_bounding_box, routing_configuration, hdmap_utils_ptr)) {
+    const auto lateral_bounding_box_distance = distance::boundingBoxLaneLateralDistance(
+      from, from_bounding_box, to, to_bounding_box, routing_configuration)) {
     position.offset = lateral_bounding_box_distance.value();
   }
   return position;

--- a/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
+++ b/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <traffic_simulator/hdmap_utils/hdmap_utils.hpp>
 #include <traffic_simulator/helper/helper.hpp>
+#include <traffic_simulator/lanelet_wrapper/distance.hpp>
 #include <traffic_simulator/lanelet_wrapper/lanelet_map.hpp>
 #include <traffic_simulator/lanelet_wrapper/pose.hpp>
 
@@ -1758,7 +1759,7 @@ TEST_F(HdMapUtilsTest_FourTrackHighwayMap, getLateralDistance_sameLane)
 {
   const auto from = traffic_simulator::helper::constructLaneletPose(3002185, 0.0, 0.5);
   const auto to = traffic_simulator::helper::constructLaneletPose(3002185, 10.0, 0.2);
-  const auto result = hdmap_utils.getLateralDistance(from, to);
+  const auto result = traffic_simulator::lanelet_wrapper::distance::lateralDistance(from, to);
 
   EXPECT_TRUE(result.has_value());
   EXPECT_NEAR(result.value(), to.offset - from.offset, 1e-3);
@@ -1771,10 +1772,9 @@ TEST_F(HdMapUtilsTest_FourTrackHighwayMap, getLateralDistance_sameLane)
  */
 TEST_F(HdMapUtilsTest_FourTrackHighwayMap, getLateralDistance_parallelLanesCanNotChange)
 {
-  EXPECT_FALSE(hdmap_utils
-                 .getLateralDistance(
-                   traffic_simulator::helper::constructLaneletPose(3002185, 0.0, 0.5),
-                   traffic_simulator::helper::constructLaneletPose(3002184, 10.0, 0.2))
+  EXPECT_FALSE(traffic_simulator::lanelet_wrapper::distance::lateralDistance(
+                 traffic_simulator::helper::constructLaneletPose(3002185, 0.0, 0.5),
+                 traffic_simulator::helper::constructLaneletPose(3002184, 10.0, 0.2))
                  .has_value());
 }
 
@@ -1790,8 +1790,8 @@ TEST_F(HdMapUtilsTest_FourTrackHighwayMap, getLateralDistance_parallelLanesCanCh
 
   traffic_simulator::RoutingConfiguration lane_changeable_routing_configuration;
   lane_changeable_routing_configuration.allow_lane_change = true;
-  const auto result =
-    hdmap_utils.getLateralDistance(from, to, lane_changeable_routing_configuration);
+  const auto result = traffic_simulator::lanelet_wrapper::distance::lateralDistance(
+    from, to, lane_changeable_routing_configuration);
 
   EXPECT_TRUE(result.has_value());
   EXPECT_NEAR(result.value(), 2.80373 / 2.0 + 3.03463 / 2.0 + to.offset - from.offset, 1e-3);
@@ -1808,11 +1808,10 @@ TEST_F(HdMapUtilsTest_FourTrackHighwayMap, getLateralDistance_notConnected)
 {
   traffic_simulator::RoutingConfiguration lane_changeable_routing_configuration;
   lane_changeable_routing_configuration.allow_lane_change = true;
-  EXPECT_FALSE(hdmap_utils
-                 .getLateralDistance(
-                   traffic_simulator::helper::constructLaneletPose(3002185, 0.0, 0.5),
-                   traffic_simulator::helper::constructLaneletPose(3002166, 10.0, 0.2),
-                   lane_changeable_routing_configuration)
+  EXPECT_FALSE(traffic_simulator::lanelet_wrapper::distance::lateralDistance(
+                 traffic_simulator::helper::constructLaneletPose(3002185, 0.0, 0.5),
+                 traffic_simulator::helper::constructLaneletPose(3002166, 10.0, 0.2),
+                 lane_changeable_routing_configuration)
                  .has_value());
 }
 

--- a/simulation/traffic_simulator/test/src/utils/test_distance.cpp
+++ b/simulation/traffic_simulator/test/src/utils/test_distance.cpp
@@ -95,12 +95,12 @@ TEST_F(distanceTest_FourTrackHighwayMap, lateralDistance_impossible_noChange)
   {
     const auto result = traffic_simulator::distance::lateralDistance(
       pose_from, pose_to, std::numeric_limits<double>::infinity(),
-      traffic_simulator::RoutingConfiguration(), hdmap_utils_ptr);
+      traffic_simulator::RoutingConfiguration());
     EXPECT_FALSE(result.has_value());
   }
   {
     const auto result = traffic_simulator::distance::lateralDistance(
-      pose_from, pose_to, traffic_simulator::RoutingConfiguration(), hdmap_utils_ptr);
+      pose_from, pose_to, traffic_simulator::RoutingConfiguration());
     EXPECT_FALSE(result.has_value());
   }
 }
@@ -118,13 +118,13 @@ TEST_F(distanceTest_FourTrackHighwayMap, lateralDistance_possible_noChange)
   {
     const auto result = traffic_simulator::distance::lateralDistance(
       pose_from, pose_to, std::numeric_limits<double>::infinity(),
-      traffic_simulator::RoutingConfiguration(), hdmap_utils_ptr);
+      traffic_simulator::RoutingConfiguration());
     ASSERT_TRUE(result.has_value());
     EXPECT_NEAR(result.value(), 0.0, std::numeric_limits<double>::epsilon());
   }
   {
     const auto result = traffic_simulator::distance::lateralDistance(
-      pose_from, pose_to, traffic_simulator::RoutingConfiguration(), hdmap_utils_ptr);
+      pose_from, pose_to, traffic_simulator::RoutingConfiguration());
     ASSERT_TRUE(result.has_value());
     EXPECT_NEAR(result.value(), 0.0, std::numeric_limits<double>::epsilon());
   }
@@ -146,14 +146,14 @@ TEST_F(distanceTest_FourTrackHighwayMap, lateralDistance_impossible_change)
     lane_changeable_routing_configuration.allow_lane_change = true;
     const auto result = traffic_simulator::distance::lateralDistance(
       pose_from, pose_to, std::numeric_limits<double>::infinity(),
-      lane_changeable_routing_configuration, hdmap_utils_ptr);
+      lane_changeable_routing_configuration);
     EXPECT_FALSE(result.has_value());
   }
   {
     traffic_simulator::RoutingConfiguration lane_changeable_routing_configuration;
     lane_changeable_routing_configuration.allow_lane_change = true;
     const auto result = traffic_simulator::distance::lateralDistance(
-      pose_from, pose_to, lane_changeable_routing_configuration, hdmap_utils_ptr);
+      pose_from, pose_to, lane_changeable_routing_configuration);
     EXPECT_FALSE(result.has_value());
   }
 }
@@ -175,7 +175,7 @@ TEST_F(distanceTest_FourTrackHighwayMap, lateralDistance_possible_change)
     lane_changeable_routing_configuration.allow_lane_change = true;
     const auto result = traffic_simulator::distance::lateralDistance(
       pose_from, pose_to, std::numeric_limits<double>::infinity(),
-      lane_changeable_routing_configuration, hdmap_utils_ptr);
+      lane_changeable_routing_configuration);
     ASSERT_TRUE(result.has_value());
     EXPECT_NEAR(result.value(), approx_distance, tolerance);
   }
@@ -183,7 +183,7 @@ TEST_F(distanceTest_FourTrackHighwayMap, lateralDistance_possible_change)
     traffic_simulator::RoutingConfiguration lane_changeable_routing_configuration;
     lane_changeable_routing_configuration.allow_lane_change = true;
     const auto result = traffic_simulator::distance::lateralDistance(
-      pose_from, pose_to, lane_changeable_routing_configuration, hdmap_utils_ptr);
+      pose_from, pose_to, lane_changeable_routing_configuration);
     ASSERT_TRUE(result.has_value());
     EXPECT_NEAR(result.value(), approx_distance, tolerance);
   }
@@ -203,7 +203,7 @@ TEST_F(distanceTest_FourTrackHighwayMap, lateralDistance_impossible_matching)
     traffic_simulator::RoutingConfiguration lane_changeable_routing_configuration;
     lane_changeable_routing_configuration.allow_lane_change = true;
     const auto result = traffic_simulator::distance::lateralDistance(
-      pose_from, pose_to, 2.0, lane_changeable_routing_configuration, hdmap_utils_ptr);
+      pose_from, pose_to, 2.0, lane_changeable_routing_configuration);
     EXPECT_FALSE(result.has_value());
   }
 }
@@ -222,7 +222,7 @@ TEST_F(distanceTest_FourTrackHighwayMap, lateralDistance_possible_matching)
     traffic_simulator::RoutingConfiguration lane_changeable_routing_configuration;
     lane_changeable_routing_configuration.allow_lane_change = true;
     const auto result = traffic_simulator::distance::lateralDistance(
-      pose_from, pose_to, 3.0, lane_changeable_routing_configuration, hdmap_utils_ptr);
+      pose_from, pose_to, 3.0, lane_changeable_routing_configuration);
     ASSERT_TRUE(result.has_value());
     EXPECT_NEAR(result.value(), -3.0, 0.5);
   }


### PR DESCRIPTION
# Description

## Abstract

This is the partial PR of the HdMapUtils refactor (PR 2/6) ( https://github.com/tier4/scenario_simulator_v2/pull/1478 )

## Details

Replace usage of HdMapUtils::getLateralDistance with non-member function lanelet_wrapper::distance::lateralDistance

## References

- #1478

# Destructive Changes

The hdmap_utils_ptr parameter has been removed from the following functions:

- `traffic_simulator::distance::lateralDistance`
- `traffic_simulator::distance::boundingBoxLaneLateralDistance`

For the rationale behind this change, see #1478.

## Migration Guide
### Before (Old Signature)
``` 
auto lateralDistance(
  const CanonicalizedLaneletPose & from, const CanonicalizedLaneletPose & to,
  const traffic_simulator::RoutingConfiguration & routing_configuration,
  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>;

auto lateralDistance(
  const CanonicalizedLaneletPose & from, const CanonicalizedLaneletPose & to,
  double matching_distance, const traffic_simulator::RoutingConfiguration & routing_configuration,
  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>;

auto boundingBoxLaneLateralDistance(
  const CanonicalizedLaneletPose & from,
  const traffic_simulator_msgs::msg::BoundingBox & from_bounding_box,
  const CanonicalizedLaneletPose & to,
  const traffic_simulator_msgs::msg::BoundingBox & to_bounding_box,
  const traffic_simulator::RoutingConfiguration & routing_configuration,
  const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr) -> std::optional<double>;
```

### After (New Signature)
``` 
auto lateralDistance(
  const CanonicalizedLaneletPose & from, const CanonicalizedLaneletPose & to,
  const traffic_simulator::RoutingConfiguration & routing_configuration,
  const RoutingConfiguration & routing_configuration) -> std::optional<double>;

auto lateralDistance(
  const CanonicalizedLaneletPose & from, const CanonicalizedLaneletPose & to,
  const double matching_distance, const RoutingConfiguration & routing_configuration)
  -> std::optional<double>;

auto boundingBoxLaneLateralDistance(
  const CanonicalizedLaneletPose & from,
  const traffic_simulator_msgs::msg::BoundingBox & from_bounding_box,
  const CanonicalizedLaneletPose & to,
  const traffic_simulator_msgs::msg::BoundingBox & to_bounding_box,
  const RoutingConfiguration & routing_configuration) -> std::optional<double>;
```
 `const std::shared_ptr<hdmap_utils::HdMapUtils> & hdmap_utils_ptr` parameter has been removed.
Remove the `hdmap_utils_ptr` argument from call to `lateralDistance` and `boundingBoxLaneLateralDistance`.


# Known Limitations
None.