### PR TITLE
modify BuildAndRun workflow to avoid `No space left on device` error

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -36,12 +36,10 @@ jobs:
         cmake_build_type: [RelWithDebInfo, Release] # Debug build type is currently unavailable. @TODO Fix problem and add Debug build.
     steps:
       - name: free disk
-        run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/hostedtoolcache
-          df -h
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - name: Suppress warnings
         run: git config --global --add safe.directory '*'
 

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -26,7 +26,6 @@ jobs:
     name: BuildAndRun
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 180
-    container: ros:${{ matrix.rosdistro }}
     env:
       DEBIAN_FRONTEND: noninteractive
     strategy:
@@ -36,6 +35,13 @@ jobs:
         runs_on: [ubuntu-22.04, ubuntu-22.04-arm]
         cmake_build_type: [RelWithDebInfo, Release] # Debug build type is currently unavailable. @TODO Fix problem and add Debug build.
     steps:
+      - name: free disk
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/hostedtoolcache
+          df -h
       - name: Suppress warnings
         run: git config --global --add safe.directory '*'
 
@@ -51,7 +57,24 @@ jobs:
         with:
           repository: RobotecAI/scenario_simulator_v2_scenarios
           path: src/scenario_simulator_v2_scenarios
+      
+      - name: Cache apt and rosdep
+        id: cache-apt-rosdep
+        uses: actions/cache@v4
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+            /etc/ros/rosdep
+          key: ${{ runner.os }}-ros-${{ matrix.rosdistro }}-apt-${{ hashFiles('**/package.xml', '**/dependency_*.repos') }}
+          restore-keys: |
+            ${{ runner.os }}-ros-${{ matrix.rosdistro }}-apt-
 
+      - name: Setup ROS environment
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ matrix.rosdistro }}
+  
       - name: Search packages in this repository
         id: list_packages
         run: |
@@ -103,7 +126,6 @@ jobs:
             -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage -Wno-error=class-memaccess' \
             -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage' \
             --packages-up-to ${{ steps.list_packages.outputs.package_list }}
-          rm -rf build/
         shell: bash
 
       - name: Colcon test

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -98,7 +98,7 @@ jobs:
           colcon mixin update default
           df -h
           sudo apt-get clean
-          rm -rf /var/lib/apt/lists/*
+          sudo rm -rf /var/lib/apt/lists/*
           df -h
         shell: bash
 

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -73,6 +73,10 @@ jobs:
           rosdep install -iy --from-paths src --rosdistro ${{ matrix.rosdistro }}
           colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           colcon mixin update default
+          df -h
+          apt-get clean
+          rm -rf /var/lib/apt/lists/*
+          df -h
         shell: bash
 
       - name: Install Build Wrapper

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -103,6 +103,7 @@ jobs:
             -DCMAKE_CXX_FLAGS='-fprofile-arcs -ftest-coverage -Wno-error=class-memaccess' \
             -DCMAKE_C_FLAGS='-fprofile-arcs -ftest-coverage' \
             --packages-up-to ${{ steps.list_packages.outputs.package_list }}
+          rm -rf build/
         shell: bash
 
       - name: Colcon test

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Resolve rosdep and install colcon mixin
         run: |
           sudo apt-get update
-          sudo apt-get install -y python3-pip python3-colcon-lcov-result lcov unzip gcovr
+          sudo apt-get install -y python3-pip python3-colcon-lcov-result lcov unzip gcovr libunwind-dev
           rosdep update --include-eol-distros
           rosdep install -iy --from-paths src --rosdistro ${{ matrix.rosdistro }}
           colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml

--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -90,14 +90,14 @@ jobs:
 
       - name: Resolve rosdep and install colcon mixin
         run: |
-          apt-get update
-          apt-get install -y python3-pip python3-colcon-lcov-result lcov unzip gcovr
+          sudo apt-get update
+          sudo apt-get install -y python3-pip python3-colcon-lcov-result lcov unzip gcovr
           rosdep update --include-eol-distros
           rosdep install -iy --from-paths src --rosdistro ${{ matrix.rosdistro }}
           colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           colcon mixin update default
           df -h
-          apt-get clean
+          sudo apt-get clean
           rm -rf /var/lib/apt/lists/*
           df -h
         shell: bash


### PR DESCRIPTION
# Description

## Abstract

modify `BuildAndRun` workflow to avoid `No space left on device` error

- Stop using ros container to delete host large unused files
- Use `actions/cache` for quick ros setup

## Background

Recently, the `BuildAndRun` workflows were failed due to `No space left on device` error

https://github.com/tier4/scenario_simulator_v2/actions/workflows/BuildAndRun.yaml

<details>
<summary>Screenshot</summary>

<img width="1233" height="1667" alt="image" src="https://github.com/user-attachments/assets/292d9256-ea77-4c19-b86c-e60aecfd03a1" />

</details>

## References


# Destructive Changes

None

# Known Limitations

None