### PR TITLE
Fix Dockerfile: remove undefined WORKDIR and correct file copy destination

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
 WORKDIR /home/ubuntu/Desktop/scenario_simulator_ws/src/scenario_simulator
-COPY . $WORKDIR
+COPY . .
 
 WORKDIR /home/ubuntu/Desktop/scenario_simulator_ws/
 RUN mkdir -p /home/ubuntu/Desktop/scenario_simulator_ws/src/scenario_simulator/external


### PR DESCRIPTION
## Abstract

Fix the Dockerfile by removing the undefined $WORKDIR variable and copying the build context into the current working directory instead. This prevents accidental copies to a literal "$WORKDIR" path and aligns with Docker’s WORKDIR semantics. 

## Background

During image builds, the Dockerfile used an undefined $WORKDIR variable as the COPY destination. GitHub displayed a warning about this in the repository/PR checks, and the warning had remained unaddressed.

<img width="979" height="393" alt="スクリーンショット 2025-10-20 10 39 47" src="https://github.com/user-attachments/assets/263793d6-8d51-41a2-b012-8eeb7140cdd1" />


# Destructive Changes

N/A

# Known Limitations

N/A
