### PR TITLE
Remove quates from `SonarSource/sonarqube-scan-action` args to fix errors on v6 series

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -213,7 +213,7 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         with:
           args: >
-            --define sonar.cfamily.compile-commands="src/scenario_simulator_v2/bw-output/compile_commands.json"
+            --define sonar.cfamily.compile-commands=src/scenario_simulator_v2/bw-output/compile_commands.json
           projectBaseDir: src/scenario_simulator_v2/
       #      - name: Basic test
       #        run: |


### PR DESCRIPTION
# Description

## Abstract

Remove quates from `SonarSource/sonarqube-scan-action` args to fix errors on v6 series.


## Background

The latest version of Action has changed how quotation marks are handled, so an error occurred.
In workflow, quotation marks were used in places where they were not needed, so I removed them.

[Final error](https://github.com/tier4/scenario_simulator_v2/actions/runs/19020262801/job/54314186504#step:23:140)
```
 java.lang.IllegalStateException: java.nio.file.NoSuchFileException: /home/runner/work/scenario_simulator_v2/scenario_simulator_v2/"src/scenario_simulator_v2/bw-output/compile_commands.json"
```

<img width="951" height="152" alt="image" src="https://github.com/user-attachments/assets/5796d4e4-d092-4161-8205-4941c12f853d" />



## References

Acton document for `args`: https://github.com/SonarSource/sonarqube-scan-action#args

It says that quoting and escaping is limited from v6 to prevent command injection.

After deleting quotes, sonar qube action is going fine.
https://github.com/tier4/scenario_simulator_v2/pull/1729#issuecomment-3483678560


# Destructive Changes

None

# Known Limitations

None