### PR TITLE
Fix simulation error after removing "--symlink-install" build option

### DIFF
--- a/openscenario/openscenario_utility/CMakeLists.txt
+++ b/openscenario/openscenario_utility/CMakeLists.txt
@@ -8,7 +8,8 @@ find_package(ament_cmake_python REQUIRED)
 ament_python_install_package(${PROJECT_NAME})
 
 install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/
+  PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/conversion.py
+           ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/validation.py
   DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/openscenario/openscenario_utility/CMakeLists.txt
+++ b/openscenario/openscenario_utility/CMakeLists.txt
@@ -8,6 +8,10 @@ find_package(ament_cmake_python REQUIRED)
 ament_python_install_package(${PROJECT_NAME})
 
 install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/
+  DESTINATION lib/${PROJECT_NAME})
+
+install(
   PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/conversion.py
            ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/validation.py
   DESTINATION lib/${PROJECT_NAME})

--- a/test_runner/scenario_test_runner/CMakeLists.txt
+++ b/test_runner/scenario_test_runner/CMakeLists.txt
@@ -8,7 +8,9 @@ find_package(ament_cmake_python REQUIRED)
 ament_python_install_package(${PROJECT_NAME})
 
 install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/
+  PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/scenario_test_runner.py
+           ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/result_checker.py
+           ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/lifecycle_controller.py
   DESTINATION lib/${PROJECT_NAME})
 
 install(

--- a/test_runner/scenario_test_runner/CMakeLists.txt
+++ b/test_runner/scenario_test_runner/CMakeLists.txt
@@ -11,6 +11,7 @@ install(
   PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/scenario_test_runner.py
            ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/result_checker.py
            ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/lifecycle_controller.py
+           ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/scenario.py
   DESTINATION lib/${PROJECT_NAME})
 
 install(


### PR DESCRIPTION
## Abstract

> [!NOTE]
> This pull-request is a continuation of #1614, created by @f0reachARR.
> And fixed by @Zhenfeng-Sun.
> The description is written by @f0reachARR.

This PR will fix these errors which were happened when `--symlink-install` is not used

- executable 'scenario_test_runner.py' not found on the libexec directory
- [openscenario_preprocessor_node-XX] No executable found 
  - Direct cause: `ros2 run openscenario_utility validation.py` in openscenario_preprocessor_node

## Background

[`install` in CMake](https://cmake.org/cmake/help/latest/command/install.html#directory) does not respect original file permission, and use default "file" permission which is read and write.

> If no permissions are specified files will be given the default permissions specified in the FILES form of the command, and the directories will be given the default permissions specified in the PROGRAMS form of the command.

When `--symlink-install` is used, `install` is replaced by ament and this behavior does not happen, then everything works.
However, without `--symlink-install`, some Python based packages will lose these executable permission and then they stopped working.

## Details

To address this error, I have two options: `USE_SOURCE_PERMISSIONS` or `PROGRAMS`

- `USE_SOURCE_PERMISSIONS` is a option of `install`, which will respect original file permission. However, adding this will [prevent symlink behavior](https://github.com/ament/ament_cmake/blob/2a2beafc80132d9d6d3516b41b081076cc0b6983/ament_cmake_core/cmake/symlink_install/ament_cmake_symlink_install_directory.cmake#L28-L46) and force copy based install.
- `PROGRAMS` is special form of `FILES` in `install`, which will set permission executable. However, I need to replace DIRECTORY with PROGRAMS for each executable files.

In my research, `ament_cmake_python` uses [`USE_SOURCE_PERMISSIONS` for non `--symlink-install` case](https://github.com/ament/ament_cmake/blob/2a2beafc80132d9d6d3516b41b081076cc0b6983/ament_cmake_python/cmake/ament_python_install_package.cmake#L172-L175). But it is complex to check if we use `--symlink-install` and change install options, I use `PROGRAMS`.

> After this pull request, we need to specify all executable in CMakeLists.txt in addition to add Python script to package.
