### PR TITLE
RJD-1057: Remove some entity type specific functions in EntityManager

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -47,7 +47,7 @@ namespace traffic_simulator
 {
 namespace entity
 {
-class EntityBase
+class EntityBase : public std::enable_shared_from_this<EntityBase>
 {
 public:
   explicit EntityBase(
@@ -68,6 +68,28 @@ public:
   /*   */ auto is() const -> bool
   {
     return dynamic_cast<EntityType const *>(this) != nullptr;
+  }
+
+  template <typename EntityType>
+  /*   */ auto as() -> EntityType &
+  {
+    if (const auto derived_ptr = dynamic_cast<EntityType *>(this); !derived_ptr) {
+      THROW_SEMANTIC_ERROR(
+        "Entity ", std::quoted(name), " is not ", std::quoted(typeid(EntityType).name()), "type");
+    } else {
+      return *derived_ptr;
+    }
+  }
+
+  template <typename EntityType>
+  /*   */ auto as() const -> const EntityType &
+  {
+    if (const auto derived_ptr = dynamic_cast<EntityType const *>(this); !derived_ptr) {
+      THROW_SEMANTIC_ERROR(
+        "Entity ", std::quoted(name), " is not ", std::quoted(typeid(EntityType).name()), "type");
+    } else {
+      return *derived_ptr;
+    }
   }
 
   virtual void appendDebugMarker(visualization_msgs::msg::MarkerArray & /*unused*/);

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/pedestrian_entity.hpp
@@ -112,6 +112,8 @@ public:
 
   auto getRouteLanelets(double horizon = 100) -> lanelet::Ids override;
 
+  auto getParameters() const -> const traffic_simulator_msgs::msg::PedestrianParameters &;
+
   auto getObstacle() -> std::optional<traffic_simulator_msgs::msg::Obstacle> override;
 
   auto getGoalPoses() -> std::vector<CanonicalizedLaneletPose> override;

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
@@ -88,6 +88,8 @@ public:
 
   auto getGoalPoses() -> std::vector<CanonicalizedLaneletPose> override;
 
+  auto getParameters() const -> const traffic_simulator_msgs::msg::VehicleParameters &;
+
   auto getObstacle() -> std::optional<traffic_simulator_msgs::msg::Obstacle> override;
 
   auto getRouteLanelets(double horizon = 100) -> lanelet::Ids override;

--- a/simulation/traffic_simulator/src/entity/entity_manager.cpp
+++ b/simulation/traffic_simulator/src/entity/entity_manager.cpp
@@ -213,7 +213,7 @@ auto EntityManager::getNumberOfEgo() const -> std::size_t
 auto EntityManager::getFirstEgoName() const -> std::optional<std::string>
 {
   for (const auto & [name, entity_ptr] : entities_) {
-    if (entity_ptr->template is<EgoEntity>()) {
+    if (entity_ptr->is<EgoEntity>()) {
       return entity_ptr->getName();
     }
   }
@@ -283,12 +283,12 @@ void EntityManager::resetBehaviorPlugin(
       "Entity :", name, "is MiscObjectEntity.",
       "You cannot reset behavior plugin of MiscObjectEntity.");
   } else if (reference_entity.is<VehicleEntity>()) {
-    const auto parameters = getVehicleParameters(name);
+    const auto parameters = reference_entity.as<VehicleEntity>().getParameters();
     despawnEntity(name);
     spawnEntity<VehicleEntity>(
       name, status.getMapPose(), parameters, status.getTime(), behavior_plugin_name);
   } else if (reference_entity.is<PedestrianEntity>()) {
-    const auto parameters = getPedestrianParameters(name);
+    const auto parameters = reference_entity.as<PedestrianEntity>().getParameters();
     despawnEntity(name);
     spawnEntity<PedestrianEntity>(
       name, status.getMapPose(), parameters, status.getTime(), behavior_plugin_name);
@@ -323,7 +323,7 @@ auto EntityManager::updateNpcLogic(
   if (npc_logic_started_) {
     entity.onUpdate(current_time, step_time);
   } else if (entity.is<entity::EgoEntity>()) {
-    getEgoEntity(name).updateFieldOperatorApplication();
+    entity.as<EgoEntity>().updateFieldOperatorApplication();
   }
   return entity.getCanonicalizedStatus();
 }

--- a/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/pedestrian_entity.cpp
@@ -174,6 +174,12 @@ void PedestrianEntity::setTrafficLights(
   behavior_plugin_ptr_->setTrafficLights(traffic_lights_);
 }
 
+auto PedestrianEntity::getParameters() const
+  -> const traffic_simulator_msgs::msg::PedestrianParameters &
+{
+  return pedestrian_parameters;
+}
+
 auto PedestrianEntity::getBehaviorParameter() const
   -> traffic_simulator_msgs::msg::BehaviorParameter
 {

--- a/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
@@ -81,6 +81,11 @@ auto VehicleEntity::getDefaultMatchingDistanceForLaneletPoseCalculation() const 
          1.5;
 }
 
+auto VehicleEntity::getParameters() const -> const traffic_simulator_msgs::msg::VehicleParameters &
+{
+  return vehicle_parameters;
+}
+
 auto VehicleEntity::getBehaviorParameter() const -> traffic_simulator_msgs::msg::BehaviorParameter
 {
   return behavior_plugin_ptr_->getBehaviorParameter();


### PR DESCRIPTION
## Abstract

This is a partial pull request of #1334

This PR will remove some entity type specific functions in EntityManager.
Removed: `getPedestrianParameters`, `getVehicleParameters`

## Details

This PR add `as<T>()` to EntityBase like interpreter implementation.
It removes some functions that perform search by name, and will improve performance.

## References

#1334

# Destructive Changes

Remove some functions: `getPedestrianParameters`, `getVehicleParameters`