### PR TITLE
chore: add `xmlschema` workaround to `BuildAndRun.yaml`

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Install dependencies
         run: |
           vcs import src < src/scenario_simulator_v2/dependency_${{ matrix.rosdistro }}.repos
-      
+
       - name: Resolve rosdep and install colcon mixin
         run: |
           apt-get update


### PR DESCRIPTION
# Description



## Abstract

To run `openscenario_utility` correctly, use `xmlschema` 3.4.5.

## Background

With `xmlschema` >= 4.0.0, the errors like below are occured.

https://github.com/tier4/scenario_simulator_v2/actions/runs/14435381683/job/40475549963#step:16:2278
```bash
[scenario_test_runner.py-1] Error: failed validating '1' with XsdPatternFacets(['[$][{][ A-Za-z0-9_\\+\\-\\*/%$\\(\\)\\.,]*[\\}]']):
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Reason: value doesn't match any pattern of ['[$][{][ A-Za-z0-9_\\+\\-\\*/%$\\(\\)\\.,]*[\\}]']
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Schema component:
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1]   <xsd:pattern xmlns:xsd="http://www.w3.org/2001/XMLSchema" value="[$][{][ A-Za-z0-9_\+\-\*/%$\(\)\.,]*[\}]" />
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Instance type: <class 'xml.etree.ElementTree.Element'>
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Instance:
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1]   <FileHeader description="Scenario where test collision conditions by type" author="abco20" date="2024-10-17T05:57:14.376Z" revMajor="1" revMinor="0" />
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Path: /OpenSCENARIO/FileHeader
[scenario_test_runner.py-1] 
```

## References


# Destructive Changes

None

# Known Limitations

This is a just fix for build CI only.
And this doesn't fix errors on Autoware Evaluator, any local environment.
