### PR TITLE
fix(vehicle_simulation): publish currect lateral acceleration

### DIFF
--- a/simulation/simple_sensor_simulator/src/vehicle_simulation/ego_entity_simulation.cpp
+++ b/simulation/simple_sensor_simulator/src/vehicle_simulation/ego_entity_simulation.cpp
@@ -175,6 +175,7 @@ auto EgoEntitySimulation::setAutowareStatus() -> void
   autoware->current_acceleration.store([this]() {
     geometry_msgs::msg::Accel message;
     message.linear.x = vehicle_model_ptr_->getAx();
+    message.linear.y = vehicle_model_ptr_->getWz() * vehicle_model_ptr_->getVx();
     return message;
   }());
 
@@ -408,6 +409,7 @@ auto EgoEntitySimulation::getCurrentAccel(const double step_time) const -> geome
   geometry_msgs::msg::Accel accel;
   if (previous_angular_velocity_) {
     accel.linear.x = vehicle_model_ptr_->getAx();
+    accel.linear.y = vehicle_model_ptr_->getWz() * vehicle_model_ptr_->getVx();
     accel.angular.z =
       (vehicle_model_ptr_->getWz() - previous_angular_velocity_.value()) / step_time;
   }


### PR DESCRIPTION
# Description

The original vehicle_simulation didn't publish lateral acceleration (accel.linear.y). This PR additionally calculates and publishes it.

## Background

In [internal Slack thread](https://star4.slack.com/archives/C03QW0GU6P7/p1758682728110909), we are trying to analyze Autoware's lateral acceleration, but the scenario simulator didn't publish it.

## References

I referenced the implementation of [simple_planning_simulator](https://github.com/autowarefoundation/autoware_universe/blob/main/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp#L853-L854)


## Tests

Check SIMULATION ARCHIVE files of any test case([sample](https://evaluation.tier4.jp/evaluation/reports/a1a74166-307b-5a4a-96af-9119545ee218/tests/7828bb2c-868a-5ef1-b075-d0b4d91dc92c/7b77ac06-9735-5355-890e-350730465491/17d194a3-76d0-5b41-a279-3f9b4df1cbab?project_id=prd_jt)).

You can find the results of autoware_control_evaluator, like:
```
...
    "lateral_acceleration_abs/count": 599,
    "lateral_acceleration_abs/description": "Absolute lateral acceleration[m/s^2]",
    "lateral_acceleration_abs/max": 0.08607245110513566,
    "lateral_acceleration_abs/mean": 0.012509483193040747,
    "lateral_acceleration_abs/min": 0.0,
...
```
They were all zeros before this PR.
