### PR TITLE
Add arm64 build test

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         rosdistro: [humble]
-        runs_on: [ubuntu-22.04] # macos-14 is added for arm support. See also https://x.com/github/status/1752458943245189120?s=20
+        runs_on: [ubuntu-22.04, ubuntu-22.04-arm]
         cmake_build_type: [RelWithDebInfo, Release] # Debug build type is currently unavailable. @TODO Fix problem and add Debug build.
     steps:
       - name: Suppress warnings
@@ -76,15 +76,16 @@ jobs:
           colcon mixin update default
         shell: bash
 
-      - name: Install sonar-scanner and build-wrapper
-        uses: sonarsource/sonarcloud-github-c-cpp@v3
+      - name: Install Build Wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v4.2.1
+        id: build_wrapper
         env:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: Build with SonarCloud Build Wrapper
         run: |
           source /opt/ros/${{ matrix.rosdistro }}/setup.bash
-          build-wrapper-linux-x86-64 --out-dir src/scenario_simulator_v2/bw-output \
+          ${{ steps.build_wrapper.outputs.build-wrapper-binary }} --out-dir src/scenario_simulator_v2/bw-output \
           colcon build --symlink-install \
           --cmake-args \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
@@ -96,6 +97,8 @@ jobs:
         shell: bash
 
       - name: Colcon test
+        # ARM testing is currently broken
+        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
         run: |
           source /opt/ros/${{ matrix.rosdistro }}/setup.bash
           source install/local_setup.bash
@@ -104,6 +107,7 @@ jobs:
         shell: bash
 
       - name: generate gcov report for sonarcloud
+        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
         run: gcovr -r src/scenario_simulator_v2 build --sonarqube coverage.xml
 
       - name: Show test result
@@ -115,42 +119,16 @@ jobs:
         shell: bash
 
       - name: Scenario test
+        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
         run: |
           source install/setup.bash
           source install/local_setup.bash
           ./src/scenario_simulator_v2/.github/workflows/workflow.sh ./src/scenario_simulator_v2/test_runner/scenario_test_runner/config/workflow.txt global_frame_rate:=20
         shell: bash
 
-      - name: Scenario test (optional)
-        id: optional-scenario-test
-        run: |
-          source install/setup.bash
-          source install/local_setup.bash
-          # execute scenarios but ignore the return code
-          ./src/scenario_simulator_v2/.github/workflows/workflow.sh ./src/scenario_simulator_v2/test_runner/scenario_test_runner/config/optional_workflow.txt global_frame_rate:=20 || true
-          ./src/scenario_simulator_v2/.github/workflows/generate_workflow_report.sh /tmp/scenario_workflow/optional_workflow
-          echo failure=$(grep -c "<failure"  /tmp/scenario_workflow/optional_workflow/failure_report.md) >> $GITHUB_OUTPUT
-        shell: bash
-
-      - uses: actions/github-script@v7
-        if: steps.optional-scenario-test.outputs.failure > 0
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            let commentBody = fs.readFileSync('/tmp/scenario_workflow/optional_workflow/failure_report.md', 'utf8');
-            if (commentBody) {
-              commentBody = '## Failure optional scenarios\n> [!NOTE]\n> This is an experimental check and does not block merging the pull-request. \n> But, please be aware that this may indicate a regression.\n' + commentBody;
-            }
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: commentBody
-            })
-
       - name: Upload Lcov result
         uses: actions/upload-artifact@v4
+        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
         with:
           name: lcov-${{ matrix.cmake_build_type }}
           path: lcov
@@ -158,19 +136,24 @@ jobs:
 
       - name: Upload Gcov result
         uses: actions/upload-artifact@v4
+        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
         with:
           name: coverage${{ matrix.cmake_build_type }}.xml
           path: coverage.xml
           retention-days: 1
 
-      - name: Run SonarCloud scan
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
+        # In ARM build, SonarQube result should be same as x86 build because no test runs
+        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io/
-        working-directory: src/scenario_simulator_v2/
-        run: sonar-scanner --define sonar.cfamily.compile-commands="bw-output/compile_commands.json"
-
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        with:
+          args: >
+            --define sonar.cfamily.compile-commands="src/scenario_simulator_v2/bw-output/compile_commands.json"
+          projectBaseDir: src/scenario_simulator_v2/
 #      - name: Basic test
 #        run: |
 #          source install/setup.bash

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -83,6 +83,9 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: Build with SonarCloud Build Wrapper
+        # Note: `-Wno-error=class-memaccess` is temporary workaround for aarch64 GCC error
+        # This should be removed when Eigen is updated in Ubuntu package repository
+        # See also: https://gitlab.com/libeigen/eigen/-/issues/2326
         run: |
           source /opt/ros/${{ matrix.rosdistro }}/setup.bash
           ${{ steps.build_wrapper.outputs.build-wrapper-binary }} --out-dir src/scenario_simulator_v2/bw-output \

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Colcon test
         # ARM testing is currently broken
-        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
+        if: matrix.runs_on != 'ubuntu-22.04-arm'
         run: |
           source /opt/ros/${{ matrix.rosdistro }}/setup.bash
           source install/local_setup.bash
@@ -107,7 +107,7 @@ jobs:
         shell: bash
 
       - name: generate gcov report for sonarcloud
-        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
+        if: matrix.runs_on != 'ubuntu-22.04-arm'
         run: gcovr -r src/scenario_simulator_v2 build --sonarqube coverage.xml
 
       - name: Show test result
@@ -119,16 +119,45 @@ jobs:
         shell: bash
 
       - name: Scenario test
-        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
+        if: matrix.runs_on != 'ubuntu-22.04-arm'
         run: |
           source install/setup.bash
           source install/local_setup.bash
           ./src/scenario_simulator_v2/.github/workflows/workflow.sh ./src/scenario_simulator_v2/test_runner/scenario_test_runner/config/workflow.txt global_frame_rate:=20
         shell: bash
 
+      - name: Scenario test (optional)
+        id: optional-scenario-test
+        if: matrix.runs_on != 'ubuntu-22.04-arm'
+        run: |
+          source install/setup.bash
+          source install/local_setup.bash
+          # execute scenarios but ignore the return code
+          ./src/scenario_simulator_v2/.github/workflows/workflow.sh ./src/scenario_simulator_v2/test_runner/scenario_test_runner/config/optional_workflow.txt global_frame_rate:=20 || true
+          ./src/scenario_simulator_v2/.github/workflows/generate_workflow_report.sh /tmp/scenario_workflow/optional_workflow
+          echo failure=$(grep -c "<failure"  /tmp/scenario_workflow/optional_workflow/failure_report.md) >> $GITHUB_OUTPUT
+        shell: bash
+
+      - uses: actions/github-script@v7
+        if: steps.optional-scenario-test.outputs.failure > 0 && matrix.runs_on != 'ubuntu-22.04-arm'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            let commentBody = fs.readFileSync('/tmp/scenario_workflow/optional_workflow/failure_report.md', 'utf8');
+            if (commentBody) {
+              commentBody = '## Failure optional scenarios\n> [!NOTE]\n> This is an experimental check and does not block merging the pull-request. \n> But, please be aware that this may indicate a regression.\n' + commentBody;
+            }
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentBody
+            })
+
       - name: Upload Lcov result
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
+        if: matrix.runs_on != 'ubuntu-22.04-arm'
         with:
           name: lcov-${{ matrix.cmake_build_type }}
           path: lcov
@@ -136,7 +165,7 @@ jobs:
 
       - name: Upload Gcov result
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
+        if: matrix.runs_on != 'ubuntu-22.04-arm'
         with:
           name: coverage${{ matrix.cmake_build_type }}.xml
           path: coverage.xml
@@ -145,7 +174,7 @@ jobs:
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v4.2.1
         # In ARM build, SonarQube result should be same as x86 build because no test runs
-        if: ${{ matrix.runs_on != 'ubuntu-22.04-arm' }}
+        if: matrix.runs_on != 'ubuntu-22.04-arm'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -91,7 +91,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DBUILD_CPP_MOCK_SCENARIOS=ON \
             -DBUILD_TESTING=true \
-            -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage' \
+            -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage -Wno-error=class-memaccess' \
             -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage' \
             --packages-up-to ${{ steps.list_packages.outputs.package_list }}
         shell: bash

--- a/.github/workflows/DocumentationLinkCheck.yaml
+++ b/.github/workflows/DocumentationLinkCheck.yaml
@@ -18,6 +18,6 @@ jobs:
         uses: lycheeverse/lychee-action@v1.5.0
         with:
           fail: true
-          args: "--verbose --no-progress './**/*.md' './**/*.html' --timeout 1000 --max-concurrency 32 -T 1 --retry-wait-time 10"
+          args: "--verbose --no-progress './**/*.md' './**/*.html' --timeout 1000 --max-concurrency 16 -T 1 --retry-wait-time 10 --github-token ${{secrets.GITHUB_TOKEN}}"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/DocumentationLinkCheck.yaml
+++ b/.github/workflows/DocumentationLinkCheck.yaml
@@ -18,6 +18,6 @@ jobs:
         uses: lycheeverse/lychee-action@v1.5.0
         with:
           fail: true
-          args: "--verbose --no-progress './**/*.md' './**/*.html' --timeout 1000 --max-concurrency 16 -T 1 --retry-wait-time 10 --github-token ${{secrets.GITHUB_TOKEN}}"
+          args: "--verbose --no-progress './**/*.md' './**/*.html' --timeout 1000 --max-concurrency 1 -T 1 --retry-wait-time 10 --github-token ${{secrets.GITHUB_TOKEN}}"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# Description
## Abstract

This PR will enable ARM64 CI buildtest support.

## Background

[Linux arm64 hosted runners now available for free in public repositories](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)

## Details

Add build test for ARM64 runner.

## References

#1426 

# Destructive Changes

N/A

# Known Limitations

- Multiple test scenarios, unit tests fail in ARM CPU environment, so test case build and execution is turned off in ARM64 environment 
- Sending coverage to SonarCloud is also not done in ARM64
- Docker building is currently not modified
