### PR TITLE
Disable sonar cloud step in pull-request from external forks

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -77,6 +77,7 @@ jobs:
         shell: bash
 
       - name: Install Build Wrapper
+        if: github.event.pull_request.head.repo.fork == false
         uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v4.2.1
         id: build_wrapper
         env:
@@ -88,8 +89,10 @@ jobs:
         # See also: https://gitlab.com/libeigen/eigen/-/issues/2326
         run: |
           source /opt/ros/${{ matrix.rosdistro }}/setup.bash
-          ${{ steps.build_wrapper.outputs.build-wrapper-binary }} --out-dir src/scenario_simulator_v2/bw-output \
-          colcon build --symlink-install \
+          if [[ -n "${{ steps.build_wrapper.outputs.build-wrapper-binary }}" ]]; then
+            COMMAND_PREFIX="${{ steps.build_wrapper.outputs.build-wrapper-binary }} --out-dir src/scenario_simulator_v2/bw-output"
+          fi
+          $COMMAND_PREFIX colcon build --symlink-install \
           --cmake-args \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DBUILD_CPP_MOCK_SCENARIOS=ON \
@@ -142,7 +145,7 @@ jobs:
         shell: bash
 
       - uses: actions/github-script@v7
-        if: steps.optional-scenario-test.outputs.failure > 0 && matrix.runs_on != 'ubuntu-22.04-arm'
+        if: steps.optional-scenario-test.outputs.failure > 0 && matrix.runs_on != 'ubuntu-22.04-arm' && github.event.pull_request.head.repo.fork == false
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -177,7 +180,7 @@ jobs:
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v4.2.1
         # In ARM build, SonarQube result should be same as x86 build because no test runs
-        if: matrix.runs_on != 'ubuntu-22.04-arm'
+        if: matrix.runs_on != 'ubuntu-22.04-arm' && github.event.pull_request.head.repo.fork == false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
# Description

## Abstract

Disable sonar cloud action in pull-request from external forks

## Background

Many workflows does not work well in pull-request from external forks like [this](https://github.com/tier4/scenario_simulator_v2/pull/1649).

## References

The modified workflow works well in pull-request from external fork.
https://github.com/tier4/scenario_simulator_v2/pull/1605

# Destructive Changes

None

# Known Limitations

comment step for optional warning is also disabled in this pull-request bacause it requires write permission that is not provided in pull-request from external forks for security perspective.