### PR TITLE
feat: add launch_system_monitor parameter

### DIFF
--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -67,6 +67,7 @@ EgoEntity::EgoEntity(
       parameters.push_back("perception/enable_traffic_light:=" + std::string(architecture_type >= "awf/universe/20230906" ? "true" : "false"));
       parameters.push_back("use_sim_time:=" + std::string(common::getParameter<bool>(node_parameters, "use_sim_time", false) ? "true" : "false"));
       parameters.push_back("localization_sim_mode:=" + std::string(common::getParameter<bool>(node_parameters, "simulate_localization") ? "api" : "pose_twist_estimator"));
+      parameters.push_back("launch_system_monitor:=" + std::string(common::getParameter<bool>(node_parameters, "launch_system_monitor", false) ? "true" : "false"));
       // clang-format on
 
       return common::getParameter<bool>(node_parameters, "launch_autoware", true)

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -85,6 +85,7 @@ def launch_setup(context, *args, **kwargs):
     launch_autoware                             = LaunchConfiguration("launch_autoware",                             default=True)
     launch_rviz                                 = LaunchConfiguration("launch_rviz",                                 default=False)
     launch_simple_sensor_simulator              = LaunchConfiguration("launch_simple_sensor_simulator",              default=True)
+    launch_system_monitor                       = LaunchConfiguration("launch_system_monitor",                       default=False)
     launch_visualization                        = LaunchConfiguration("launch_visualization",                        default=True)
     output_directory                            = LaunchConfiguration("output_directory",                            default=Path("/tmp"))
     override_parameters                         = LaunchConfiguration("override_parameters",                         default="")
@@ -122,6 +123,7 @@ def launch_setup(context, *args, **kwargs):
     print(f"initialize_localization                     := {initialize_localization.perform(context)}")
     print(f"launch_autoware                             := {launch_autoware.perform(context)}")
     print(f"launch_rviz                                 := {launch_rviz.perform(context)}")
+    print(f"launch_system_monitor                       := {launch_system_monitor.perform(context)}")
     print(f"launch_visualization                        := {launch_visualization.perform(context)}")
     print(f"output_directory                            := {output_directory.perform(context)}")
     print(f"override_parameters                         := {override_parameters.perform(context)}")
@@ -161,6 +163,7 @@ def launch_setup(context, *args, **kwargs):
             {"initialize_duration": initialize_duration},
             {"initialize_localization": initialize_localization},
             {"launch_autoware": launch_autoware},
+            {"launch_system_monitor": launch_system_monitor},
             {"pedestrian_ignore_see_around": pedestrian_ignore_see_around},
             {"port": port},
             {"publish_empty_context" : publish_empty_context},
@@ -233,6 +236,7 @@ def launch_setup(context, *args, **kwargs):
         DeclareLaunchArgument("initialize_localization",                     default_value=initialize_localization                    ),
         DeclareLaunchArgument("launch_autoware",                             default_value=launch_autoware                            ),
         DeclareLaunchArgument("launch_rviz",                                 default_value=launch_rviz                                ),
+        DeclareLaunchArgument("launch_system_monitor",                       default_value=launch_system_monitor                      ),
         DeclareLaunchArgument("output_directory",                            default_value=output_directory                           ),
         DeclareLaunchArgument("parameter_file_path",                         default_value=parameter_file_path                        ),
         DeclareLaunchArgument("pedestrian_ignore_see_around",                default_value=pedestrian_ignore_see_around               ),


### PR DESCRIPTION
# Description

## Abstract

This PR adds a new parameter, `launch_system_monitor`.

```
simulations:
  - name: planning_sim_v2
    type: planning_sim_v2
    simulator:
      parameters:
        launch_system_monitor: "true"
```

## Background

Depending on the computing performance of the simulation execution environment, there are cases where simulation results become inconsistent or incorrect.
Autoware includes a resource monitoring module called System Monitor. By utilizing this module, we can obtain useful information for debugging such issues.
Actual case: [TIER IV INTERNAL LINK](https://star4.slack.com/archives/CJVHMJDJ7/p1765867045170619)

## Details

- Autoware has a parameter named `launch_system_monitor` that controls whether the System Monitor is launched.
This PR enables configuring this parameter from scenario_simulator.
- In planning_simulator, this parameter is disabled (false) by default, since System Monitor is not required in most cases. With this change, the default behavior remains disabled (false), allowing users to enable it only when necessary.
- This PR is not a mandatory change. If reviewers determine that this change is unnecessary, it is acceptable to close the PR.

## References

Test Results

- [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/22243ff4-b8de-5716-b577-2141e7311c4d?project_id=prd_jt)
  - Execution result with this PR applied. Confirmed that the system behaves as before with System Monitor disabled.
- [TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/13ceddef-d589-5bab-8217-ccc2193bf848?project_id=prd_jt)
  - Execution result with this PR applied and `launch_system_monitor`=true set. Confirmed that System Monitor is enabled and that the related nodes are launched, as verified from the logs.

# Destructive Changes

None

# Known Limitations

None
