### PR TITLE
Initialize twist/accel values to zero in DoNothingBehavior when not following trajectory

### DIFF
--- a/simulation/do_nothing_plugin/src/plugin.cpp
+++ b/simulation/do_nothing_plugin/src/plugin.cpp
@@ -192,7 +192,8 @@ void DoNothingBehavior::update(double current_time, double step_time)
     }
   } else {
     behavior = "do_nothing";
-    auto entity_status_with_zero_twist_accel = static_cast<traffic_simulator::EntityStatus>(*canonicalized_entity_status_);
+    auto entity_status_with_zero_twist_accel =
+      static_cast<traffic_simulator::EntityStatus>(*canonicalized_entity_status_);
     entity_status_with_zero_twist_accel.action_status.twist =
       geometry_msgs::build<geometry_msgs::msg::Twist>()
         .linear(geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0).y(0).z(0))
@@ -202,8 +203,8 @@ void DoNothingBehavior::update(double current_time, double step_time)
         .linear(geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0).y(0).z(0))
         .angular(geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0).y(0).z(0));
     canonicalized_entity_status_->set(
-      entity_status_with_zero_twist_accel,
-      getRouteLanelets(), getDefaultMatchingDistanceForLaneletPoseCalculation());
+      entity_status_with_zero_twist_accel, getRouteLanelets(),
+      getDefaultMatchingDistanceForLaneletPoseCalculation());
   }
 }
 auto DoNothingBehavior::getCurrentAction() -> const std::string & { return behavior; }

--- a/simulation/do_nothing_plugin/src/plugin.cpp
+++ b/simulation/do_nothing_plugin/src/plugin.cpp
@@ -192,8 +192,17 @@ void DoNothingBehavior::update(double current_time, double step_time)
     }
   } else {
     behavior = "do_nothing";
+    auto entity_status_with_zero_twist_accel = static_cast<traffic_simulator::EntityStatus>(*canonicalized_entity_status_);
+    entity_status_with_zero_twist_accel.action_status.twist =
+      geometry_msgs::build<geometry_msgs::msg::Twist>()
+        .linear(geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0).y(0).z(0))
+        .angular(geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0).y(0).z(0));
+    entity_status_with_zero_twist_accel.action_status.accel =
+      geometry_msgs::build<geometry_msgs::msg::Accel>()
+        .linear(geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0).y(0).z(0))
+        .angular(geometry_msgs::build<geometry_msgs::msg::Vector3>().x(0).y(0).z(0));
     canonicalized_entity_status_->set(
-      static_cast<traffic_simulator::EntityStatus>(*canonicalized_entity_status_),
+      entity_status_with_zero_twist_accel,
       getRouteLanelets(), getDefaultMatchingDistanceForLaneletPoseCalculation());
   }
 }


### PR DESCRIPTION
# Description

  ## Abstract

  Fixed DoNothingBehavior to initialize twist and accel values to zero when not in FollowTrajectory state, ensuring proper StandStillDuration calculations for stopped entities.

  ## Background

  Previously, when DoNothingBehavior was not following a trajectory, the twist and accel values were not being reset to zero. This caused issues with StandStillDuration calculations, as the system would incorrectly measure standstill duration even when the entity appeared to be stopped but still had non-zero
   velocity values internally.

  ## Details

  * Modified the `update` method in DoNothingBehavior plugin to explicitly set twist and accel to zero when in "do_nothing" state
  * Used geometry_msgs::build functions for consistent initialization with existing code style

  ## References

  N/A

  # Destructive Changes

  N/A

  # Known Limitations

  N/A

🤖 Generated with [Claude Code](https://claude.ai/code)