### PR TITLE
fix: add workaround to avoid build CI fail due to tinyxml2

### DIFF
--- a/simulation/traffic_simulator/CMakeLists.txt
+++ b/simulation/traffic_simulator/CMakeLists.txt
@@ -23,6 +23,22 @@ find_package(tinyxml2_vendor REQUIRED)
 find_package(pluginlib REQUIRED)
 include(FindProtobuf REQUIRED)
 
+# TODO(HansRobo): Remove this workaround once https://github.com/autowarefoundation/autoware_universe/issues/10410 is fixed
+find_package(TinyXML2 CONFIG QUIET)
+if(NOT TinyXML2_FOUND)
+  find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h)
+  find_library(TINYXML2_LIBRARY tinyxml2)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
+  mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
+  if(NOT TARGET tinyxml2::tinyxml2)
+    add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
+    set_property(TARGET tinyxml2::tinyxml2 PROPERTY IMPORTED_LOCATION ${TINYXML2_LIBRARY})
+    set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${TINYXML2_INCLUDE_DIR})
+    list(APPEND TinyXML2_TARGETS tinyxml2::tinyxml2)
+  endif()
+endif()
+
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(traffic_simulator SHARED

--- a/simulation/traffic_simulator/CMakeLists.txt
+++ b/simulation/traffic_simulator/CMakeLists.txt
@@ -23,22 +23,6 @@ find_package(tinyxml2_vendor REQUIRED)
 find_package(pluginlib REQUIRED)
 include(FindProtobuf REQUIRED)
 
-# TODO(HansRobo): Remove this workaround once https://github.com/autowarefoundation/autoware_universe/issues/10410 is fixed
-find_package(TinyXML2 CONFIG QUIET)
-if(NOT TinyXML2_FOUND)
-  find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h)
-  find_library(TINYXML2_LIBRARY tinyxml2)
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
-  mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
-  if(NOT TARGET tinyxml2::tinyxml2)
-    add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
-    set_property(TARGET tinyxml2::tinyxml2 PROPERTY IMPORTED_LOCATION ${TINYXML2_LIBRARY})
-    set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${TINYXML2_INCLUDE_DIR})
-    list(APPEND TinyXML2_TARGETS tinyxml2::tinyxml2)
-  endif()
-endif()
-
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(traffic_simulator SHARED

--- a/test_runner/random_test_runner/CMakeLists.txt
+++ b/test_runner/random_test_runner/CMakeLists.txt
@@ -35,6 +35,22 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 include(FindProtobuf REQUIRED)
 
+# TODO(HansRobo): Remove this workaround once https://github.com/autowarefoundation/autoware_universe/issues/10410 is fixed
+find_package(TinyXML2 CONFIG QUIET)
+if(NOT TinyXML2_FOUND)
+  find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h)
+  find_library(TINYXML2_LIBRARY tinyxml2)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
+  mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
+  if(NOT TARGET tinyxml2::tinyxml2)
+    add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
+    set_property(TARGET tinyxml2::tinyxml2 PROPERTY IMPORTED_LOCATION ${TINYXML2_LIBRARY})
+    set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${TINYXML2_INCLUDE_DIR})
+    list(APPEND TinyXML2_TARGETS tinyxml2::tinyxml2)
+  endif()
+endif()
+
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED


### PR DESCRIPTION
# Description

## Abstract

To avoid cmake error related to `tinyxml2_vendor`, this workaround is introduced.
This workaround is not elegant and is temporary.
If better solution is found, this workaround is withdrew and replaced.



## Background

https://github.com/tier4/scenario_simulator_v2/actions/workflows/BuildAndRun.yaml

All of `BuildAndRun` executions are failed from April 7th due to the CMake errors like below. 

```bash
Starting >>> random_test_runner
--- stderr: random_test_runner
CMake Error at /opt/ros/humble/share/tinyxml2_vendor/cmake/tinyxml2_vendor-extras.cmake:23 (message):
  Unable to extract the library file path from
Call Stack (most recent call first):
  /opt/ros/humble/share/tinyxml2_vendor/cmake/tinyxml2_vendorConfig.cmake:41 (include)
  /__w/scenario_simulator_v2/scenario_simulator_v2/install/traffic_simulator/share/traffic_simulator/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package)
  /__w/scenario_simulator_v2/scenario_simulator_v2/install/traffic_simulator/share/traffic_simulator/cmake/traffic_simulatorConfig.cmake:41 (include)
  /opt/ros/humble/share/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake:67 (find_package)
  CMakeLists.txt:38 (ament_auto_find_build_dependencies)


---
Failed   <<< random_test_runner [4.80s, exited with code 1]
```

## References

Same workaround was introduced in autoware ( this pull-request was affected by the pull-request  )
https://github.com/autowarefoundation/autoware_cmake/pull/24

Continuous discussions are here for this issue. I'll be keeping an my eye on this issue.
https://github.com/autowarefoundation/autoware_universe/issues/10410

# Destructive Changes

None

# Known Limitations

As I said, it's a temporary fix and not perfect.