### PR TITLE
fix push tag position

### DIFF
--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -70,7 +70,7 @@ jobs:
             *.cache-from=type=gha
             *.tags=ghcr.io/tier4/scenario_simulator_v2:traffic_simulator_${{ matrix.rosdistro }}-${{ github.event.inputs.version }}
             *.tags=ghcr.io/tier4/scenario_simulator_v2:traffic_simulator-latest
-            push: true
+          push: true
           targets: |
             traffic_simulator_${{ matrix.rosdistro }}
 


### PR DESCRIPTION
# Description

## Abstract

Fix wrong format in push tag in [Docker.yaml](https://github.com/tier4/scenario_simulator_v2/blob/master/.github/workflows/Docker.yaml).

## Background

Docker images for traffic_simulator does not exist on [GitHub container](https://github.com/tier4/scenario_simulator_v2/pkgs/container/scenario_simulator_v2) registry.

## Details

In, #1535.
Push tags in [Docker.yaml](https://github.com/tier4/scenario_simulator_v2/blob/master/.github/workflows/Docker.yaml) was wrong.

### wrong

```yaml
      - name: Build and push
        if: github.event_name == 'workflow_dispatch'
        uses: docker/bake-action@v6.3.0
        with:
          files: |
            ./docker-bake.hcl
          workdir: .
          set: |
            *.cache-to=type=gha,mode=max
            *.cache-from=type=gha
            *.tags=ghcr.io/tier4/scenario_simulator_v2:traffic_simulator_${{ matrix.rosdistro }}-${{ github.event.inputs.version }}
            *.tags=ghcr.io/tier4/scenario_simulator_v2:traffic_simulator-latest
            push: true
          targets: |
            traffic_simulator_${{ matrix.rosdistro }}
```

### right

```yaml
      - name: Build and push
        if: github.event_name == 'workflow_dispatch'
        uses: docker/bake-action@v6.3.0
        with:
          files: |
            ./docker-bake.hcl
          workdir: .
          set: |
            *.cache-to=type=gha,mode=max
            *.cache-from=type=gha
            *.tags=ghcr.io/tier4/scenario_simulator_v2:traffic_simulator_${{ matrix.rosdistro }}-${{ github.event.inputs.version }}
            *.tags=ghcr.io/tier4/scenario_simulator_v2:traffic_simulator-latest
          push: true
          targets: |
            traffic_simulator_${{ matrix.rosdistro }}
```

## References

#1535 

# Destructive Changes

N/A  

# Known Limitations

N/A  
