### PR TITLE
CI workaround: ignore SonarQube Cloud error

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -179,6 +179,7 @@ jobs:
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v4.2.1
+        id: sonarcloud
         # In ARM build, SonarQube result should be same as x86 build because no test runs
         if: matrix.runs_on != 'ubuntu-22.04-arm' && github.event.pull_request.head.repo.fork == false
         continue-on-error: true
@@ -196,3 +197,10 @@ jobs:
 #          source install/local_setup.bash
 #          ./src/scenario_simulator_v2/.github/workflows/workflow.sh ./src/scenario_simulator_v2_scenarios/workflow/basic.txt
 #        shell: bash
+
+      - name: Report error if SonarQube scan failed
+        if: steps.sonarcloud.outcome == 'failure'
+        uses: mshick/add-pr-comment@v2
+        with:
+          message: "This PR has failed the SonarQube scan. Please check the details in the SonarQube dashboard."
+          message-id: "sonarcloud-scan-failure"


### PR DESCRIPTION
# Description

## Abstract

This PR will ignore SonarQube Cloud error.

## Background

In some GitHub Actions Exection, SonarQube error was observed (e.g., https://github.com/tier4/scenario_simulator_v2/actions/runs/16771379430/job/47487096560)
By reading error logs carefully, it caused by Network Error.

```
10:06:58.020 INFO  Analysis report generated in 189ms, dir size=987 KB
10:06:58.509 INFO  Analysis report compressed in 488ms, zip size=778 KB
10:07:09.206 ERROR Error during SonarScanner Engine execution
java.lang.IllegalStateException: Fail to request ***/api/ce/submit?organization=tier4&projectKey=tier4_scenario_simulator_v2&projectName=scenario_simulator_v2&characteristic=pullRequest%3D1661
	at com.sonarsource.scanner.engine.webapi.client.HttpConnector.doCall(HttpConnector.java:253)
	at com.sonarsource.scanner.engine.webapi.client.HttpConnector.post(HttpConnector.java:182)
	at com.sonarsource.scanner.engine.webapi.client.HttpConnector.call(HttpConnector.java:138)
	at org.sonar.scanner.http.DefaultScannerWsClient.call(DefaultScannerWsClient.java:54)
	at org.sonar.scanner.report.ReportPublisher.upload(ReportPublisher.java:220)```
```
However, retrying shortly will not fix (maybe root cause is Azure problem)

## Details

By this PR, any error of SonarQube will not affect Check result (instead, send some messages to PR)