### PR TITLE
CppMockScenarios AWSIM support

### DIFF
--- a/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
+++ b/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
@@ -88,6 +88,7 @@ private:
   }
 
   void checkConfiguration(const traffic_simulator::Configuration & configuration);
+  auto configureEgoEntity() -> void;
 };
 
 }  // namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
+++ b/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
@@ -53,6 +53,10 @@ public:
     const std::vector<traffic_simulator::CanonicalizedLaneletPose> & goal_lanelet_pose,
     const traffic_simulator_msgs::msg::VehicleParameters & parameters);
 
+  auto spawnEgoEntity(
+    const traffic_simulator::CanonicalizedLaneletPose & spawn_lanelet_pose,
+    const traffic_simulator_msgs::msg::VehicleParameters & parameters) -> void;
+
   auto isVehicle(const std::string & name) const -> bool;
 
   auto isPedestrian(const std::string & name) const -> bool;

--- a/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
+++ b/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
@@ -35,7 +35,7 @@ public:
     const std::string & lanelet2_map_file, const std::string & scenario_filename,
     const bool verbose, const rclcpp::NodeOptions & option,
     const std::set<std::uint8_t> & auto_sink_entity_types = {});
-  void start();
+  void start(const bool start_scenario_clock = true);
   void stop(Result result, const std::string & description = "");
   void expectThrow() { exception_expect_ = true; }
   void expectNoThrow() { exception_expect_ = false; }
@@ -63,6 +63,7 @@ protected:
 
 private:
   std::string scenario_filename_;
+  std::string ego_model_;
   bool exception_expect_;
   std::string junit_path_;
   void update();

--- a/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
+++ b/mock/cpp_mock_scenarios/include/cpp_mock_scenarios/cpp_scenario_node.hpp
@@ -53,10 +53,6 @@ public:
     const std::vector<traffic_simulator::CanonicalizedLaneletPose> & goal_lanelet_pose,
     const traffic_simulator_msgs::msg::VehicleParameters & parameters);
 
-  auto spawnEgoEntity(
-    const traffic_simulator::CanonicalizedLaneletPose & spawn_lanelet_pose,
-    const traffic_simulator_msgs::msg::VehicleParameters & parameters) -> void;
-
   auto isVehicle(const std::string & name) const -> bool;
 
   auto isPedestrian(const std::string & name) const -> bool;
@@ -88,7 +84,6 @@ private:
   }
 
   void checkConfiguration(const traffic_simulator::Configuration & configuration);
-  auto configureEgoEntity() -> void;
 };
 
 }  // namespace cpp_mock_scenarios

--- a/mock/cpp_mock_scenarios/launch/mock_test.launch.py
+++ b/mock/cpp_mock_scenarios/launch/mock_test.launch.py
@@ -130,6 +130,7 @@ def launch_setup(context, *args, **kwargs):
     scenario_package                    = LaunchConfiguration("package",                                default="cpp_mock_scenarios")
     junit_path                          = LaunchConfiguration("junit_path",                             default="/tmp/output.xunit.xml")
     ego_model                           = LaunchConfiguration("ego_model",                              default="")
+    map_path                            = LaunchConfiguration("map_path",                               default="")
     # fmt: on
 
     print(f"architecture_type                   := {architecture_type.perform(context)}")
@@ -159,6 +160,7 @@ def launch_setup(context, *args, **kwargs):
     print(f"scenario_package                    := {scenario_package.perform(context)}")
     print(f"junit_path                          := {junit_path.perform(context)}")
     print(f"ego_model                           := {ego_model.perform(context)}")
+    print(f"map_path                            := {map_path.perform(context)}")
 
     def make_parameters():
         parameters = [
@@ -182,6 +184,7 @@ def launch_setup(context, *args, **kwargs):
             {"global_timeout": global_timeout},
             {"junit_path": junit_path},
             {"ego_model": ego_model}
+            {"map_path": map_path}
         ]
         parameters += make_vehicle_parameters()
         parameters += [parameter_file_path.perform(context)]
@@ -250,6 +253,7 @@ def launch_setup(context, *args, **kwargs):
         DeclareLaunchArgument("scenario_package",                    default_value=scenario_package                   ),
         DeclareLaunchArgument("junit_path",                          default_value=junit_path                         ),
         DeclareLaunchArgument("ego_model",                           default_value=ego_model                          ),
+        DeclareLaunchArgument("map_path",                            default_value=map_path                           ),
         # fmt: on
         cpp_scenario_node,
         Node(

--- a/mock/cpp_mock_scenarios/launch/mock_test.launch.py
+++ b/mock/cpp_mock_scenarios/launch/mock_test.launch.py
@@ -129,6 +129,7 @@ def launch_setup(context, *args, **kwargs):
     vehicle_model                       = LaunchConfiguration("vehicle_model",                          default="")
     scenario_package                    = LaunchConfiguration("package",                                default="cpp_mock_scenarios")
     junit_path                          = LaunchConfiguration("junit_path",                             default="/tmp/output.xunit.xml")
+    ego_model                           = LaunchConfiguration("ego_model",                              default="")
     # fmt: on
 
     print(f"architecture_type                   := {architecture_type.perform(context)}")
@@ -157,6 +158,7 @@ def launch_setup(context, *args, **kwargs):
     print(f"vehicle_model                       := {vehicle_model.perform(context)}")
     print(f"scenario_package                    := {scenario_package.perform(context)}")
     print(f"junit_path                          := {junit_path.perform(context)}")
+    print(f"ego_model                           := {ego_model.perform(context)}")
 
     def make_parameters():
         parameters = [
@@ -179,6 +181,7 @@ def launch_setup(context, *args, **kwargs):
             {"global_frame_rate": global_frame_rate},
             {"global_timeout": global_timeout},
             {"junit_path": junit_path},
+            {"ego_model": ego_model}
         ]
         parameters += make_vehicle_parameters()
         parameters += [parameter_file_path.perform(context)]
@@ -246,6 +249,7 @@ def launch_setup(context, *args, **kwargs):
         DeclareLaunchArgument("vehicle_model",                       default_value=vehicle_model                      ),
         DeclareLaunchArgument("scenario_package",                    default_value=scenario_package                   ),
         DeclareLaunchArgument("junit_path",                          default_value=junit_path                         ),
+        DeclareLaunchArgument("ego_model",                           default_value=ego_model                          ),
         # fmt: on
         cpp_scenario_node,
         Node(

--- a/mock/cpp_mock_scenarios/launch/mock_test.launch.py
+++ b/mock/cpp_mock_scenarios/launch/mock_test.launch.py
@@ -129,8 +129,6 @@ def launch_setup(context, *args, **kwargs):
     vehicle_model                       = LaunchConfiguration("vehicle_model",                          default="")
     scenario_package                    = LaunchConfiguration("package",                                default="cpp_mock_scenarios")
     junit_path                          = LaunchConfiguration("junit_path",                             default="/tmp/output.xunit.xml")
-    ego_model                           = LaunchConfiguration("ego_model",                              default="")
-    map_path                            = LaunchConfiguration("map_path",                               default="")
     # fmt: on
 
     print(f"architecture_type                   := {architecture_type.perform(context)}")
@@ -159,8 +157,6 @@ def launch_setup(context, *args, **kwargs):
     print(f"vehicle_model                       := {vehicle_model.perform(context)}")
     print(f"scenario_package                    := {scenario_package.perform(context)}")
     print(f"junit_path                          := {junit_path.perform(context)}")
-    print(f"ego_model                           := {ego_model.perform(context)}")
-    print(f"map_path                            := {map_path.perform(context)}")
 
     def make_parameters():
         parameters = [
@@ -183,8 +179,6 @@ def launch_setup(context, *args, **kwargs):
             {"global_frame_rate": global_frame_rate},
             {"global_timeout": global_timeout},
             {"junit_path": junit_path},
-            {"ego_model": ego_model}
-            {"map_path": map_path}
         ]
         parameters += make_vehicle_parameters()
         parameters += [parameter_file_path.perform(context)]
@@ -252,8 +246,6 @@ def launch_setup(context, *args, **kwargs):
         DeclareLaunchArgument("vehicle_model",                       default_value=vehicle_model                      ),
         DeclareLaunchArgument("scenario_package",                    default_value=scenario_package                   ),
         DeclareLaunchArgument("junit_path",                          default_value=junit_path                         ),
-        DeclareLaunchArgument("ego_model",                           default_value=ego_model                          ),
-        DeclareLaunchArgument("map_path",                            default_value=map_path                           ),
         # fmt: on
         cpp_scenario_node,
         Node(

--- a/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
+++ b/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
@@ -25,7 +25,16 @@ CppScenarioNode::CppScenarioNode(
 : Node(node_name, option),
   api_(
     this,
-    configure(map_path, lanelet2_map_file, scenario_filename, verbose, auto_sink_entity_types),
+    configure(
+      [this, &map_path]() {
+        if (map_path.empty()) {
+          declare_parameter<std::string>("map_path", "");
+          return get_parameter("map_path").as_string();
+        } else {
+          return map_path;
+        }
+      }(),
+      lanelet2_map_file, scenario_filename, verbose, auto_sink_entity_types),
     declare_parameter<double>("global_real_time_factor", 1.0),
     declare_parameter<double>("global_frame_rate", 20.0)),
   scenario_filename_(scenario_filename),

--- a/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
+++ b/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
@@ -123,26 +123,8 @@ void CppScenarioNode::spawnEgoEntity(
   api_.spawn(
     "ego", spawn_lanelet_pose, parameters, traffic_simulator::VehicleBehavior::autoware(),
     ego_model_);
+  configureEgoEntity();
   auto & ego_entity = api_.getEgoEntity("ego");
-  ego_entity.setParameter<bool>("allow_goal_modification", true);
-  api_.attachLidarSensor("ego", 0.0);
-
-  api_.attachDetectionSensor("ego", 200.0, true, 0.0, 0, 0.0, 0.0);
-
-  api_.attachOccupancyGridSensor([this] {
-    simulation_api_schema::OccupancyGridSensorConfiguration configuration;
-    // clang-format off
-      configuration.set_architecture_type(api_.getROS2Parameter<std::string>("architecture_type", "awf/universe/20240605"));
-      configuration.set_entity("ego");
-      configuration.set_filter_by_range(true);
-      configuration.set_height(200);
-      configuration.set_range(300);
-      configuration.set_resolution(0.5);
-      configuration.set_update_duration(0.1);
-      configuration.set_width(200);
-    // clang-format on
-    return configuration;
-  }());
   ego_entity.requestAssignRoute(goal_lanelet_poses);
 
   using namespace std::chrono_literals;
@@ -164,6 +146,11 @@ auto CppScenarioNode::spawnEgoEntity(
   api_.spawn(
     "ego", spawn_lanelet_pose, parameters, traffic_simulator::VehicleBehavior::autoware(),
     ego_model_);
+  configureEgoEntity();
+}
+
+auto CppScenarioNode::configureEgoEntity() -> void
+{
   auto & ego_entity = api_.getEgoEntity("ego");
   ego_entity.setParameter<bool>("allow_goal_modification", true);
   api_.attachLidarSensor("ego", 0.0);

--- a/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
+++ b/mock/cpp_mock_scenarios/src/cpp_scenario_node.cpp
@@ -35,6 +35,8 @@ CppScenarioNode::CppScenarioNode(
   get_parameter<std::string>("junit_path", junit_path_);
   declare_parameter<int>("global_timeout", 10.0);
   get_parameter<int>("global_timeout", timeout_);
+  declare_parameter<std::string>("ego_model", "");
+  get_parameter<std::string>("ego_model", ego_model_);
 
   traffic_simulator::lanelet_pose::CanonicalizedLaneletPose::setConsiderPoseByRoadSlope([&]() {
     if (not has_parameter("consider_pose_by_road_slope")) {
@@ -62,10 +64,14 @@ void CppScenarioNode::update()
   }
 }
 
-void CppScenarioNode::start()
+void CppScenarioNode::start(const bool start_scenario_clock)
 {
   onInitialize();
-  api_.startNpcLogic();
+  /// @note If true (default), start the scenario clock immediately.
+  /// For AWSIM + Autoware integration, set to false and start manually after EGO reaches the expected state.
+  if (start_scenario_clock) {
+    api_.startNpcLogic();
+  }
   const auto rate =
     std::chrono::duration<double>(1.0 / get_parameter("global_frame_rate").as_double());
   update_timer_ = this->create_wall_timer(rate, std::bind(&CppScenarioNode::update, this));
@@ -105,7 +111,9 @@ void CppScenarioNode::spawnEgoEntity(
 {
   api_.updateFrame();
   std::this_thread::sleep_for(std::chrono::duration<double>(1.0 / 20.0));
-  api_.spawn("ego", spawn_lanelet_pose, parameters, traffic_simulator::VehicleBehavior::autoware());
+  api_.spawn(
+    "ego", spawn_lanelet_pose, parameters, traffic_simulator::VehicleBehavior::autoware(),
+    ego_model_);
   auto & ego_entity = api_.getEgoEntity("ego");
   ego_entity.setParameter<bool>("allow_goal_modification", true);
   api_.attachLidarSensor("ego", 0.0);


### PR DESCRIPTION
# Description
This PR enables the execution of C++ scenarios with AWSIM. To achieve this, several changes have been introduced while preserving the default functionality. By default, the code behaves as it did before the modifications.

## Abstract

Enable support for running C++ scenarios with AWSIM.

## Background

## Details

- Added support for delaying the scenario clock start. By default, this behavior remains unchanged.
- Added support for spawning the EGO vehicle without assigning a route. If no goal pose is provided, the vehicle will spawn without a route.
- Introduced the ego_model parameter to ensure correct spawning in AWSIM. If not provided, it defaults to an empty string, preserving previous behavior.
- Introduced the map_path parameter. If not specified, the ROS 2 parameter is used. If specified in the scenario, it takes precedence and overrides the ROS 2 parameter.

## References

Jira: [link](https://tier4.atlassian.net/browse/RJD-1776)

# Destructive Changes

N/A

# Known Limitations

N/A