### PR TITLE
Add remote context_gamma_planner build test.

### DIFF
--- a/.github/workflows/DispatchTrigger.yaml
+++ b/.github/workflows/DispatchTrigger.yaml
@@ -1,0 +1,42 @@
+name: Repository Dispatch Trigger
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ "master" ]
+  push:
+    branches: [ "master" ]
+
+jobs:
+  trigger-repository-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Repository and Branch Info
+        id: set_repo_branch_info
+        run: |
+          echo "TARGET_REPOSITORY=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            echo "TARGET_BRANCH=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          else
+            echo "TARGET_BRANCH=${GITHUB_SHA}" >> $GITHUB_ENV
+          fi
+
+      - name: Print Dispatch Data
+        run: |
+          echo "Dispatch Event Data:"
+          echo "Branch: ${{ env.TARGET_BRANCH }}"
+          echo "Repository: ${{ env.TARGET_REPOSITORY }}"
+
+      - name: Send Repository Dispatch Event
+        run: |
+          DISPATCH_OWNER=tier4
+          DISPATCH_REPOSITORY=context_gamma_planner
+          TARGET_BRANCH=${{ env.TARGET_BRANCH }}
+          TARGET_REPOSITORY=${{ env.TARGET_REPOSITORY }}
+
+          curl --fail \
+            -X POST \
+            -H "Authorization: token ${{ secrets.BLOOM_GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/$DISPATCH_OWNER/$DISPATCH_REPOSITORY/dispatches \
+            -d "{\"event_type\":\"on-demand-test\",\"client_payload\":{\"ref\":\"$TARGET_BRANCH\",\"repo\":\"$TARGET_REPOSITORY\"}}"


### PR DESCRIPTION
## Abstract

This PR adds a test to remotely run build tests for `context_gamma_planner`.


## Background

It serves as a CI to check that there are no breaking changes in SSv2, a privately maintained dependency of `context_gamma_planner`.


## Details

When this CI is triggered, the hash of the triggering source (e.g., a commit pushed to a PR or to the master branch) is sent and used for building and testing together.

## References

- https://github.com/tier4/context_gamma_planner/blob/master/.github/workflows/dispatch-build.yml
- https://github.com/tier4/context_gamma_planner/pull/106
- https://github.com/tier4/context_gamma_planner/actions/runs/14074333158

# Destructive Changes

N/A

# Known Limitations

N/A
