### PR TITLE
Fix XML validation when ScenarioModifier is used

### DIFF
--- a/openscenario/openscenario_utility/openscenario_utility/conversion.py
+++ b/openscenario/openscenario_utility/openscenario_utility/conversion.py
@@ -21,6 +21,7 @@ from itertools import product
 from pathlib import Path
 from re import sub
 from sys import exit, stderr
+from typing import List
 from pkg_resources import resource_string
 
 import math
@@ -52,7 +53,7 @@ def normalize_yaml_bools(obj):
 
 
 class MacroExpander:
-    def __init__(self, rules, schema):
+    def __init__(self, rules, schema: xmlschema.XMLSchema):
 
         self.rules = rules
 
@@ -76,7 +77,7 @@ class MacroExpander:
                     )
 
     def __call__(self, xosc: str, output: Path, basename: str):
-        paths = []
+        paths: List[Path] = []
 
         for index, bindings in enumerate(product(*self.specs)):
             target = deepcopy(xosc)
@@ -185,33 +186,25 @@ def convert(input: Path, output: Path, verbose: bool = True):
 
     macroexpand = MacroExpander(yaml.pop("ScenarioModifiers", None), schema)
 
-    xosc, errors = schema.encode(
+    xosc = schema.encode(
         from_yaml("OpenSCENARIO", yaml),
         indent=2,
         preserve_root=True,
         unordered=True,  # Reorder elements
-        validation="lax",  # The "strict" mode is too strict than we would like.
+        validation="skip",  # The "strict" mode is too strict than we would like.
     )
 
-    if not schema.is_valid(xosc) and len(errors) != 0:
-        print(
-            "Error: " + str(errors[0]), file=stderr
-        )  # Other than the first is not important.
-        exit()
+    paths = macroexpand(
+        xmlschema.XMLResource(xosc).tostring(),
+        output,
+        input.stem,
+    )
 
-    else:
-        paths = macroexpand(
-            xmlschema.XMLResource(xosc)
-            .tostring(),
-            output,
-            input.stem,
-        )
+    if verbose:
+        for each in paths:
+            print(each)
 
-        if verbose:
-            for each in paths:
-                print(each)
-
-        return paths
+    return paths
 
 
 def main():


### PR DESCRIPTION
# Description

## Abstract

Fix XML validation error when ScenarioModifier is used

## Background

YAML scenario with ScenarioModifier is invalid as a OpenSCENARIO schema before ScenarioModifier being expanded.
This caused XML validation error in some scenarios with latest xmlschema (3.1.0).

## Details

- Skip validation before ScenarioModifier being expanded
- Validation will be performed for expanded OpenSCENARIO
