### PR TITLE
Return "follow_polyline_trajectory" behavior in do_nothing behavior plugin

### DIFF
--- a/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
+++ b/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
@@ -35,7 +35,6 @@ public:
   void configure(const rclcpp::Logger & logger) override;
   /**
    * @brief Get the Current Action object
-   * @return const std::string& always return "do_nothing"
    */
   auto getCurrentAction() -> const std::string & override;
 
@@ -80,6 +79,7 @@ private:                                                               \
   DEFINE_GETTER_SETTER(StepTime,                  double,                                                           step_time_)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
+  std::string behavior = "do_nothing";  ///< The action name for this behavior plugin.
 };
 }  // namespace entity_behavior
 

--- a/simulation/do_nothing_plugin/src/plugin.cpp
+++ b/simulation/do_nothing_plugin/src/plugin.cpp
@@ -180,6 +180,7 @@ void DoNothingBehavior::update(double current_time, double step_time)
 
   canonicalized_entity_status_->setTime(current_time);
   if (getRequest() == traffic_simulator::behavior::Request::FOLLOW_POLYLINE_TRAJECTORY) {
+    behavior = "follow_polyline_trajectory";
     canonicalized_entity_status_->set(
       interpolate_entity_status_on_polyline_trajectory(), getRouteLanelets(),
       getDefaultMatchingDistanceForLaneletPoseCalculation());
@@ -187,8 +188,10 @@ void DoNothingBehavior::update(double current_time, double step_time)
       getCurrentTime() + getStepTime() >=
       do_nothing_behavior::follow_trajectory::getLastVertexTimestamp(getPolylineTrajectory())) {
       setRequest(traffic_simulator::behavior::Request::NONE);
+      behavior = "do_nothing";
     }
   } else {
+    behavior = "do_nothing";
     canonicalized_entity_status_->set(
       static_cast<traffic_simulator::EntityStatus>(*canonicalized_entity_status_),
       getRouteLanelets(), getDefaultMatchingDistanceForLaneletPoseCalculation());
@@ -196,7 +199,6 @@ void DoNothingBehavior::update(double current_time, double step_time)
 }
 auto DoNothingBehavior::getCurrentAction() -> const std::string &
 {
-  static const std::string behavior = "do_nothing";
   return behavior;
 }
 }  // namespace entity_behavior


### PR DESCRIPTION
# Description

## Abstract

Return "follow_polyline_trajectory" behavior in do_nothing behavior plugin when following a polyline trajectory request.

## Background

The do_nothing behavior plugin previously always returned "do_nothing" as its current action, even when it was actively following a polyline trajectory. This made it difficult to distinguish between actual do-nothing behavior and trajectory-following behavior.

## Details

This PR modifies the `DoNothingBehavior` plugin to properly report its current action based on the actual behavior being executed:

- Changed `behavior` from a static local variable to a class member variable
- When `Request::FOLLOW_POLYLINE_TRAJECTORY` is active, the plugin now returns "follow_polyline_trajectory" 
- When the trajectory is completed or no trajectory request exists, it returns "do_nothing"
- Updated the documentation comment in the header file to reflect that the method no longer always returns "do_nothing"

This change improves observability by allowing external systems to correctly identify when the entity is following a trajectory versus truly doing nothing.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>