### PR TITLE
[Do not merge!!!] Keep previous route lanelet

### DIFF
--- a/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/vehicle_entity.cpp
@@ -110,7 +110,26 @@ auto VehicleEntity::getObstacle() -> std::optional<traffic_simulator_msgs::msg::
 auto VehicleEntity::getRouteLanelets(double horizon) -> lanelet::Ids
 {
   if (const auto canonicalized_lanelet_pose = status_->getCanonicalizedLaneletPose()) {
-    return route_planner_.getRouteLanelets(canonicalized_lanelet_pose.value(), horizon);
+    // WARNING: TEMPORARY FIX ##################################################################################
+    // temporary fix to avoid the error of getRouteLanelets
+    auto canonicalized_lanelet_pose_value = canonicalized_lanelet_pose.value();
+    if (previous_route_lanelets_.size() > 0) {
+      if (
+        std::find(
+          previous_route_lanelets_.begin(), previous_route_lanelets_.end(),
+          canonicalized_lanelet_pose_value.getLaneletId()) == previous_route_lanelets_.end()) {
+        // set previous lanelet as current lanelet
+        CanonicalizedLaneletPose previous_pose =
+          toCanonicalizedLaneletPose(
+            status_->getMapPose(), status_->getBoundingBox(), previous_route_lanelets_, false,
+            getDefaultMatchingDistanceForLaneletPoseCalculation())
+            .value();
+        return previous_route_lanelets_;
+      }
+    }
+    return route_planner_.getRouteLanelets(canonicalized_lanelet_pose_value, horizon);
+    // #########################################################################################################
+    // return route_planner_.getRouteLanelets(canonicalized_lanelet_pose.value(), horizon);
   } else {
     return {};
   }


### PR DESCRIPTION
# Description

## Abstract

This PR changes the behavior of function
`traffic_simulator::entity::VehicleEntity::getRouteLanelets`

## Background

While integrating [this](https://github.com/tier4/scenario_simulator_v2/pull/1460) feature, the behavior of entity became insufficient. The refactor was done but this block was out of `context_gamma_planner` so is detached as different PR.

## Details

The function `getRouteLanelets` used to just return the value of `getRouteLanelets` function in `traffic_simulator::RoutePlanner` when `canonicalized_lanelet_pose` had a value. 

In this PR, this function's behavior was changed to keep returning the previous route lanelets if the new current lanelet pose is not in the previous route lanelets.

While integrating the feature `context_gamma_planner`, the vehicle's current lanelet was not appropriate and made the vehicle oscillate at the cross. This was due to that even if the vehicle was going straight the entity's lanelet pose was determined as the lane left or right. This also happens when you tries to go right or left. 

To avoid this problem, we kept the the same route lanelet when the entity seems to be not in the right lanelet.

## References

https://github.com/tier4/scenario_simulator_v2/pull/1460

# Destructive Changes

It might affect to various features, such as when the map is incredibly complicated.

# Known Limitations

None