### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* ms.kataoka@gmail.com httperror@404-notfound.jp kotaro.yoshimoto@tier4.jp shouth373@gmail.com ttttghghnb554z@outlook.jp


### PR DESCRIPTION
# Description

## Abstract

Add GitHub CODEOWNERS file and add TIER IV scenario simulator developers to it.

## Background

There was a risk that it would be merged if there was approval from outside the team.

## References

https://docs.github.com/ja/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

# Destructive Changes

None

# Known Limitations

If we set this, everyone on the team will be set as a reviewer, and there will be a problem where it will be unclear who is the primary reviewer. For the time being, we will deal with this by closely communicating with each other and removing the assignment of everyone except the primary reviewer during reviews.