### PR TITLE
Fix Docker build workflow trigger

### DIFF
--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -12,8 +12,10 @@ on:
       - "!pyproject.toml"
       - "!poetry.lock"
   push:
-    tags:
-      - "*"
+    branches:
+      - master
+    paths:
+      - "**/package.xml"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
# Description

## Abstract

This PR will fix Docker build workflow is not working.

## Background

Docker workflow is not ran after #1657 

## References

Some explanation of `push` trigger https://blog.chaotic-notes.com/articles/describe-github-actions-on-push/

## Note

If this PR will not work, we may use `create` trigger for tags