### PR TITLE
Refactor ActionNode to isolate side effects via pure virtual methods

### DIFF
--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
@@ -118,6 +118,8 @@ protected:
   lanelet::Ids route_lanelets_;
   traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter_;
 
+  virtual bool checkPreconditions() { return true; }
+  virtual BT::NodeStatus doAction() = 0;
   auto getDistanceToTargetEntity(
     const math::geometry::CatmullRomSplineInterface & spline,
     const traffic_simulator::CanonicalizedEntityStatus & status) const -> std::optional<double>;
@@ -137,6 +139,7 @@ private:
     -> std::vector<traffic_simulator::CanonicalizedEntityStatus>;
   auto isOtherEntityAtConsideredAltitude(
     const traffic_simulator::CanonicalizedEntityStatus & entity_status) const -> bool;
+  auto tick() -> BT::NodeStatus override;
 
   std::shared_ptr<EuclideanDistancesMap> euclidean_distances_map_;
 };

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_lane_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_lane_action.hpp
@@ -39,7 +39,8 @@ class FollowLaneAction : public entity_behavior::PedestrianActionNode
 {
 public:
   FollowLaneAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   void getBlackBoardValues() override;
   static BT::PortsList providedPorts()
   {

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp
@@ -34,7 +34,8 @@ struct FollowPolylineTrajectoryAction : public PedestrianActionNode
 
   static auto providedPorts() -> BT::PortsList;
 
-  auto tick() -> BT::NodeStatus override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
 };
 }  // namespace pedestrian
 }  // namespace entity_behavior

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/walk_straight_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/walk_straight_action.hpp
@@ -44,7 +44,8 @@ class WalkStraightAction : public entity_behavior::PedestrianActionNode
 {
 public:
   WalkStraightAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   void getBlackBoardValues() override;
   static BT::PortsList providedPorts()
   {

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/follow_front_entity_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/follow_front_entity_action.hpp
@@ -31,7 +31,8 @@ class FollowFrontEntityAction : public entity_behavior::VehicleActionNode
 {
 public:
   FollowFrontEntityAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   static BT::PortsList providedPorts()
   {
     return entity_behavior::VehicleActionNode::providedPorts();

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/follow_lane_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/follow_lane_action.hpp
@@ -31,7 +31,8 @@ class FollowLaneAction : public entity_behavior::VehicleActionNode
 {
 public:
   FollowLaneAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   void getBlackBoardValues() override;
   static BT::PortsList providedPorts()
   {

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/move_backward_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/move_backward_action.hpp
@@ -31,7 +31,8 @@ class MoveBackwardAction : public entity_behavior::VehicleActionNode
 {
 public:
   MoveBackwardAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   void getBlackBoardValues() override;
   static BT::PortsList providedPorts()
   {

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.hpp
@@ -31,7 +31,8 @@ class StopAtCrossingEntityAction : public entity_behavior::VehicleActionNode
 {
 public:
   StopAtCrossingEntityAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   static BT::PortsList providedPorts()
   {
     return entity_behavior::VehicleActionNode::providedPorts();

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/stop_at_stop_line_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/stop_at_stop_line_action.hpp
@@ -31,7 +31,8 @@ class StopAtStopLineAction : public entity_behavior::VehicleActionNode
 {
 public:
   StopAtStopLineAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   static BT::PortsList providedPorts()
   {
     return entity_behavior::VehicleActionNode::providedPorts();

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/stop_at_traffic_light_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/stop_at_traffic_light_action.hpp
@@ -31,7 +31,8 @@ class StopAtTrafficLightAction : public entity_behavior::VehicleActionNode
 {
 public:
   StopAtTrafficLightAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   static BT::PortsList providedPorts()
   {
     return entity_behavior::VehicleActionNode::providedPorts();

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/yield_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_lane_sequence/yield_action.hpp
@@ -31,7 +31,8 @@ class YieldAction : public entity_behavior::VehicleActionNode
 {
 public:
   YieldAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   static BT::PortsList providedPorts()
   {
     return entity_behavior::VehicleActionNode::providedPorts();

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/follow_trajectory_sequence/follow_polyline_trajectory_action.hpp
@@ -34,7 +34,8 @@ struct FollowPolylineTrajectoryAction : public VehicleActionNode
 
   static auto providedPorts() -> BT::PortsList;
 
-  auto tick() -> BT::NodeStatus override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
 };
 }  // namespace vehicle
 }  // namespace entity_behavior

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/lane_change_action.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/lane_change_action.hpp
@@ -34,7 +34,8 @@ class LaneChangeAction : public entity_behavior::VehicleActionNode
 {
 public:
   LaneChangeAction(const std::string & name, const BT::NodeConfiguration & config);
-  BT::NodeStatus tick() override;
+  bool checkPreconditions() override;
+  BT::NodeStatus doAction() override;
   static BT::PortsList providedPorts()
   {
     return BT::PortsList(

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -51,6 +51,15 @@ ActionNode::ActionNode(const std::string & name, const BT::NodeConfiguration & c
 
 auto ActionNode::executeTick() -> BT::NodeStatus { return BT::ActionNodeBase::executeTick(); }
 
+auto ActionNode::tick() -> BT::NodeStatus
+{
+  getBlackBoardValues();
+  if (!checkPreconditions()) {
+    return BT::NodeStatus::FAILURE;
+  }
+  return doAction();
+}
+
 auto ActionNode::getBlackBoardValues() -> void
 {
   if (!getInput<traffic_simulator::behavior::Request>("request", request_)) {

--- a/simulation/behavior_tree_plugin/src/pedestrian/follow_lane_action.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/follow_lane_action.cpp
@@ -103,15 +103,19 @@ bool FollowLaneAction::detectObstacleInLane(
     return false;
   }
 }
-
-BT::NodeStatus FollowLaneAction::tick()
+bool FollowLaneAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else {
+    return true;
   }
+}
+
+BT::NodeStatus FollowLaneAction::doAction()
+{
   if (!canonicalized_entity_status_->isInLanelet()) {
     stopEntity();
     return BT::NodeStatus::RUNNING;

--- a/simulation/behavior_tree_plugin/src/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
@@ -54,7 +54,24 @@ auto FollowPolylineTrajectoryAction::providedPorts() -> BT::PortsList
   return ports;
 }
 
-auto FollowPolylineTrajectoryAction::tick() -> BT::NodeStatus
+bool FollowPolylineTrajectoryAction::checkPreconditions()
+{
+  if (getBlackBoardValues();
+      request_ != traffic_simulator::behavior::Request::FOLLOW_POLYLINE_TRAJECTORY or
+      not getInput<decltype(polyline_trajectory)>("polyline_trajectory", polyline_trajectory) or
+      not getInput<decltype(target_speed_)>("target_speed", target_speed_) or
+      not polyline_trajectory) {
+    return false;
+  } else if (std::isnan(canonicalized_entity_status_->getTime())) {
+    THROW_SIMULATION_ERROR(
+      "Time in canonicalized_entity_status is NaN - FollowTrajectoryAction does not support such "
+      "case.");
+  } else {
+    return true;
+  }
+}
+
+auto FollowPolylineTrajectoryAction::doAction() -> BT::NodeStatus
 {
   auto getTargetSpeed = [&]() -> double {
     if (target_speed_.has_value()) {
@@ -64,17 +81,7 @@ auto FollowPolylineTrajectoryAction::tick() -> BT::NodeStatus
     }
   };
 
-  if (getBlackBoardValues();
-      request_ != traffic_simulator::behavior::Request::FOLLOW_POLYLINE_TRAJECTORY or
-      not getInput<decltype(polyline_trajectory)>("polyline_trajectory", polyline_trajectory) or
-      not getInput<decltype(target_speed_)>("target_speed", target_speed_) or
-      not polyline_trajectory) {
-    return BT::NodeStatus::FAILURE;
-  } else if (std::isnan(canonicalized_entity_status_->getTime())) {
-    THROW_SIMULATION_ERROR(
-      "Time in canonicalized_entity_status is NaN - FollowTrajectoryAction does not support such "
-      "case.");
-  } else if (
+  if (
     const auto entity_status_updated = traffic_simulator::follow_trajectory::makeUpdatedStatus(
       static_cast<traffic_simulator::EntityStatus>(*canonicalized_entity_status_),
       *polyline_trajectory, behavior_parameter_, hdmap_utils_, step_time_,

--- a/simulation/behavior_tree_plugin/src/pedestrian/walk_straight_action.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/walk_straight_action.cpp
@@ -40,11 +40,7 @@ void WalkStraightAction::getBlackBoardValues() { PedestrianActionNode::getBlackB
 
 bool WalkStraightAction::checkPreconditions()
 {
-  if (request_ != traffic_simulator::behavior::Request::WALK_STRAIGHT) {
-    return false;
-  } else {
-    return true;
-  }
+  return request_ == traffic_simulator::behavior::Request::WALK_STRAIGHT;
 }
 
 BT::NodeStatus WalkStraightAction::doAction()

--- a/simulation/behavior_tree_plugin/src/pedestrian/walk_straight_action.cpp
+++ b/simulation/behavior_tree_plugin/src/pedestrian/walk_straight_action.cpp
@@ -38,12 +38,17 @@ WalkStraightAction::WalkStraightAction(
 
 void WalkStraightAction::getBlackBoardValues() { PedestrianActionNode::getBlackBoardValues(); }
 
-BT::NodeStatus WalkStraightAction::tick()
+bool WalkStraightAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (request_ != traffic_simulator::behavior::Request::WALK_STRAIGHT) {
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else {
+    return true;
   }
+}
+
+BT::NodeStatus WalkStraightAction::doAction()
+{
   if (!target_speed_) {
     target_speed_ = 1.111;
   }

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
@@ -69,20 +69,23 @@ const traffic_simulator_msgs::msg::WaypointsArray FollowFrontEntityAction::calcu
   }
 }
 
-BT::NodeStatus FollowFrontEntityAction::tick()
+bool FollowFrontEntityAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else if (getRightOfWayEntities(route_lanelets_).size() != 0) {
+    return false;
+  } else if (!behavior_parameter_.see_around) {
+    return false;
+  } else {
+    return true;
   }
-  if (getRightOfWayEntities(route_lanelets_).size() != 0) {
-    return BT::NodeStatus::FAILURE;
-  }
-  if (!behavior_parameter_.see_around) {
-    return BT::NodeStatus::FAILURE;
-  }
+}
+
+BT::NodeStatus FollowFrontEntityAction::doAction()
+{
   const auto waypoints = calculateWaypoints();
   if (waypoints.waypoints.empty()) {
     return BT::NodeStatus::FAILURE;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
@@ -75,7 +75,7 @@ bool FollowFrontEntityAction::checkPreconditions()
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
     return false;
-  } else if (getRightOfWayEntities(route_lanelets_).empty()) {
+  } else if (!getRightOfWayEntities(route_lanelets_).empty()) {
     return false;
   } else if (!behavior_parameter_.see_around) {
     return false;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_front_entity_action.cpp
@@ -75,7 +75,7 @@ bool FollowFrontEntityAction::checkPreconditions()
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
     return false;
-  } else if (getRightOfWayEntities(route_lanelets_).size() != 0) {
+  } else if (getRightOfWayEntities(route_lanelets_).empty()) {
     return false;
   } else if (!behavior_parameter_.see_around) {
     return false;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_lane_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/follow_lane_action.cpp
@@ -66,14 +66,19 @@ void FollowLaneAction::getBlackBoardValues()
   }
 }
 
-BT::NodeStatus FollowLaneAction::tick()
+bool FollowLaneAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else {
+    return true;
   }
+}
+
+BT::NodeStatus FollowLaneAction::doAction()
+{
   if (!canonicalized_entity_status_->isInLanelet()) {
     stopEntity();
     const auto waypoints = traffic_simulator_msgs::msg::WaypointsArray{};

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/move_backward_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/move_backward_action.cpp
@@ -62,17 +62,21 @@ const traffic_simulator_msgs::msg::WaypointsArray MoveBackwardAction::calculateW
 
 void MoveBackwardAction::getBlackBoardValues() { VehicleActionNode::getBlackBoardValues(); }
 
-BT::NodeStatus MoveBackwardAction::tick()
+bool MoveBackwardAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else if (!canonicalized_entity_status_->isInLanelet()) {
+    return false;
+  } else {
+    return true;
   }
-  if (!canonicalized_entity_status_->isInLanelet()) {
-    return BT::NodeStatus::FAILURE;
-  }
+}
+
+BT::NodeStatus MoveBackwardAction::doAction()
+{
   const auto waypoints = calculateWaypoints();
   if (waypoints.waypoints.empty()) {
     return BT::NodeStatus::FAILURE;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
@@ -92,7 +92,7 @@ bool StopAtCrossingEntityAction::checkPreconditions()
     return false;
   } else if (!behavior_parameter_.see_around) {
     return false;
-  } else if (getRightOfWayEntities(route_lanelets_).size() != 0) {
+  } else if (getRightOfWayEntities(route_lanelets_).empty()) {
     return false;
   } else {
     return true;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
@@ -82,23 +82,25 @@ std::optional<double> StopAtCrossingEntityAction::calculateTargetSpeed(double cu
   return current_velocity;
 }
 
-BT::NodeStatus StopAtCrossingEntityAction::tick()
+bool StopAtCrossingEntityAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else if (!canonicalized_entity_status_->isInLanelet()) {
+    return false;
+  } else if (!behavior_parameter_.see_around) {
+    return false;
+  } else if (getRightOfWayEntities(route_lanelets_).size() != 0) {
+    return false;
+  } else {
+    return true;
   }
-  if (!canonicalized_entity_status_->isInLanelet()) {
-    return BT::NodeStatus::FAILURE;
-  }
-  if (!behavior_parameter_.see_around) {
-    return BT::NodeStatus::FAILURE;
-  }
-  if (getRightOfWayEntities(route_lanelets_).size() != 0) {
-    return BT::NodeStatus::FAILURE;
-  }
+}
+
+BT::NodeStatus StopAtCrossingEntityAction::doAction()
+{
   const auto waypoints = calculateWaypoints();
   if (waypoints.waypoints.empty()) {
     return BT::NodeStatus::FAILURE;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_crossing_entity_action.cpp
@@ -92,7 +92,7 @@ bool StopAtCrossingEntityAction::checkPreconditions()
     return false;
   } else if (!behavior_parameter_.see_around) {
     return false;
-  } else if (getRightOfWayEntities(route_lanelets_).empty()) {
+  } else if (!getRightOfWayEntities(route_lanelets_).empty()) {
     return false;
   } else {
     return true;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
@@ -83,23 +83,25 @@ std::optional<double> StopAtStopLineAction::calculateTargetSpeed(double current_
   return current_velocity;
 }
 
-BT::NodeStatus StopAtStopLineAction::tick()
+bool StopAtStopLineAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else if (!behavior_parameter_.see_around) {
+    return false;
+  } else if (getRightOfWayEntities(route_lanelets_).size() != 0) {
+    return false;
+  } else if (!canonicalized_entity_status_->isInLanelet()) {
+    return false;
+  } else {
+    return true;
   }
-  if (!behavior_parameter_.see_around) {
-    return BT::NodeStatus::FAILURE;
-  }
-  if (getRightOfWayEntities(route_lanelets_).size() != 0) {
-    return BT::NodeStatus::FAILURE;
-  }
-  if (!canonicalized_entity_status_->isInLanelet()) {
-    return BT::NodeStatus::FAILURE;
-  }
+}
+
+BT::NodeStatus StopAtStopLineAction::doAction()
+{
   const auto waypoints = calculateWaypoints();
   if (waypoints.waypoints.empty()) {
     return BT::NodeStatus::FAILURE;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
@@ -91,7 +91,7 @@ bool StopAtStopLineAction::checkPreconditions()
     return false;
   } else if (!behavior_parameter_.see_around) {
     return false;
-  } else if (getRightOfWayEntities(route_lanelets_).empty()) {
+  } else if (!getRightOfWayEntities(route_lanelets_).empty()) {
     return false;
   } else if (!canonicalized_entity_status_->isInLanelet()) {
     return false;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_stop_line_action.cpp
@@ -91,7 +91,7 @@ bool StopAtStopLineAction::checkPreconditions()
     return false;
   } else if (!behavior_parameter_.see_around) {
     return false;
-  } else if (getRightOfWayEntities(route_lanelets_).size() != 0) {
+  } else if (getRightOfWayEntities(route_lanelets_).empty()) {
     return false;
   } else if (!canonicalized_entity_status_->isInLanelet()) {
     return false;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
@@ -94,7 +94,7 @@ bool StopAtTrafficLightAction::checkPreconditions()
     return false;
   } else if (!behavior_parameter_.see_around) {
     return false;
-  } else if (getRightOfWayEntities(route_lanelets_).empty()) {
+  } else if (!getRightOfWayEntities(route_lanelets_).empty()) {
     return false;
   } else {
     return true;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
@@ -94,7 +94,7 @@ bool StopAtTrafficLightAction::checkPreconditions()
     return false;
   } else if (!behavior_parameter_.see_around) {
     return false;
-  } else if (getRightOfWayEntities(route_lanelets_).size() != 0) {
+  } else if (getRightOfWayEntities(route_lanelets_).empty()) {
     return false;
   } else {
     return true;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/stop_at_traffic_light_action.cpp
@@ -84,23 +84,25 @@ std::optional<double> StopAtTrafficLightAction::calculateTargetSpeed(double curr
   return current_velocity;
 }
 
-BT::NodeStatus StopAtTrafficLightAction::tick()
+bool StopAtTrafficLightAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else if (!canonicalized_entity_status_->isInLanelet()) {
+    return false;
+  } else if (!behavior_parameter_.see_around) {
+    return false;
+  } else if (getRightOfWayEntities(route_lanelets_).size() != 0) {
+    return false;
+  } else {
+    return true;
   }
-  if (!canonicalized_entity_status_->isInLanelet()) {
-    return BT::NodeStatus::FAILURE;
-  }
-  if (!behavior_parameter_.see_around) {
-    return BT::NodeStatus::FAILURE;
-  }
-  if (getRightOfWayEntities(route_lanelets_).size() != 0) {
-    return BT::NodeStatus::FAILURE;
-  }
+}
+
+BT::NodeStatus StopAtTrafficLightAction::doAction()
+{
   const auto waypoints = calculateWaypoints();
   if (waypoints.waypoints.empty()) {
     return BT::NodeStatus::FAILURE;

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/yield_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_lane_sequence/yield_action.cpp
@@ -85,20 +85,23 @@ std::optional<double> YieldAction::calculateTargetSpeed()
   return canonicalized_entity_status_->getTwist().linear.x;
 }
 
-BT::NodeStatus YieldAction::tick()
+bool YieldAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (
     request_ != traffic_simulator::behavior::Request::NONE &&
     request_ != traffic_simulator::behavior::Request::FOLLOW_LANE) {
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else if (!behavior_parameter_.see_around) {
+    return false;
+  } else if (!canonicalized_entity_status_->isInLanelet()) {
+    return false;
+  } else {
+    return true;
   }
-  if (!behavior_parameter_.see_around) {
-    return BT::NodeStatus::FAILURE;
-  }
-  if (!canonicalized_entity_status_->isInLanelet()) {
-    return BT::NodeStatus::FAILURE;
-  }
+}
+
+BT::NodeStatus YieldAction::doAction()
+{
   const auto right_of_way_entities = getRightOfWayEntities(route_lanelets_);
   if (right_of_way_entities.empty()) {
     if (!target_speed_) {

--- a/simulation/behavior_tree_plugin/src/vehicle/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/follow_trajectory_sequence/follow_polyline_trajectory_action.cpp
@@ -54,7 +54,24 @@ auto FollowPolylineTrajectoryAction::providedPorts() -> BT::PortsList
   return ports;
 }
 
-auto FollowPolylineTrajectoryAction::tick() -> BT::NodeStatus
+bool FollowPolylineTrajectoryAction::checkPreconditions()
+{
+  if (
+    request_ != traffic_simulator::behavior::Request::FOLLOW_POLYLINE_TRAJECTORY or
+    not getInput<decltype(polyline_trajectory)>("polyline_trajectory", polyline_trajectory) or
+    not getInput<decltype(target_speed_)>("target_speed", target_speed_) or
+    not polyline_trajectory) {
+    return false;
+  } else if (std::isnan(canonicalized_entity_status_->getTime())) {
+    THROW_SIMULATION_ERROR(
+      "Time in canonicalized_entity_status is NaN - FollowTrajectoryAction does not support such "
+      "case.");
+  } else {
+    return true;
+  }
+}
+
+BT::NodeStatus FollowPolylineTrajectoryAction::doAction()
 {
   auto getTargetSpeed = [&]() -> double {
     if (target_speed_.has_value()) {
@@ -64,17 +81,7 @@ auto FollowPolylineTrajectoryAction::tick() -> BT::NodeStatus
     }
   };
 
-  if (getBlackBoardValues();
-      request_ != traffic_simulator::behavior::Request::FOLLOW_POLYLINE_TRAJECTORY or
-      not getInput<decltype(polyline_trajectory)>("polyline_trajectory", polyline_trajectory) or
-      not getInput<decltype(target_speed_)>("target_speed", target_speed_) or
-      not polyline_trajectory) {
-    return BT::NodeStatus::FAILURE;
-  } else if (std::isnan(canonicalized_entity_status_->getTime())) {
-    THROW_SIMULATION_ERROR(
-      "Time in canonicalized_entity_status is NaN - FollowTrajectoryAction does not support such "
-      "case.");
-  } else if (
+  if (
     const auto entity_status_updated = traffic_simulator::follow_trajectory::makeUpdatedStatus(
       static_cast<traffic_simulator::EntityStatus>(*canonicalized_entity_status_),
       *polyline_trajectory, behavior_parameter_, hdmap_utils_, step_time_,

--- a/simulation/behavior_tree_plugin/src/vehicle/lane_change_action.cpp
+++ b/simulation/behavior_tree_plugin/src/vehicle/lane_change_action.cpp
@@ -88,19 +88,23 @@ void LaneChangeAction::getBlackBoardValues()
   }
 }
 
-BT::NodeStatus LaneChangeAction::tick()
+bool LaneChangeAction::checkPreconditions()
 {
-  getBlackBoardValues();
   if (request_ != traffic_simulator::behavior::Request::LANE_CHANGE) {
     curve_ = std::nullopt;
     current_s_ = 0;
-    return BT::NodeStatus::FAILURE;
-  }
-  if (!lane_change_parameters_) {
+    return false;
+  } else if (!lane_change_parameters_) {
     curve_ = std::nullopt;
     current_s_ = 0;
-    return BT::NodeStatus::FAILURE;
+    return false;
+  } else {
+    return true;
   }
+}
+
+BT::NodeStatus LaneChangeAction::doAction()
+{
   if (!curve_) {
     if (request_ == traffic_simulator::behavior::Request::LANE_CHANGE) {
       if (!canonicalized_entity_status_->isInLanelet()) {


### PR DESCRIPTION
## Abstract

This pull request is a refactoring of the BehaviorTreePlugin proposed by ROBOTECH.

## Background

N/A

## Details

Extract common pre-/post-processing into the base ActionNode and introduce a pure virtual doAction() method.
Delegate all action-specific side effects (state updates, outputs) to derived classes for improved traceability and testability.

```c++
// Base class (defines pure virtual function)
class ActionNode : public BT::ActionNodeBase {
public:
  ActionNode(const std::string &name, const BT::NodeConfiguration &config)
  : BT::ActionNodeBase(name, config) {}

  BT::NodeStatus tick() override {
    // ① Common: Retrieve values from the blackboard
    getBlackBoardValues();
    // ② Common: Perform precondition checks
    if (!checkPreconditions()) {
      return BT::NodeStatus::FAILURE;
    }
    // ③ Delegate logic to derived class (pure virtual)
    return doAction();
  }

protected:
  virtual void getBlackBoardValues() {
    // Common blackboard reading logic
  }
  virtual bool checkPreconditions() { return true; }

  // Must be implemented by derived classes
  virtual BT::NodeStatus doAction() = 0;
};

// Example of a derived class
class ExampleAction : public ActionNode {
public:

protected:
  void getBlackBoardValues() override {
    ActionNode::getBlackBoardValues();
    // Retrieve additional vehicle-specific parameters
  }

  BT::NodeStatus doAction() override {
    // Consolidate logic such as calculateUpdatedEntityStatus,
    // setOutput(), and other side effects here
    return BT::NodeStatus::SUCCESS;  // or RUNNING/FAILURE
  }
};
```

## References

- https://github.com/tier4/sim_evaluation_tools/issues/526
- https://tier4.atlassian.net/jira/software/c/projects/RT4/boards/446?assignee=712020%3A86ceb94c-d91a-412a-8dcf-056519a0fbf8&selectedIssue=RT4-16990

# Destructive Changes

N/A

# Known Limitations

N/A 
