### PR TITLE
Add GitHub Action step to verify random_test_runner execution

### DIFF
--- a/.github/workflows/workflow.sh
+++ b/.github/workflows/workflow.sh
@@ -25,4 +25,17 @@ do
   fi
 done < "$file_path"
 
+random_output_dir="/tmp/random_test_runner"
+mkdir -p "$random_output_dir"
+
+# Note: In this case, we consider the test as PASSED if at least one scenario passes.
+ros2 launch random_test_runner random_test.launch.py output_directory:="$random_output_dir" npc_count:=1 test_timeout:=120.0
+ros2 run random_test_runner result_checker.py "$random_output_dir/random_test_runner/result.junit.xml"
+random_passed=$?
+
+if [ $random_passed -ne 0 ]; then
+  echo "Error: caught non-zero exit status（code: $random_passed)"
+  exit_status=1
+fi
+
 exit $exit_status

--- a/test_runner/random_test_runner/CMakeLists.txt
+++ b/test_runner/random_test_runner/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake_auto REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 include(FindProtobuf REQUIRED)
 
 # TODO(HansRobo): Remove this workaround once https://github.com/autowarefoundation/autoware_universe/issues/10410 is fixed
@@ -76,6 +77,11 @@ ament_auto_add_executable(${PROJECT_NAME}_node
 install(
   DIRECTORY launch rviz include param test/map
   DESTINATION share/${PROJECT_NAME}
+)
+
+install(
+  PROGRAMS scripts/result_checker.py
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)

--- a/test_runner/random_test_runner/package.xml
+++ b/test_runner/random_test_runner/package.xml
@@ -28,6 +28,7 @@
 
   <exec_depend>openscenario_visualization</exec_depend>
   <exec_depend>behavior_tree_plugin</exec_depend>
+  <exec_depend>ament_cmake_python</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/test_runner/random_test_runner/script/result_checker.py
+++ b/test_runner/random_test_runner/script/result_checker.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import argparse
+import xml.etree.ElementTree as ET
+import sys
+
+class ResultChecker:
+    def __init__(self):
+        pass
+
+    def check(self, xml_path):
+        try:
+            tree = ET.parse(xml_path)
+            root = tree.getroot()
+        except Exception as e:
+            print(f"Failed to parse XML: {e}")
+            return False
+
+        passed, failed = 0, 0
+
+        for suite in root:
+            for case in suite:
+                if case.find("failure") is None and case.find("error") is None:
+                    passed += 1
+                else:
+                    failed += 1
+
+        return passed > 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check result.junit.xml: passes if at least one test passed.")
+    parser.add_argument("xml", help="JUnit XML result file")
+    args = parser.parse_args()
+
+    checker = ResultChecker()
+    result = checker.check(args.xml)
+    sys.exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description


## Abstract

## Background

## Details

This change adds a GitHub Action step that runs the `random_test_runner` using its launch file
and verifies the test outcome via `result_checker.py`.

It ensures that:
- The test executes correctly in CI environment
- The result is parsed from `result.junit.xml`
- The job fails if no tests pass (at least one must succeed)

Implements outcome from the meeting: verify random test runner execution in CI.

## References

Jira [ticket](https://tier4.atlassian.net/browse/RJD-1755)

# Destructive Changes

N/A 

# Known Limitations
N/A