### PR TITLE
RJD-1057: Small refactor for simulator API

### DIFF
--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -77,8 +77,7 @@ public:
       return NativeLanePosition(non_canonicalized);
     }
 
-    template <typename T, typename std::enable_if_t<std::is_same_v<T, NativeLanePosition>, int> = 0>
-    static auto convert(const NativeWorldPosition & pose) -> NativeLanePosition
+    static auto convertToNativeLanePosition(const NativeWorldPosition & pose) -> NativeLanePosition
     {
       constexpr bool include_crosswalk{false};
       if (
@@ -98,11 +97,10 @@ public:
       }
     }
 
-    template <
-      typename T, typename std::enable_if_t<std::is_same_v<T, NativeWorldPosition>, int> = 0>
-    static auto convert(const NativeLanePosition & native_lane_position) -> NativeWorldPosition
+    static auto convertToNativeWorldPosition(const NativeLanePosition & lanelet_pose)
+      -> NativeWorldPosition
     {
-      return traffic_simulator::pose::toMapPose(native_lane_position);
+      return traffic_simulator::pose::toMapPose(lanelet_pose);
     }
 
     static auto makeNativeRelativeWorldPosition(

--- a/openscenario/openscenario_interpreter/src/syntax/add_entity_action.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/add_entity_action.cpp
@@ -141,28 +141,30 @@ try {
       TeleportAction::teleport(entity_ref, position);
     },
     [&](const MiscObject & misc_object) {
+      /// @note for MiscObject BehaviorTree is not run, so an empty string is passed
+      const auto behavior_name = "";
       if (position.is<WorldPosition>()) {
         applyAddEntityAction(
           entity_ref, static_cast<NativeWorldPosition>(position.as<WorldPosition>()),
           static_cast<traffic_simulator_msgs::msg::MiscObjectParameters>(misc_object),
-          misc_object.model3d);
+          behavior_name, misc_object.model3d);
       } else if (position.is<RelativeWorldPosition>()) {
         applyAddEntityAction(
           entity_ref,
           static_cast<NativeRelativeWorldPosition>(position.as<RelativeWorldPosition>()),
           static_cast<traffic_simulator_msgs::msg::MiscObjectParameters>(misc_object),
-          misc_object.model3d);
+          behavior_name, misc_object.model3d);
       } else if (position.is<RelativeObjectPosition>()) {
         applyAddEntityAction(
           entity_ref,
           static_cast<NativeRelativeWorldPosition>(position.as<RelativeObjectPosition>()),
           static_cast<traffic_simulator_msgs::msg::MiscObjectParameters>(misc_object),
-          misc_object.model3d);
+          behavior_name, misc_object.model3d);
       } else if (position.is<LanePosition>()) {
         applyAddEntityAction(
           entity_ref, static_cast<NativeLanePosition>(position.as<LanePosition>()),
           static_cast<traffic_simulator_msgs::msg::MiscObjectParameters>(misc_object),
-          misc_object.model3d);
+          behavior_name, misc_object.model3d);
       } else {
         throw common::Error(__FILE__);
       }

--- a/openscenario/openscenario_interpreter/src/syntax/lane_position.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/lane_position.cpp
@@ -51,7 +51,7 @@ LanePosition::operator NativeLanePosition() const
 
 LanePosition::operator NativeWorldPosition() const
 {
-  return convert<NativeWorldPosition>(static_cast<NativeLanePosition>(*this));
+  return convertToNativeWorldPosition(static_cast<NativeLanePosition>(*this));
 }
 }  // namespace syntax
 }  // namespace openscenario_interpreter

--- a/openscenario/openscenario_interpreter/src/syntax/relative_object_position.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/relative_object_position.cpp
@@ -44,7 +44,7 @@ RelativeObjectPosition::operator geometry_msgs::msg::Point() const
 
 RelativeObjectPosition::operator NativeLanePosition() const
 {
-  return convert<NativeLanePosition>(static_cast<NativeWorldPosition>(*this));
+  return convertToNativeLanePosition(static_cast<NativeWorldPosition>(*this));
 }
 
 RelativeObjectPosition::operator NativeWorldPosition() const

--- a/openscenario/openscenario_interpreter/src/syntax/world_position.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/world_position.cpp
@@ -33,7 +33,7 @@ WorldPosition::WorldPosition(const pugi::xml_node & node, Scope & scope)
 
 WorldPosition::operator NativeLanePosition() const
 {
-  return convert<NativeLanePosition>(static_cast<NativeWorldPosition>(*this));
+  return convertToNativeLanePosition(static_cast<NativeWorldPosition>(*this));
 }
 
 WorldPosition::operator NativeWorldPosition() const

--- a/simulation/traffic_simulator/include/traffic_simulator/helper/ostream_helpers.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/helper/ostream_helpers.hpp
@@ -38,7 +38,10 @@ std::ostream & operator<<(std::ostream & os, const geometry_msgs::msg::Quaternio
 std::ostream & operator<<(std::ostream & os, const geometry_msgs::msg::Pose & pose);
 
 std::ostream & operator<<(
-  std::ostream & os, const traffic_simulator_msgs::msg::LaneletPose & ll_pose);
+  std::ostream & os, const traffic_simulator_msgs::msg::LaneletPose & lanelet_pose);
+
+std::ostream & operator<<(
+  std::ostream & os, const std::vector<traffic_simulator_msgs::msg::LaneletPose> & lanelet_pose);
 
 std::ostream & operator<<(
   std::ostream & os, const traffic_simulator_msgs::msg::EntitySubtype & subtype);

--- a/simulation/traffic_simulator/src/helper/helper.cpp
+++ b/simulation/traffic_simulator/src/helper/helper.cpp
@@ -54,15 +54,14 @@ auto constructCanonicalizedLaneletPose(
   lanelet::Id lanelet_id, double s, double offset, double roll, double pitch, double yaw)
   -> CanonicalizedLaneletPose
 {
-  if (
-    auto canonicalized_lanelet_pose = pose::toCanonicalizedLaneletPose(
-      traffic_simulator::helper::constructLaneletPose(lanelet_id, s, offset, roll, pitch, yaw))) {
+  const auto & lanelet_pose =
+    traffic_simulator::helper::constructLaneletPose(lanelet_id, s, offset, roll, pitch, yaw);
+  if (auto canonicalized_lanelet_pose = pose::toCanonicalizedLaneletPose(lanelet_pose)) {
     return canonicalized_lanelet_pose.value();
   } else {
-    THROW_SEMANTIC_ERROR(
-      "Lanelet pose (id=", lanelet_id, ",s=", s, ",offset=", offset, ",rpy.x=", roll,
-      ",rpy.y=", pitch, ",rpy.z=", yaw,
-      ") is invalid, please check lanelet length and connection.");
+    std::ostringstream oss;
+    oss << lanelet_pose;
+    THROW_SEMANTIC_ERROR(oss.str(), " is invalid, please check lanelet length and connection.");
   }
 }
 

--- a/simulation/traffic_simulator/src/helper/ostream_helpers.cpp
+++ b/simulation/traffic_simulator/src/helper/ostream_helpers.cpp
@@ -55,6 +55,15 @@ std::ostream & operator<<(
 }
 
 std::ostream & operator<<(
+  std::ostream & os, const std::vector<traffic_simulator_msgs::msg::LaneletPose> & lanelet_poses)
+{
+  for (size_t i = 0; i < lanelet_poses.size(); ++i) {
+    os << "[" << i << "] " << lanelet_poses[i] << std::endl;
+  }
+  return os;
+}
+
+std::ostream & operator<<(
   std::ostream & os, const traffic_simulator_msgs::msg::EntitySubtype & subtype)
 {
   using EntitySubtype = traffic_simulator_msgs::msg::EntitySubtype;

--- a/simulation/traffic_simulator/src/utils/pose.cpp
+++ b/simulation/traffic_simulator/src/utils/pose.cpp
@@ -61,10 +61,9 @@ auto canonicalize(const LaneletPose & lanelet_pose) -> LaneletPose
       lanelet_wrapper::pose::canonicalizeLaneletPose(lanelet_pose))) {
     return canonicalized.value();
   } else {
-    THROW_SEMANTIC_ERROR(
-      "Lanelet pose (id=", lanelet_pose.lanelet_id, ",s=", lanelet_pose.s,
-      ",offset=", lanelet_pose.offset, ",rpy.x=", lanelet_pose.rpy.x, ",rpy.y=", lanelet_pose.rpy.y,
-      ",rpy.z=", lanelet_pose.rpy.z, ") is invalid, please check lanelet length and connection.");
+    std::ostringstream oss;
+    oss << lanelet_pose;
+    THROW_SEMANTIC_ERROR(oss.str(), " is invalid, please check lanelet length and connection.");
   }
 }
 
@@ -76,11 +75,10 @@ auto canonicalize(const LaneletPose & lanelet_pose, const lanelet::Ids & route_l
       lanelet_wrapper::pose::canonicalizeLaneletPose(lanelet_pose, route_lanelets))) {
     return canonicalized.value();
   } else {
+    std::ostringstream oss;
+    oss << lanelet_pose;
     THROW_SEMANTIC_ERROR(
-      "Lanelet pose (id=", lanelet_pose.lanelet_id, ",s=", lanelet_pose.s,
-      ",offset=", lanelet_pose.offset, ",rpy.x=", lanelet_pose.rpy.x, ",rpy.y=", lanelet_pose.rpy.y,
-      ",rpy.z=", lanelet_pose.rpy.z,
-      ") is invalid, please check lanelet length, connection and entity route.");
+      oss.str(), " is invalid, please check lanelet length, connection and entity route.");
   }
 }
 


### PR DESCRIPTION
# Description
## Abstract

Small refactor for simulator API.
Includes:

- Reduce `xs...` parameter pack usage in simulator_core.hpp for readability
- Reduce template usage in coordinate conversion
- Use outputstream helper functions for some error messages

## References

This is a partial PR of #1337.

# Destructive Changes

`convert<T>` API in  simulator_core.hpp is removed