### PR TITLE
fix(openscenario_interpreter): Prevent data race in callback and get()

### DIFF
--- a/openscenario/openscenario_interpreter/src/syntax/user_defined_value_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/user_defined_value_condition.cpp
@@ -88,8 +88,7 @@ struct MagicSubscription : private T
     }
 
     subscription = node->template create_subscription<T>(
-      topic_name, rclcpp::QoS(1).best_effort(),
-      [this](const typename T::SharedPtr message) {
+      topic_name, rclcpp::QoS(1).best_effort(), [this](const typename T::SharedPtr message) {
         std::lock_guard<std::mutex> lock(data_mutex);
         static_cast<T &>(*this) = *message;
       });

--- a/openscenario/openscenario_interpreter/src/syntax/user_defined_value_condition.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/user_defined_value_condition.cpp
@@ -38,7 +38,8 @@ struct MagicSubscription : private T
   {
     std::atomic_bool stop_requested = false;
 
-    std::mutex mutex;
+    /// @note Synchronizes access to `thrown` to avoid data races between spin thread and rethrow().
+    std::mutex exception_mutex;
 
     std::exception_ptr thrown;
 
@@ -50,7 +51,7 @@ struct MagicSubscription : private T
           try {
             rclcpp::spin_some(get_node_base_interface());
           } catch (...) {
-            auto lock = std::lock_guard(mutex);
+            auto lock = std::lock_guard(exception_mutex);
             thrown = std::current_exception();
           }
         }
@@ -67,7 +68,7 @@ struct MagicSubscription : private T
 
     auto rethrow()
     {
-      if (auto lock = std::lock_guard(mutex); thrown) {
+      if (auto lock = std::lock_guard(exception_mutex); thrown) {
         std::rethrow_exception(thrown);
       }
     }
@@ -79,7 +80,9 @@ struct MagicSubscription : private T
 
   typename rclcpp::Subscription<T>::SharedPtr subscription;
 
-  mutable std::mutex data_mutex;
+  /// @note Protects access to the stored message,
+  /// ensuring get() and callback() are synchronized.
+  mutable std::mutex message_mutex;
 
   explicit MagicSubscription(const std::string & topic_name)
   {
@@ -89,7 +92,7 @@ struct MagicSubscription : private T
 
     subscription = node->template create_subscription<T>(
       topic_name, rclcpp::QoS(1).best_effort(), [this](const typename T::SharedPtr message) {
-        std::lock_guard<std::mutex> lock(data_mutex);
+        std::lock_guard<std::mutex> lock(message_mutex);
         static_cast<T &>(*this) = *message;
       });
   }
@@ -101,11 +104,11 @@ struct MagicSubscription : private T
     }
   }
 
-  auto get() const -> const T
+  auto get() const -> T
   {
     node->rethrow();
-    std::lock_guard<std::mutex> lock(data_mutex);
-    return static_cast<T>(*this);
+    std::lock_guard<std::mutex> lock(message_mutex);
+    return static_cast<const T &>(*this);
   }
 };
 


### PR DESCRIPTION
# Description

This PR resolves a data race in MagicSubscription<T>, which occurred when one thread accessed the internal data (e.g., by casting a UserDefinedValue to double) while another thread was concurrently receiving and writing new data from a ROS 2 topic. The fix introduces synchronization using std::mutex, ensuring safe access to the shared state.

## Abstract

Fix data race in `MagicSubscription<T>::get()` and subscription callback by introducing mutex-based synchronization.

## Background

## Details

- Previously, get() returned data via static_cast<const T&>(*this) without locking, which could race with the callback.
- The callback copied data into the object via static_cast<T&>(*this) = *message, but it could still race with concurrent get().
- This PR introduces a std::mutex data_mutex and locks it in both the callback and get().

## References

Jira: [link](https://tier4.atlassian.net/browse/RJD-1679)

# Destructive Changes

N/A

# Known Limitations

N/A
