### PR TITLE
Update pedestrian consideration to factor in distance from ego vehicle

### DIFF
--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_lane_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_lane_action.hpp
@@ -19,6 +19,7 @@
 #include <behaviortree_cpp_v3/bt_factory.h>
 
 #include <behavior_tree_plugin/pedestrian/pedestrian_action_node.hpp>
+#include <geometry/vector3/norm.hpp>
 #include <geometry/vector3/operator.hpp>
 #include <get_parameter/get_parameter.hpp>
 #include <memory>

--- a/simulation/behavior_tree_plugin/src/pedestrian/follow_lane_action.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/follow_lane_action.cpp
@@ -53,22 +53,33 @@ bool FollowLaneAction::detectObstacleInLane(
     return false;
   }
 
-  auto hasObstacleInPedestrianLanes = [this](const lanelet::Ids pedestrian_lanes_local) {
-    lanelet::Ids other_entity_lane_ids;
-    for (const auto & [_, status] : other_entity_status) {
-      if (status.isInLanelet()) {
+  auto hasObstacleInPedestrianLanes =
+    [this](const lanelet::Ids pedestrian_lanes_local, const double max_detect_length) {
+      using math::geometry::operator-;
+      const auto & pedestrian_position = canonicalized_entity_status->getMapPose().position;
+      lanelet::Ids other_entity_lane_ids;
+      for (const auto & [_, status] : other_entity_status) {
+        if (status.getType().type != traffic_simulator_msgs::msg::EntityType::EGO) {
+          continue;
+        }
+        if (!status.isInLanelet()) {
+          continue;
+        }
+        const auto norm = math::geometry::norm(status.getMapPose().position - pedestrian_position);
+        if (!(norm < max_detect_length)) {
+          continue;
+        }
         other_entity_lane_ids.push_back(status.getLaneletId());
       }
-    }
-    std::unordered_set<lanelet::Id> other_lane_id_set(
-      other_entity_lane_ids.begin(), other_entity_lane_ids.end());
-    for (const auto & pedestrian_lane : pedestrian_lanes_local) {
-      if (other_lane_id_set.count(pedestrian_lane)) {
-        return true;
+      std::unordered_set<lanelet::Id> other_lane_id_set(
+        other_entity_lane_ids.begin(), other_entity_lane_ids.end());
+      for (const auto & pedestrian_lane : pedestrian_lanes_local) {
+        if (other_lane_id_set.count(pedestrian_lane)) {
+          return true;
+        }
       }
-    }
-    return false;
-  };
+      return false;
+    };
 
   auto hasObstacleInFrontOfPedestrian = [this]() {
     using math::geometry::operator-;
@@ -86,7 +97,7 @@ bool FollowLaneAction::detectObstacleInLane(
     return false;
   };
 
-  if (hasObstacleInPedestrianLanes(pedestrian_lanes) && hasObstacleInFrontOfPedestrian()) {
+  if (hasObstacleInPedestrianLanes(pedestrian_lanes, 40) && hasObstacleInFrontOfPedestrian()) {
     return true;
   } else {
     return false;

--- a/simulation/behavior_tree_plugin/src/pedestrian/follow_lane_action.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/follow_lane_action.cpp
@@ -97,7 +97,7 @@ bool FollowLaneAction::detectObstacleInLane(
     return false;
   };
 
-  if (hasObstacleInPedestrianLanes(pedestrian_lanes, 40) && hasObstacleInFrontOfPedestrian()) {
+  if (hasObstacleInPedestrianLanes(pedestrian_lanes, 10) && hasObstacleInFrontOfPedestrian()) {
     return true;
   } else {
     return false;


### PR DESCRIPTION
## Abstract

This pull request enhances pedestrian obstacle detection by adding a maximum detection range, so that only pedestrians within a specified distance from the ego vehicle are considered when evaluating lane obstacles.

## Background

The previous implementation only checked whether a pedestrian occupied a lane and was ahead, causing the vehicle to react even to distant pedestrians. This could lead to unnecessary stops or unnatural behavior. Introducing a distance threshold ensures more realistic and efficient obstacle detection.


## Details

- Extended the signature of the `hasObstacleInPedestrianLanes` lambda to accept a new parameter, `max_detect_length` (maximum detection distance).

- Calculated the Euclidean distance between the ego vehicle and each pedestrian; only if `norm < max_detect_length` are the pedestrian’s lane IDs collected.

- Updated the call within `FollowLaneAction::detectObstacleInLane` from:
  ```c++
  hasObstacleInPedestrianLanes(pedestrian_lanes)
  ```
  to:
  
  ```c++
  hasObstacleInPedestrianLanes(pedestrian_lanes, 10)
  ```
  where 10.0 m is the default detection range.


#### Before

https://github.com/user-attachments/assets/fd13912c-bd30-42e9-b9c3-2b17c009b543


#### After


https://github.com/user-attachments/assets/0ace460e-2606-4b72-8cd6-728ce65a8721



## References

- https://github.com/tier4/sim_evaluation_tools/issues/507

# Destructive Changes

N/A

# Known Limitations

N/A
