### PR TITLE
Fixed POSE_IN_LANE reference

### DIFF
--- a/test_runner/scenario_test_runner/scenario/sample_awsim.yaml
+++ b/test_runner/scenario_test_runner/scenario/sample_awsim.yaml
@@ -101,7 +101,7 @@ OpenSCENARIO:
                     LanePosition:
                       roadId: ''
                       laneId: '225'
-                      s: POSE_IN_LANE
+                      s: ${POSE_IN_LANE}
                       offset: -0.1748
                       Orientation:
                         type: relative


### PR DESCRIPTION
# Description

Fix variable reference in sample_awsim.yaml

## Abstract

For running OpenScenario with AWSIM 2.0 the following command is required: 
```
source install/setup.bash
ros2 launch scenario_test_runner scenario_test_runner.launch.py                        \
architecture_type:=awf/universe/20250130  record:=false                                         \
scenario:='$(find-pkg-share scenario_test_runner)/scenario/sample_awsim.yaml'          \
sensor_model:=awsim_sensor_kit  vehicle_model:=sample_vehicle                          \
launch_simple_sensor_simulator:=false autoware_launch_file:="e2e_simulator.launch.xml" \
initialize_duration:=260 port:=8080
```

However this results in the following error:
```

[scenario_test_runner.py-1] Error: failed validating 'POSE_IN_LANE' with XsdPatternFacets(['[$][{][ A-Za-z0-9_\\+\\-\\*/%$\\(\\)\\.,]*[\\}]']):
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Reason: value doesn't match any pattern of ['[$][{][ A-Za-z0-9_\\+\\-\\*/%$\\(\\)\\.,]*[\\}]']
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Schema component:
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1]   <xsd:pattern xmlns:xsd="http://www.w3.org/2001/XMLSchema" value="[$][{][ A-Za-z0-9_\+\-\*/%$\(\)\.,]*[\}]" />
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Instance type: <class 'xml.etree.ElementTree.Element'>
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Instance:
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1]   <LanePosition roadId="" laneId="225" s="POSE_IN_LANE" offset="-0.1748">
[scenario_test_runner.py-1]     <Orientation type="relative" h="0" p="-0.0" r="0" />
[scenario_test_runner.py-1]   </LanePosition>
[scenario_test_runner.py-1] 
[scenario_test_runner.py-1] Path: /OpenSCENARIO/Storyboard/Init/Actions/Private[1]/PrivateAction[1]/TeleportAction/Position/LanePosition
[scenario_test_runner.py-1] 
```

I fixed the reference and the script is working fine again.
