### PR TITLE
fix(random_test_runner): remove workaround, fixed in https://github.c…

### DIFF
--- a/test_runner/random_test_runner/CMakeLists.txt
+++ b/test_runner/random_test_runner/CMakeLists.txt
@@ -35,22 +35,6 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 include(FindProtobuf REQUIRED)
 
-# TODO(HansRobo): Remove this workaround once https://github.com/autowarefoundation/autoware_universe/issues/10410 is fixed
-find_package(TinyXML2 CONFIG QUIET)
-if(NOT TinyXML2_FOUND)
-  find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h)
-  find_library(TINYXML2_LIBRARY tinyxml2)
-  include(FindPackageHandleStandardArgs)
-  find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
-  mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
-  if(NOT TARGET tinyxml2::tinyxml2)
-    add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
-    set_property(TARGET tinyxml2::tinyxml2 PROPERTY IMPORTED_LOCATION ${TINYXML2_LIBRARY})
-    set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${TINYXML2_INCLUDE_DIR})
-    list(APPEND TinyXML2_TARGETS tinyxml2::tinyxml2)
-  endif()
-endif()
-
 ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED


### PR DESCRIPTION
…om/ros2/tinyxml2_vendor/pull/23

## Description

This PR removes the workaround for https://github.com/autowarefoundation/autoware_universe/issues/10410

## Abstract

The `tinyxml2_vendor` package is unable to find the TinyXML2 library, potential fix can be found at https://github.com/ros2/tinyxml2_vendor/pull/23