### PR TITLE
Avoid link check error

### DIFF
--- a/.github/workflows/DocumentationLinkCheck.yaml
+++ b/.github/workflows/DocumentationLinkCheck.yaml
@@ -18,6 +18,6 @@ jobs:
         uses: lycheeverse/lychee-action@v1.5.0
         with:
           fail: true
-          args: "--verbose --no-progress './**/*.md' './**/*.html' --timeout 1000 --max-concurrency 32 -T 1 --retry-wait-time 10"
+          args: "--verbose --no-progress './**/*.md' './**/*.html' --timeout 1000 --max-concurrency 1 -T 1 --retry-wait-time 10"
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/DocumentationLinkCheck.yaml
+++ b/.github/workflows/DocumentationLinkCheck.yaml
@@ -6,7 +6,8 @@ on:
   schedule:
     - cron: 0 0 * * *
   pull_request:
-
+    paths:
+      - "**/*.md"
 jobs:
   linkChecker:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,4 +13,3 @@ Scenario testing framework for Autoware.
 
 See [Documentation](https://tier4.github.io/scenario_simulator_v2-docs/)
 See [C++ API Documentation](https://tier4.github.io/scenario_simulator_v2-api-docs/index.html)
-

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Scenario testing framework for Autoware.
 
 See [Documentation](https://tier4.github.io/scenario_simulator_v2-docs/)
 See [C++ API Documentation](https://tier4.github.io/scenario_simulator_v2-api-docs/index.html)
+


### PR DESCRIPTION
# Description

## Abstract

To avoid link check errors, reduce max-concurrency, and trigger files

## Background

Recently, link checks are failed due to rate limit of github

https://github.com/tier4/scenario_simulator_v2/actions/workflows/DocumentationLinkCheck.yaml

## References

To test this pull-request, I added a test commit that changes markdown file.
The commit triggers the link check action and has no errors.
https://github.com/tier4/scenario_simulator_v2/actions/runs/14924888377/job/41927399418?pr=1591

# Destructive Changes

None

# Known Limitations

Due to this change, link check takes long time.