### PR TITLE
Renamed getStopLineIds to stopLineIds to revive functionality.

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/lanelet_wrapper/lanelet_map.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/lanelet_wrapper/lanelet_map.hpp
@@ -104,7 +104,13 @@ auto toPolygon(const lanelet::ConstLineString3d & line_string) -> std::vector<Po
 auto trafficSignsOnPath(const lanelet::Ids & lanelet_ids)
   -> std::vector<std::shared_ptr<const lanelet::TrafficSign>>;
 
+auto trafficSigns() -> std::vector<std::shared_ptr<const lanelet::TrafficSign>>;
+
+auto stopLines() -> lanelet::ConstLineStrings3d;
+
 auto stopLinesOnPath(const lanelet::Ids & lanelet_ids) -> lanelet::ConstLineStrings3d;
+
+auto stopLineIds() -> lanelet::Ids;
 
 auto stopLineIdsOnPath(const lanelet::Ids & lanelet_ids) -> lanelet::Ids;
 }  // namespace lanelet_map

--- a/simulation/traffic_simulator/src/lanelet_wrapper/lanelet_map.cpp
+++ b/simulation/traffic_simulator/src/lanelet_wrapper/lanelet_map.cpp
@@ -279,6 +279,31 @@ auto trafficSignsOnPath(const lanelet::Ids & lanelet_ids)
   return ret;
 }
 
+auto trafficSigns() -> std::vector<std::shared_ptr<const lanelet::TrafficSign>>
+{
+  std::vector<std::shared_ptr<const lanelet::TrafficSign>> ret;
+  for (const auto & lanelet_id : laneletIds()) {
+    const auto lanelet = LaneletWrapper::map()->laneletLayer.get(lanelet_id);
+    const auto traffic_signs = lanelet.regulatoryElementsAs<const lanelet::TrafficSign>();
+    for (const auto & traffic_sign : traffic_signs) {
+      ret.push_back(traffic_sign);
+    }
+  }
+  return ret;
+}
+
+auto stopLines() -> lanelet::ConstLineStrings3d
+{
+  lanelet::ConstLineStrings3d stop_lines;
+  for (const auto & traffic_sign : lanelet_wrapper::lanelet_map::trafficSigns()) {
+    if (traffic_sign->type() == "stop_sign") {
+      const auto & ref_lines = traffic_sign->refLines();
+      stop_lines.insert(stop_lines.end(), ref_lines.begin(), ref_lines.end());
+    }
+  }
+  return stop_lines;
+}
+
 auto stopLinesOnPath(const lanelet::Ids & lanelet_ids) -> lanelet::ConstLineStrings3d
 {
   lanelet::ConstLineStrings3d stop_lines;
@@ -289,6 +314,17 @@ auto stopLinesOnPath(const lanelet::Ids & lanelet_ids) -> lanelet::ConstLineStri
     }
   }
   return stop_lines;
+}
+
+auto stopLineIds() -> lanelet::Ids
+{
+  lanelet::Ids stop_line_ids;
+  const auto & stop_lines = stopLines();
+  stop_line_ids.reserve(stop_lines.size());
+  for (const auto & ret : stop_lines) {
+    stop_line_ids.push_back(ret.id());
+  }
+  return stop_line_ids;
 }
 
 auto stopLineIdsOnPath(const lanelet::Ids & lanelet_ids) -> lanelet::Ids

--- a/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
+++ b/simulation/traffic_simulator/test/src/hdmap_utils/test_hdmap_utils.cpp
@@ -2293,6 +2293,30 @@ TEST_F(HdMapUtilsTest_StandardMap, getStopLineIdsOnPath_empty)
 }
 
 /**
+ * @note Test obtaining stop line ids for a standard map.
+ */
+TEST_F(HdMapUtilsTest_StandardMap, stopLineIds_standardMap)
+{
+  EXPECT_EQ(traffic_simulator::lanelet_wrapper::lanelet_map::stopLineIds(), (lanelet::Ids{120635}));
+}
+
+/**
+ * @note Test obtaining stop line ids for an intersection map.
+ */
+TEST_F(HdMapUtilsTest_IntersectionMap, stopLineIds_intersectionMap)
+{
+  EXPECT_EQ(traffic_simulator::lanelet_wrapper::lanelet_map::stopLineIds(), (lanelet::Ids{6960}));
+}
+
+/**
+ * @note Test function behavior when used with an empty map.
+ */
+TEST_F(HdMapUtilsTest_EmptyMap, stopLineIds_emptyMap)
+{
+  EXPECT_THROW(traffic_simulator::lanelet_wrapper::lanelet_map::stopLineIds(), std::runtime_error);
+}
+
+/**
  * @note Test basic functionality.
  * Test obtaining traffic light stop line ids
  * correctness with a traffic light that has one stop line.


### PR DESCRIPTION
## Abstract

This Pull Request restores a function that was mistakenly deleted. During the restoration, the code has been refactored.

## Background

The getStopLineIds function, which was removed in the commit below, has been restored as stopLineIds.

- https://github.com/tier4/scenario_simulator_v2/commit/8e01a8195080a128d35a62ba2529ca3ecc99b598

## Details

N/A

## References

- https://github.com/tier4/scenario_simulator_v2/commit/8e01a8195080a128d35a62ba2529ca3ecc99b598
- https://github.com/tier4/scenario_simulator_v2/pull/1538

# Destructive Changes

N/A

# Known Limitations

N/A
