### PR TITLE
Feature/openscenario per entity lateral collision margin

### DIFF
--- a/docs/developer_guide/NPCBehavior.md
+++ b/docs/developer_guide/NPCBehavior.md
@@ -191,26 +191,29 @@ This behavior was developed primarily to drive the simulator from Autoware rosba
 
 ## Shared Property: Lateral Collision Threshold (`lateralCollisionThreshold`)
 
-**Summary** — Allows you to override, per entity, the distance threshold (meters) used for lateral collision checks. If unspecified, the legacy behavior uses half of the ego vehicle’s width.
+**Terminology** — *Acting entity* means the entity currently executing the BT action. It does **not** mean an Autoware-operated vehicle.
+
+**Summary** — Allows you to override, per entity, the distance threshold (meters) used for lateral collision checks. If unspecified, the legacy behavior uses half of the **acting entity’s width**.
 
 **Purpose** — To adjust, per scenario and per entity, the sensitivity to “lateral interference” near lanes (e.g., lane splitting or side-by-side travel). This threshold is used in the collision-candidate computation inside the `ActionNode`.
 
 **Specification**
 
 * **Specifying from OpenSCENARIO**
-  Set `name="lateralCollisionThreshold"` (value is a real number in meters) in `ObjectController/Controller/Properties/Property` to apply it to that entity. If the property is absent, `std::nullopt` is set and the default behavior (width \* 0.5) is used.
+  Set `name="lateralCollisionThreshold"` (value is a real number in meters) in `ObjectController/Controller/Properties/Property` to apply it to that entity. If the property is absent, `std::nullopt` is set and the default behavior (**width × 0.5 of the acting entity**) is used.
 
 * **Handling in BT (Behavior Tree)**
   The common base `ActionNode` for all BT actions adds `InputPort<std::optional<double>>("lateral_collision_threshold")`, which allows overriding the value. Internally it is used as:
   `threshold = lateral_collision_threshold_.value_or(from_bounding_box.dimensions.y * 0.5)`
+  (i.e., half of the **acting entity’s bounding-box width** when unspecified)
 
 * **Scope**
   Enabled in the Vehicle / Pedestrian BT plugins. Do-Nothing does not perform BT-based collision checks, so there is no effect by default (a setter is provided in the API).
 
 * **Compatibility**
-  Existing scenarios see no behavioral change if the property is unspecified (legacy value = ego vehicle width / 2).
+  Existing scenarios see no behavioral change if the property is unspecified (legacy value = **acting entity width / 2**).
 
-**Default behavior** — When the property is unspecified, collision candidates are evaluated using the threshold `"ego vehicle width / 2"`.
+**Default behavior** — When the property is unspecified, collision candidates are evaluated using the threshold **“acting entity width / 2.”**
 
 **Example (YAML)** —
 
@@ -223,4 +226,3 @@ ObjectController:
         - name: "lateralCollisionThreshold"
           value: "0.8"   # unit: m
 ```
-

--- a/docs/developer_guide/NPCBehavior.md
+++ b/docs/developer_guide/NPCBehavior.md
@@ -188,3 +188,39 @@ When this behavior is used, entity can only be moved by specifying its pose, vel
 When using this behavior, any consistency in physical behavior is ignored. Changes in posture, velocity, acceleration, and jerk over time will not occur.  
 The EntityStatus value will continue to be the value specified and updated via the `API::setEntityStatus` function, etc.  
 This behavior was developed primarily to drive the simulator from Autoware rosbag data.  
+
+## Shared Property: Lateral Collision Threshold (`lateralCollisionThreshold`)
+
+**Summary** — Allows you to override, per entity, the distance threshold (meters) used for lateral collision checks. If unspecified, the legacy behavior uses half of the ego vehicle’s width.
+
+**Purpose** — To adjust, per scenario and per entity, the sensitivity to “lateral interference” near lanes (e.g., lane splitting or side-by-side travel). This threshold is used in the collision-candidate computation inside the `ActionNode`.
+
+**Specification**
+
+* **Specifying from OpenSCENARIO**
+  Set `name="lateralCollisionThreshold"` (value is a real number in meters) in `ObjectController/Controller/Properties/Property` to apply it to that entity. If the property is absent, `std::nullopt` is set and the default behavior (width \* 0.5) is used.
+
+* **Handling in BT (Behavior Tree)**
+  The common base `ActionNode` for all BT actions adds `InputPort<std::optional<double>>("lateral_collision_threshold")`, which allows overriding the value. Internally it is used as:
+  `threshold = lateral_collision_threshold_.value_or(from_bounding_box.dimensions.y * 0.5)`
+
+* **Scope**
+  Enabled in the Vehicle / Pedestrian BT plugins. Do-Nothing does not perform BT-based collision checks, so there is no effect by default (a setter is provided in the API).
+
+* **Compatibility**
+  Existing scenarios see no behavioral change if the property is unspecified (legacy value = ego vehicle width / 2).
+
+**Default behavior** — When the property is unspecified, collision candidates are evaluated using the threshold `"ego vehicle width / 2"`.
+
+**Example (YAML)** —
+
+```yaml
+ObjectController:
+  Controller:
+    name: '...'
+    Properties:
+      Property:
+        - name: "lateralCollisionThreshold"
+          value: "0.8"   # unit: m
+```
+

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -338,19 +338,12 @@ public:
       entity.setVelocityLimit(controller.properties.template get<Double>(
         "maxSpeed", std::numeric_limits<Double::value_type>::max()));
 
-      // Optional per-entity lateral collision margin (meters)
-      // If omitted: leave unset (std::nullopt) to preserve legacy behavior.
-      try {
-        if (controller.properties.contains("lateralCollisionMargin")) {
-          entity.setLateralCollisionMargin(
-            controller.properties.template get<Double>("lateralCollisionMargin"));
-        } else {
-          entity.setLateralCollisionMargin(std::nullopt);
-        }
-      } catch (...) {
-        // Some entity types may not support this setter; ignore silently.
+      if (controller.properties.contains("lateralCollisionMargin")) {
+        entity.setLateralCollisionMargin(
+          controller.properties.template get<Double>("lateralCollisionMargin"));
+      } else {
+        entity.setLateralCollisionMargin(std::nullopt);
       }
-
       entity.setBehaviorParameter([&]() {
         auto message = entity.getBehaviorParameter();
         message.see_around = not controller.properties.template get<Boolean>("isBlind");

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -339,12 +339,16 @@ public:
         "maxSpeed", std::numeric_limits<Double::value_type>::max()));
 
       // Optional per-entity lateral collision margin (meters)
-      // If omitted, defaults to 0 and preserves prior behavior.
+      // If omitted: leave unset (std::nullopt) to preserve legacy behavior.
       try {
         entity.setLateralCollisionMargin(
-          controller.properties.template get<Double>("lateralCollisionMargin", 0.0));
+          controller.properties.template get<Double>("lateralCollisionMargin"));
       } catch (...) {
-        // Some entity types may not support this setter; ignore silently.
+        try {
+          entity.setLateralCollisionMargin(std::nullopt);
+        } catch (...) {
+          // Some entity types may not support this setter; ignore silently.
+        }
       }
 
       entity.setBehaviorParameter([&]() {

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -341,14 +341,14 @@ public:
       // Optional per-entity lateral collision margin (meters)
       // If omitted: leave unset (std::nullopt) to preserve legacy behavior.
       try {
-        entity.setLateralCollisionMargin(
-          controller.properties.template get<Double>("lateralCollisionMargin"));
-      } catch (...) {
-        try {
+        if (controller.properties.contains("lateralCollisionMargin")) {
+          entity.setLateralCollisionMargin(
+            controller.properties.template get<Double>("lateralCollisionMargin"));
+        } else {
           entity.setLateralCollisionMargin(std::nullopt);
-        } catch (...) {
-          // Some entity types may not support this setter; ignore silently.
         }
+      } catch (...) {
+        // Some entity types may not support this setter; ignore silently.
       }
 
       entity.setBehaviorParameter([&]() {

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -338,11 +338,11 @@ public:
       entity.setVelocityLimit(controller.properties.template get<Double>(
         "maxSpeed", std::numeric_limits<Double::value_type>::max()));
 
-      if (controller.properties.contains("lateralCollisionMargin")) {
-        entity.setLateralCollisionMargin(
-          controller.properties.template get<Double>("lateralCollisionMargin"));
+      if (controller.properties.contains("lateralCollisionThreshold")) {
+        entity.setLateralCollisionThreshold(
+          controller.properties.template get<Double>("lateralCollisionThreshold"));
       } else {
-        entity.setLateralCollisionMargin(std::nullopt);
+        entity.setLateralCollisionThreshold(std::nullopt);
       }
       entity.setBehaviorParameter([&]() {
         auto message = entity.getBehaviorParameter();

--- a/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
+++ b/openscenario/openscenario_interpreter/include/openscenario_interpreter/simulator_core.hpp
@@ -338,6 +338,15 @@ public:
       entity.setVelocityLimit(controller.properties.template get<Double>(
         "maxSpeed", std::numeric_limits<Double::value_type>::max()));
 
+      // Optional per-entity lateral collision margin (meters)
+      // If omitted, defaults to 0 and preserves prior behavior.
+      try {
+        entity.setLateralCollisionMargin(
+          controller.properties.template get<Double>("lateralCollisionMargin", 0.0));
+      } catch (...) {
+        // Some entity types may not support this setter; ignore silently.
+      }
+
       entity.setBehaviorParameter([&]() {
         auto message = entity.getBehaviorParameter();
         message.see_around = not controller.properties.template get<Boolean>("isBlind");

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
@@ -86,7 +86,7 @@ public:
       BT::InputPort<traffic_simulator::behavior::Request>("request"),
       BT::InputPort<std::shared_ptr<EuclideanDistancesMap>>("euclidean_distances_map"),
       BT::InputPort<traffic_simulator_msgs::msg::BehaviorParameter>("behavior_parameter"),
-      BT::InputPort<double>("lateral_collision_margin"),
+      BT::InputPort<std::optional<double>>("lateral_collision_margin"),
       BT::OutputPort<std::optional<traffic_simulator_msgs::msg::Obstacle>>("obstacle"),
       BT::OutputPort<traffic_simulator_msgs::msg::WaypointsArray>("waypoints"),
       BT::OutputPort<traffic_simulator::behavior::Request>("request"),
@@ -118,7 +118,7 @@ protected:
   EntityStatusDict other_entity_status_;
   lanelet::Ids route_lanelets_;
   traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter_;
-  double lateral_collision_margin_ = 0.0;
+  std::optional<double> lateral_collision_margin_;
 
   virtual bool checkPreconditions() { return true; }
   virtual BT::NodeStatus doAction() = 0;

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
@@ -86,6 +86,7 @@ public:
       BT::InputPort<traffic_simulator::behavior::Request>("request"),
       BT::InputPort<std::shared_ptr<EuclideanDistancesMap>>("euclidean_distances_map"),
       BT::InputPort<traffic_simulator_msgs::msg::BehaviorParameter>("behavior_parameter"),
+      BT::InputPort<double>("lateral_collision_margin"),
       BT::OutputPort<std::optional<traffic_simulator_msgs::msg::Obstacle>>("obstacle"),
       BT::OutputPort<traffic_simulator_msgs::msg::WaypointsArray>("waypoints"),
       BT::OutputPort<traffic_simulator::behavior::Request>("request"),
@@ -117,6 +118,7 @@ protected:
   EntityStatusDict other_entity_status_;
   lanelet::Ids route_lanelets_;
   traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter_;
+  double lateral_collision_margin_ = 0.0;
 
   virtual bool checkPreconditions() { return true; }
   virtual BT::NodeStatus doAction() = 0;

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/action_node.hpp
@@ -86,7 +86,7 @@ public:
       BT::InputPort<traffic_simulator::behavior::Request>("request"),
       BT::InputPort<std::shared_ptr<EuclideanDistancesMap>>("euclidean_distances_map"),
       BT::InputPort<traffic_simulator_msgs::msg::BehaviorParameter>("behavior_parameter"),
-      BT::InputPort<std::optional<double>>("lateral_collision_margin"),
+      BT::InputPort<std::optional<double>>("lateral_collision_threshold"),
       BT::OutputPort<std::optional<traffic_simulator_msgs::msg::Obstacle>>("obstacle"),
       BT::OutputPort<traffic_simulator_msgs::msg::WaypointsArray>("waypoints"),
       BT::OutputPort<traffic_simulator::behavior::Request>("request"),
@@ -118,7 +118,7 @@ protected:
   EntityStatusDict other_entity_status_;
   lanelet::Ids route_lanelets_;
   traffic_simulator_msgs::msg::BehaviorParameter behavior_parameter_;
-  std::optional<double> lateral_collision_margin_;
+  std::optional<double> lateral_collision_threshold_;
 
   virtual bool checkPreconditions() { return true; }
   virtual BT::NodeStatus doAction() = 0;

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
@@ -55,9 +55,11 @@ public:
   DEFINE_GETTER_SETTER(CurrentTime,                                      double)
   DEFINE_GETTER_SETTER(DebugMarker,                                      std::vector<visualization_msgs::msg::Marker>)
   DEFINE_GETTER_SETTER(DefaultMatchingDistanceForLaneletPoseCalculation, double)
+  DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
   DEFINE_GETTER_SETTER(GoalPoses,                                        std::vector<geometry_msgs::msg::Pose>)
   DEFINE_GETTER_SETTER(HdMapUtils,                                       std::shared_ptr<hdmap_utils::HdMapUtils>)
   DEFINE_GETTER_SETTER(LaneChangeParameters,                             traffic_simulator::lane_change::Parameter)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
   DEFINE_GETTER_SETTER(Obstacle,                                         std::optional<traffic_simulator_msgs::msg::Obstacle>)
   DEFINE_GETTER_SETTER(OtherEntityStatus,                                EntityStatusDict)
   DEFINE_GETTER_SETTER(PedestrianParameters,                             traffic_simulator_msgs::msg::PedestrianParameters)
@@ -70,8 +72,6 @@ public:
   DEFINE_GETTER_SETTER(TrafficLights,                                    std::shared_ptr<traffic_simulator::TrafficLightsBase>)
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
-  DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
   // clang-format on
 
 #undef DEFINE_GETTER_SETTER

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
@@ -71,6 +71,7 @@ public:
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
   DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           double)
   // clang-format on
 
 #undef DEFINE_GETTER_SETTER

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
@@ -59,7 +59,7 @@ public:
   DEFINE_GETTER_SETTER(GoalPoses,                                        std::vector<geometry_msgs::msg::Pose>)
   DEFINE_GETTER_SETTER(HdMapUtils,                                       std::shared_ptr<hdmap_utils::HdMapUtils>)
   DEFINE_GETTER_SETTER(LaneChangeParameters,                             traffic_simulator::lane_change::Parameter)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
+  DEFINE_GETTER_SETTER(LateralCollisionThreshold,                        std::optional<double>)
   DEFINE_GETTER_SETTER(Obstacle,                                         std::optional<traffic_simulator_msgs::msg::Obstacle>)
   DEFINE_GETTER_SETTER(OtherEntityStatus,                                EntityStatusDict)
   DEFINE_GETTER_SETTER(PedestrianParameters,                             traffic_simulator_msgs::msg::PedestrianParameters)

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/pedestrian/behavior_tree.hpp
@@ -71,7 +71,7 @@ public:
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
   DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           double)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
   // clang-format on
 
 #undef DEFINE_GETTER_SETTER

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
@@ -75,7 +75,7 @@ public:
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
   DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           double)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
@@ -59,9 +59,11 @@ public:
   DEFINE_GETTER_SETTER(CurrentTime,                                      double)
   DEFINE_GETTER_SETTER(DebugMarker,                                      std::vector<visualization_msgs::msg::Marker>)
   DEFINE_GETTER_SETTER(DefaultMatchingDistanceForLaneletPoseCalculation, double)
+  DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
   DEFINE_GETTER_SETTER(GoalPoses,                                        std::vector<geometry_msgs::msg::Pose>)
   DEFINE_GETTER_SETTER(HdMapUtils,                                       std::shared_ptr<hdmap_utils::HdMapUtils>)
   DEFINE_GETTER_SETTER(LaneChangeParameters,                             traffic_simulator::lane_change::Parameter)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
   DEFINE_GETTER_SETTER(Obstacle,                                         std::optional<traffic_simulator_msgs::msg::Obstacle>)
   DEFINE_GETTER_SETTER(OtherEntityStatus,                                EntityStatusDict)
   DEFINE_GETTER_SETTER(PedestrianParameters,                             traffic_simulator_msgs::msg::PedestrianParameters)
@@ -74,8 +76,6 @@ public:
   DEFINE_GETTER_SETTER(TrafficLights,                                    std::shared_ptr<traffic_simulator::TrafficLightsBase>)
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
-  DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
@@ -75,6 +75,7 @@ public:
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
   DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           double)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 

--- a/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
+++ b/simulation/behavior_tree_plugin/include/behavior_tree_plugin/vehicle/behavior_tree.hpp
@@ -63,7 +63,7 @@ public:
   DEFINE_GETTER_SETTER(GoalPoses,                                        std::vector<geometry_msgs::msg::Pose>)
   DEFINE_GETTER_SETTER(HdMapUtils,                                       std::shared_ptr<hdmap_utils::HdMapUtils>)
   DEFINE_GETTER_SETTER(LaneChangeParameters,                             traffic_simulator::lane_change::Parameter)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
+  DEFINE_GETTER_SETTER(LateralCollisionThreshold,                        std::optional<double>)
   DEFINE_GETTER_SETTER(Obstacle,                                         std::optional<traffic_simulator_msgs::msg::Obstacle>)
   DEFINE_GETTER_SETTER(OtherEntityStatus,                                EntityStatusDict)
   DEFINE_GETTER_SETTER(PedestrianParameters,                             traffic_simulator_msgs::msg::PedestrianParameters)

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -383,16 +383,16 @@ auto ActionNode::getDistanceToTargetEntity(
       const auto target_bounding_box_distance =
         bounding_box_distance.value() + from_bounding_box.dimensions.x / 2.0;
 
-      /// @note Lateral conflict rule:
-      /// - If lateral_collision_margin_ is set: compare against that margin only (ignore width).
-      /// - If not set: compare against half-width of the reference entity (legacy behavior).
-      if (const auto target_to_spline_distance = traffic_simulator::distance::distanceToSpline(
-            static_cast<geometry_msgs::msg::Pose>(*target_lanelet_pose), target_bounding_box,
-            spline, longitudinal_distance.value());
-          ((lateral_collision_margin_.has_value() &&
-            target_to_spline_distance <= lateral_collision_margin_.value()) ||
-           (!lateral_collision_margin_.has_value() &&
-            target_to_spline_distance <= from_bounding_box.dimensions.y / 2.0))) {
+      const auto lateral_distance_to_spline = traffic_simulator::distance::distanceToSpline(
+        static_cast<geometry_msgs::msg::Pose>(*target_lanelet_pose), target_bounding_box, spline,
+        longitudinal_distance.value());
+
+      const double threshold =
+        lateral_collision_margin_.value_or(from_bounding_box.dimensions.y * 0.5);
+
+      std::cout << threshold << ", " << from_bounding_box.dimensions.y * 0.5 << std::endl;
+
+      if (lateral_distance_to_spline <= threshold) {
         return target_bounding_box_distance;
       }
       /// @note if the distance of the target entity to the spline cannot be calculated because a collision occurs

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -108,8 +108,8 @@ auto ActionNode::getBlackBoardValues() -> void
         "behavior_parameter", behavior_parameter_)) {
     behavior_parameter_ = traffic_simulator_msgs::msg::BehaviorParameter();
   }
-  if (!getInput<double>("lateral_collision_margin", lateral_collision_margin_)) {
-    lateral_collision_margin_ = 0.0;  // default: no extra lateral margin
+  if (!getInput<std::optional<double>>("lateral_collision_margin", lateral_collision_margin_)) {
+    lateral_collision_margin_ = std::nullopt;  // default: not set
   }
 }
 
@@ -383,13 +383,16 @@ auto ActionNode::getDistanceToTargetEntity(
       const auto target_bounding_box_distance =
         bounding_box_distance.value() + from_bounding_box.dimensions.x / 2.0;
 
-      /// @note If the lateral distance of the target entity to the spline is smaller than
-      /// half the width of the reference entity plus configurable margin, it is conflicting.
+      /// @note Lateral conflict rule:
+      /// - If lateral_collision_margin_ is set: compare against that margin only (ignore width).
+      /// - If not set: compare against half-width of the reference entity (legacy behavior).
       if (const auto target_to_spline_distance = traffic_simulator::distance::distanceToSpline(
             static_cast<geometry_msgs::msg::Pose>(*target_lanelet_pose), target_bounding_box,
             spline, longitudinal_distance.value());
-          target_to_spline_distance <=
-          from_bounding_box.dimensions.y / 2.0 + lateral_collision_margin_) {
+          ((lateral_collision_margin_.has_value() &&
+            target_to_spline_distance <= lateral_collision_margin_.value()) ||
+           (!lateral_collision_margin_.has_value() &&
+            target_to_spline_distance <= from_bounding_box.dimensions.y / 2.0))) {
         return target_bounding_box_distance;
       }
       /// @note if the distance of the target entity to the spline cannot be calculated because a collision occurs

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -108,8 +108,9 @@ auto ActionNode::getBlackBoardValues() -> void
         "behavior_parameter", behavior_parameter_)) {
     behavior_parameter_ = traffic_simulator_msgs::msg::BehaviorParameter();
   }
-  if (!getInput<std::optional<double>>("lateral_collision_margin", lateral_collision_margin_)) {
-    lateral_collision_margin_ = std::nullopt;  // default: not set
+  if (!getInput<std::optional<double>>(
+        "lateral_collision_threshold", lateral_collision_threshold_)) {
+    lateral_collision_threshold_ = std::nullopt;  // default: not set
   }
 }
 
@@ -388,7 +389,8 @@ auto ActionNode::getDistanceToTargetEntity(
         longitudinal_distance.value());
 
       const double threshold =
-        lateral_collision_margin_.value_or(from_bounding_box.dimensions.y * 0.5);
+        lateral_collision_threshold_.value_or(from_bounding_box.dimensions.y * 0.5);
+      std::cout << threshold << ", " << from_bounding_box.dimensions.y * 0.5 << std::endl;
 
       if (lateral_distance_to_spline <= threshold) {
         return target_bounding_box_distance;

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -390,8 +390,6 @@ auto ActionNode::getDistanceToTargetEntity(
       const double threshold =
         lateral_collision_margin_.value_or(from_bounding_box.dimensions.y * 0.5);
 
-      std::cout << threshold << ", " << from_bounding_box.dimensions.y * 0.5 << std::endl;
-
       if (lateral_distance_to_spline <= threshold) {
         return target_bounding_box_distance;
       }

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -108,6 +108,9 @@ auto ActionNode::getBlackBoardValues() -> void
         "behavior_parameter", behavior_parameter_)) {
     behavior_parameter_ = traffic_simulator_msgs::msg::BehaviorParameter();
   }
+  if (!getInput<double>("lateral_collision_margin", lateral_collision_margin_)) {
+    lateral_collision_margin_ = 0.0;  // default: no extra lateral margin
+  }
 }
 
 auto ActionNode::getHorizon() const -> double
@@ -380,11 +383,12 @@ auto ActionNode::getDistanceToTargetEntity(
       const auto target_bounding_box_distance =
         bounding_box_distance.value() + from_bounding_box.dimensions.x / 2.0;
 
-      /// @note if the distance of the target entity to the spline is smaller than the width of the reference entity
+      /// @note If the lateral distance of the target entity to the spline is smaller than
+      /// half the width of the reference entity plus configurable margin, it is conflicting.
       if (const auto target_to_spline_distance = traffic_simulator::distance::distanceToSpline(
             static_cast<geometry_msgs::msg::Pose>(*target_lanelet_pose), target_bounding_box,
             spline, longitudinal_distance.value());
-          target_to_spline_distance <= from_bounding_box.dimensions.y / 2.0) {
+          target_to_spline_distance <= from_bounding_box.dimensions.y / 2.0 + lateral_collision_margin_) {
         return target_bounding_box_distance;
       }
       /// @note if the distance of the target entity to the spline cannot be calculated because a collision occurs

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -390,7 +390,6 @@ auto ActionNode::getDistanceToTargetEntity(
 
       const double threshold =
         lateral_collision_threshold_.value_or(from_bounding_box.dimensions.y * 0.5);
-      std::cout << threshold << ", " << from_bounding_box.dimensions.y * 0.5 << std::endl;
 
       if (lateral_distance_to_spline <= threshold) {
         return target_bounding_box_distance;

--- a/simulation/behavior_tree_plugin/src/action_node.cpp
+++ b/simulation/behavior_tree_plugin/src/action_node.cpp
@@ -388,7 +388,8 @@ auto ActionNode::getDistanceToTargetEntity(
       if (const auto target_to_spline_distance = traffic_simulator::distance::distanceToSpline(
             static_cast<geometry_msgs::msg::Pose>(*target_lanelet_pose), target_bounding_box,
             spline, longitudinal_distance.value());
-          target_to_spline_distance <= from_bounding_box.dimensions.y / 2.0 + lateral_collision_margin_) {
+          target_to_spline_distance <=
+          from_bounding_box.dimensions.y / 2.0 + lateral_collision_margin_) {
         return target_bounding_box_distance;
       }
       /// @note if the distance of the target entity to the spline cannot be calculated because a collision occurs

--- a/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
+++ b/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
@@ -49,7 +49,7 @@ public:                                         \
   DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
   DEFINE_GETTER_SETTER(GoalPoses,                                        std::vector<geometry_msgs::msg::Pose>)
   DEFINE_GETTER_SETTER(LaneChangeParameters,                             traffic_simulator::lane_change::Parameter)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
+  DEFINE_GETTER_SETTER(LateralCollisionThreshold,                        std::optional<double>)
   DEFINE_GETTER_SETTER(Obstacle,                                         std::optional<traffic_simulator_msgs::msg::Obstacle>)
   DEFINE_GETTER_SETTER(OtherEntityStatus,                                EntityStatusDict)
   DEFINE_GETTER_SETTER(PedestrianParameters,                             traffic_simulator_msgs::msg::PedestrianParameters)

--- a/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
+++ b/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
@@ -46,8 +46,10 @@ public:                                         \
   // clang-format off
   DEFINE_GETTER_SETTER(DebugMarker,                                      std::vector<visualization_msgs::msg::Marker>)
   DEFINE_GETTER_SETTER(DefaultMatchingDistanceForLaneletPoseCalculation, double)
+  DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
   DEFINE_GETTER_SETTER(GoalPoses,                                        std::vector<geometry_msgs::msg::Pose>)
   DEFINE_GETTER_SETTER(LaneChangeParameters,                             traffic_simulator::lane_change::Parameter)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
   DEFINE_GETTER_SETTER(Obstacle,                                         std::optional<traffic_simulator_msgs::msg::Obstacle>)
   DEFINE_GETTER_SETTER(OtherEntityStatus,                                EntityStatusDict)
   DEFINE_GETTER_SETTER(PedestrianParameters,                             traffic_simulator_msgs::msg::PedestrianParameters)
@@ -56,8 +58,6 @@ public:                                         \
   DEFINE_GETTER_SETTER(TrafficLights,                                    std::shared_ptr<traffic_simulator::TrafficLightsBase>)
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
-  DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 

--- a/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
+++ b/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
@@ -57,7 +57,7 @@ public:                                         \
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
   DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           double)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           std::optional<double>)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 

--- a/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
+++ b/simulation/do_nothing_plugin/include/do_nothing_plugin/plugin.hpp
@@ -57,6 +57,7 @@ public:                                         \
   DEFINE_GETTER_SETTER(VehicleParameters,                                traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        traffic_simulator_msgs::msg::WaypointsArray)
   DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            std::shared_ptr<EuclideanDistancesMap>)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           double)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
@@ -65,7 +65,7 @@ public:
   DEFINE_GETTER_SETTER(GoalPoses,                                        "goal_poses",                                     std::vector<geometry_msgs::msg::Pose>)
   DEFINE_GETTER_SETTER(HdMapUtils,                                       "hdmap_utils",                                    std::shared_ptr<hdmap_utils::HdMapUtils>)
   DEFINE_GETTER_SETTER(LaneChangeParameters,                             "lane_change_parameters",                         traffic_simulator::lane_change::Parameter)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           "lateral_collision_margin",                       std::optional<double>)
+  DEFINE_GETTER_SETTER(LateralCollisionThreshold,                        "lateral_collision_threshold",                    std::optional<double>)
   DEFINE_GETTER_SETTER(Obstacle,                                         "obstacle",                                       std::optional<traffic_simulator_msgs::msg::Obstacle>)
   DEFINE_GETTER_SETTER(OtherEntityStatus,                                "other_entity_status",                            EntityStatusDict)
   DEFINE_GETTER_SETTER(PedestrianParameters,                             "pedestrian_parameters",                          traffic_simulator_msgs::msg::PedestrianParameters)

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
@@ -77,7 +77,7 @@ public:
   DEFINE_GETTER_SETTER(VehicleParameters,                                "vehicle_parameters",                             traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        "waypoints",                                      traffic_simulator_msgs::msg::WaypointsArray)
   DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            "euclidean_distances_map",                        std::shared_ptr<EuclideanDistancesMap>)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           "lateral_collision_margin",                       double)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           "lateral_collision_margin",                       std::optional<double>)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 };

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
@@ -61,9 +61,11 @@ public:
   DEFINE_GETTER_SETTER(CurrentTime,                                      "current_time",                                   double)
   DEFINE_GETTER_SETTER(DebugMarker,                                      "debug_marker",                                   std::vector<visualization_msgs::msg::Marker>)
   DEFINE_GETTER_SETTER(DefaultMatchingDistanceForLaneletPoseCalculation, "matching_distance_for_lanelet_pose_calculation", double)
+  DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            "euclidean_distances_map",                        std::shared_ptr<EuclideanDistancesMap>)
   DEFINE_GETTER_SETTER(GoalPoses,                                        "goal_poses",                                     std::vector<geometry_msgs::msg::Pose>)
   DEFINE_GETTER_SETTER(HdMapUtils,                                       "hdmap_utils",                                    std::shared_ptr<hdmap_utils::HdMapUtils>)
   DEFINE_GETTER_SETTER(LaneChangeParameters,                             "lane_change_parameters",                         traffic_simulator::lane_change::Parameter)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           "lateral_collision_margin",                       std::optional<double>)
   DEFINE_GETTER_SETTER(Obstacle,                                         "obstacle",                                       std::optional<traffic_simulator_msgs::msg::Obstacle>)
   DEFINE_GETTER_SETTER(OtherEntityStatus,                                "other_entity_status",                            EntityStatusDict)
   DEFINE_GETTER_SETTER(PedestrianParameters,                             "pedestrian_parameters",                          traffic_simulator_msgs::msg::PedestrianParameters)
@@ -76,8 +78,7 @@ public:
   DEFINE_GETTER_SETTER(TrafficLights,                                    "traffic_lights",                                 std::shared_ptr<traffic_simulator::TrafficLightsBase>)
   DEFINE_GETTER_SETTER(VehicleParameters,                                "vehicle_parameters",                             traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        "waypoints",                                      traffic_simulator_msgs::msg::WaypointsArray)
-  DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            "euclidean_distances_map",                        std::shared_ptr<EuclideanDistancesMap>)
-  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           "lateral_collision_margin",                       std::optional<double>)
+
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 };

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
@@ -78,7 +78,6 @@ public:
   DEFINE_GETTER_SETTER(TrafficLights,                                    "traffic_lights",                                 std::shared_ptr<traffic_simulator::TrafficLightsBase>)
   DEFINE_GETTER_SETTER(VehicleParameters,                                "vehicle_parameters",                             traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        "waypoints",                                      traffic_simulator_msgs::msg::WaypointsArray)
-
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 };

--- a/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/behavior/behavior_plugin_base.hpp
@@ -77,6 +77,7 @@ public:
   DEFINE_GETTER_SETTER(VehicleParameters,                                "vehicle_parameters",                             traffic_simulator_msgs::msg::VehicleParameters)
   DEFINE_GETTER_SETTER(Waypoints,                                        "waypoints",                                      traffic_simulator_msgs::msg::WaypointsArray)
   DEFINE_GETTER_SETTER(EuclideanDistancesMap,                            "euclidean_distances_map",                        std::shared_ptr<EuclideanDistancesMap>)
+  DEFINE_GETTER_SETTER(LateralCollisionMargin,                           "lateral_collision_margin",                       double)
   // clang-format on
 #undef DEFINE_GETTER_SETTER
 };

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -331,7 +331,7 @@ public:
 
   // Optional per-entity lateral collision margin (meters).
   // Default no-op for entities that do not use BT-based lateral collision checks.
-  virtual void setLateralCollisionMargin(const std::optional<double> &) {}
+  virtual void setLateralCollisionThreshold(const std::optional<double> &) {}
 
   virtual auto setMapPose(const geometry_msgs::msg::Pose & map_pose) -> void;
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -331,8 +331,8 @@ public:
 
   // Optional per-entity lateral collision margin (meters).
   // Default no-op for entities that do not use BT-based lateral collision checks.
-  virtual void setLateralCollisionMargin(double) {}
-  virtual double getLateralCollisionMargin() const { return 0.0; }
+  virtual void setLateralCollisionMargin(const std::optional<double> &) {}
+  virtual std::optional<double> getLateralCollisionMargin() const { return std::nullopt; }
 
   virtual auto setMapPose(const geometry_msgs::msg::Pose & map_pose) -> void;
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -332,7 +332,6 @@ public:
   // Optional per-entity lateral collision margin (meters).
   // Default no-op for entities that do not use BT-based lateral collision checks.
   virtual void setLateralCollisionMargin(const std::optional<double> &) {}
-  virtual std::optional<double> getLateralCollisionMargin() const { return std::nullopt; }
 
   virtual auto setMapPose(const geometry_msgs::msg::Pose & map_pose) -> void;
 

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/entity_base.hpp
@@ -329,6 +329,11 @@ public:
 
   virtual auto setVelocityLimit(const double) -> void = 0;
 
+  // Optional per-entity lateral collision margin (meters).
+  // Default no-op for entities that do not use BT-based lateral collision checks.
+  virtual void setLateralCollisionMargin(double) {}
+  virtual double getLateralCollisionMargin() const { return 0.0; }
+
   virtual auto setMapPose(const geometry_msgs::msg::Pose & map_pose) -> void;
 
   /*   */ auto setTwist(const geometry_msgs::msg::Twist & twist) -> void;

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
@@ -135,6 +135,7 @@ public:
   {
     behavior_plugin_ptr_->setLateralCollisionMargin(value);
   }
+
   std::optional<double> getLateralCollisionMargin() const
   {
     return behavior_plugin_ptr_->getLateralCollisionMargin();

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
@@ -131,11 +131,11 @@ public:
   void setTrafficLights(const std::shared_ptr<traffic_simulator::TrafficLightsBase> &) override;
 
   // Per-entity lateral collision margin (meters)
-  void setLateralCollisionMargin(double value)
+  void setLateralCollisionMargin(const std::optional<double> & value)
   {
     behavior_plugin_ptr_->setLateralCollisionMargin(value);
   }
-  double getLateralCollisionMargin() const
+  std::optional<double> getLateralCollisionMargin() const
   {
     return behavior_plugin_ptr_->getLateralCollisionMargin();
   }

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
@@ -130,6 +130,16 @@ public:
 
   void setTrafficLights(const std::shared_ptr<traffic_simulator::TrafficLightsBase> &) override;
 
+  // Per-entity lateral collision margin (meters)
+  void setLateralCollisionMargin(double value)
+  {
+    behavior_plugin_ptr_->setLateralCollisionMargin(value);
+  }
+  double getLateralCollisionMargin() const
+  {
+    return behavior_plugin_ptr_->getLateralCollisionMargin();
+  }
+
   const traffic_simulator_msgs::msg::VehicleParameters vehicle_parameters;
 
 private:

--- a/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/entity/vehicle_entity.hpp
@@ -131,14 +131,9 @@ public:
   void setTrafficLights(const std::shared_ptr<traffic_simulator::TrafficLightsBase> &) override;
 
   // Per-entity lateral collision margin (meters)
-  void setLateralCollisionMargin(const std::optional<double> & value)
+  void setLateralCollisionThreshold(const std::optional<double> & value)
   {
-    behavior_plugin_ptr_->setLateralCollisionMargin(value);
-  }
-
-  std::optional<double> getLateralCollisionMargin() const
-  {
-    return behavior_plugin_ptr_->getLateralCollisionMargin();
+    behavior_plugin_ptr_->setLateralCollisionThreshold(value);
   }
 
   const traffic_simulator_msgs::msg::VehicleParameters vehicle_parameters;


### PR DESCRIPTION
## Abstract

Add an **optional per-entity lateral collision threshold** (meters) that scenario authors can specify via OpenSCENARIO Controller `Properties`.
When set, this margin overrides the current default threshold (half of the reference entity width) used in lateral collision checks, enabling tighter validation rules without false failures.

## Background

There was a request from scenario authors to **set collision thresholds per entity** for NPC trajectories.
In some scenarios, the pass/fail rule declares a failure if the **ego and an NPC come within 0.2 m**. With the current behavior—where the lateral collision “tolerance” effectively equals **half the vehicle width**—the scenario can fail even when authors intend to allow a small but explicit threshold. Providing a per-entity override solves this mismatch and keeps scenarios expressive and reproducible.

## Details

* **New property (OpenSCENARIO Controller → Properties):**
  `lateralCollisionThreshold` (unit: meters, optional).
  If omitted, legacy behavior is preserved (uses half of the reference entity width).

* **Usage (example):**

  ```yaml
      - ObjectController:
          Controller:
            Properties:
              Property:
                - name: lateralCollisionThreshold
                  value: 0.62
            name: ''
  ```

* **Interpreter & Wiring**

  * The OpenSCENARIO interpreter reads `lateralCollisionThreshold` from Controller `Properties` and forwards it to the entity. If the setter is unsupported by the entity type, it is ignored gracefully.
  * Behavior Tree (BT) plumbing adds an input port `lateral_collision_threshold` and stores it as `std::optional<double>`.
  * `BehaviorPluginBase`, `VehicleBehaviorTree` (and prepared hooks for pedestrian and do-nothing plugins) expose **getter/setter** for `lateralCollisionThreshold`.
  * `VehicleEntity` implements `setLateralCollisionThreshold` and passes the value to its behavior plugin.

* **Collision logic**

  * In lateral collision distance evaluation, the **threshold** becomes:
    `threshold = lateral_collision_margin.value_or(width * 0.5)`
    where `width` is the reference entity’s bounding-box Y dimension.
  * This keeps the default unchanged while allowing per-entity tightening (e.g., `0.2`).


## References

N/A

# Destructive Changes

N/A

# Known Limitations

N/A
