### PR TITLE
Add find_package(zmpqq_vendor) to fix zmqpp/zmqpp.hpp not found error

### DIFF
--- a/simulation/simulation_interface/CMakeLists.txt
+++ b/simulation/simulation_interface/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 find_package(Boost REQUIRED thread)
 find_package(rclcpp REQUIRED)
+find_package(zmqpp_vendor REQUIRED)
 include(FindProtobuf REQUIRED)
 ament_auto_find_build_dependencies()
 


### PR DESCRIPTION
When trying to build `simulation_interface` package, it fails on `zmqpp/zmqpp.hpp` not found error. It can be reproduced in the official Docker image.

```sh
rocker --volume $PWD:/monut -- ghcr.io/autowarefoundation/autoware:universe-devel-cuda-20250205-amd64
cd /mount
colcon build
```

It is fixed by adding `find_package(zmqpp_vendor REQUIRED)` to the `CMakeLists.txt` file.

