### PR TITLE
Add missing elements to context

### DIFF
--- a/openscenario/openscenario_interpreter/src/syntax/act.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/act.cpp
@@ -60,6 +60,10 @@ auto operator<<(boost::json::object & json, const Act & datum) -> boost::json::o
     maneuver_groups.push_back(std::move(act));
   }
 
+  json["StartTrigger"].emplace_object() << datum.start_trigger;
+
+  json["StopTrigger"].emplace_object() << datum.stop_trigger;
+
   return json;
 }
 }  // namespace syntax

--- a/openscenario/openscenario_interpreter/src/syntax/storyboard.cpp
+++ b/openscenario/openscenario_interpreter/src/syntax/storyboard.cpp
@@ -75,6 +75,8 @@ auto operator<<(boost::json::object & json, const Storyboard & datum) -> boost::
     stories.push_back(std::move(each));
   }
 
+  json["StopTrigger"].emplace_object() << datum.stop_trigger;
+
   return json;
 }
 }  // namespace syntax


### PR DESCRIPTION
# Description

## Abstract

Add missing Triggers to context for external services. 

- `StartTrigger` in `Act`
- `StopTrigger` in `Act`
- `StopTrigger` in `Storyboard`


## References

[No regression](https://github.com/tier4/sim_evaluation_tools/issues/533)

# Destructive Changes

None

# Known Limitations

None