### PR TITLE
Update token secret name

### DIFF
--- a/.github/workflows/Documentation.yaml
+++ b/.github/workflows/Documentation.yaml
@@ -47,7 +47,7 @@ jobs:
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
         uses: peaceiris/actions-gh-pages@v4
         with:
-          personal_token: ${{ secrets.BLOOM_GITHUB_TOKEN }}
+          personal_token: ${{ secrets.STRONG_GITHUB_TOKEN }}
           publish_dir: site
           keep_files: false
           external_repository: tier4/scenario_simulator_v2-docs
@@ -75,7 +75,7 @@ jobs:
         if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
         uses: peaceiris/actions-gh-pages@v4
         with:
-          personal_token: ${{ secrets.BLOOM_GITHUB_TOKEN }}
+          personal_token: ${{ secrets.STRONG_GITHUB_TOKEN }}
           publish_dir: html
           keep_files: false
           external_repository: tier4/scenario_simulator_v2-api-docs

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -58,7 +58,7 @@ jobs:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ secrets.BLOOM_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.STRONG_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup git
         run: |
@@ -108,7 +108,7 @@ jobs:
         if: github.event_name == 'push' && steps.old_version.outputs.old_version != steps.new_version.outputs.new_version
         uses: CasperWA/push-protected@v2
         with:
-          token: ${{ secrets.BLOOM_GITHUB_TOKEN }}
+          token: ${{ secrets.STRONG_GITHUB_TOKEN }}
           branch: master
           force: true
 


### PR DESCRIPTION
# Description

## Abstract

This pull-request renames token secret name from `BLOOM_GITHUB_TOKEN` to `STRONG_GITHUB_TOKEN`.

## Background

Previously, the `Release` actions had a bug and we have an accident to make a wrong release and master push.
So, we expire the secret name that is used in bugged action and move into new named secret.

## References

None

# Destructive Changes

None

# Known Limitations

None