### PR TITLE
fix(CppMockScenarios): Add missing initialize_localization parameter to cpp mock scenarios launch file

### DIFF
--- a/mock/cpp_mock_scenarios/launch/mock_test.launch.py
+++ b/mock/cpp_mock_scenarios/launch/mock_test.launch.py
@@ -131,6 +131,7 @@ def launch_setup(context, *args, **kwargs):
     scenario_package                    = LaunchConfiguration("package",                                default="cpp_mock_scenarios")
     junit_path                          = LaunchConfiguration("junit_path",                             default="/tmp/output.xunit.xml")
     map_path                            = LaunchConfiguration("map_path",                               default="")
+    initialize_localization             = LaunchConfiguration("initialize_localization",                default=10)
     # fmt: on
 
     print(f"architecture_type                   := {architecture_type.perform(context)}")
@@ -159,6 +160,7 @@ def launch_setup(context, *args, **kwargs):
     print(f"vehicle_model                       := {vehicle_model.perform(context)}")
     print(f"scenario_package                    := {scenario_package.perform(context)}")
     print(f"junit_path                          := {junit_path.perform(context)}")
+    print(f"initialize_localization             := {initialize_localization.perform(context)}")
 
     def make_parameters():
         parameters = [
@@ -183,6 +185,7 @@ def launch_setup(context, *args, **kwargs):
             {"junit_path": junit_path},
             {"ego_model": ego_model},
             {"map_path": map_path},
+            {"initialize_localization": initialize_localization},
         ]
         parameters += make_vehicle_parameters()
         parameters += [parameter_file_path.perform(context)]
@@ -252,6 +255,7 @@ def launch_setup(context, *args, **kwargs):
         DeclareLaunchArgument("scenario_package",                    default_value=scenario_package                   ),
         DeclareLaunchArgument("junit_path",                          default_value=junit_path                         ),
         DeclareLaunchArgument("map_path",                            default_value=map_path                           ),
+        DeclareLaunchArgument("initialize_localization",             default_value=initialize_localization            ),
         # fmt: on
         cpp_scenario_node,
         Node(


### PR DESCRIPTION
# Description

This PR adds the missing `initialize_localization` parameter to the `cpp_mock_scenarios` launch file, allowing cpp scenarios to be executed with AWSIM. Since the `cpp_mock_scenarios` package is not covered by evaluator tests, no regression tests have been performed for this change.

This parameter was introduced in the scenario_test_runner launch file (PR [#1667](https://github.com/tier4/scenario_simulator_v2/pull/1667)) but was not added to the cpp_mock_scenarios launch file.

## Background

Currently, there are two ways to execute cpp scenarios with AWSIM:

- Using the launch file from the cpp_mock_scenarios_awsim repository.
- Using the launch file provided in the cpp_mock_scenarios package.

The second option was failing because the initialize_localization parameter was not defined.

## Details

- Added missing `initialize_localization` parameter to the `cpp_mock_scenarios` launch [file](https://github.com/tier4/scenario_simulator_v2/pull/1671/files#diff-691b7eab3add22a4a6822b6f1853989fe2cf06bb63d9c4c37a2c70562e555244).  
- Set default value to `10` to ensure consistent behavior across both launch files.  

## References

Jira [ticket](https://tier4.atlassian.net/browse/RJD-1922?actionerId=712020%3Aade2a759-9d15-4c13-9bdf-9b5afb04aa45&sourceType=assign)

# Destructive Changes

N/A

# Known Limitations

N/A