### PR TITLE
Stop delete large-packages in BuildAndRun.yaml

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -40,6 +40,7 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
+          large-packages: false
 
       - name: Suppress warnings
         run: git config --global --add safe.directory '*'


### PR DESCRIPTION
# Description

## Abstract



## Background

Somehow,  `Build and run` worklow occured error below from Jan 16th.

```
Starting >>> autoware_common_msgs
[1.182s] ERROR:colcon.colcon_cmake.task.cmake.build:Could not find 'pwsh' executable
Failed   <<< autoware_common_msgs [0.01s, exited with code 1]
Starting >>> autoware_perception_msgs
[1.193s] ERROR:colcon.colcon_cmake.task.cmake.build:Could not find 'pwsh' executable
Failed   <<< autoware_perception_msgs [0.01s, exited with code 1]
Starting >>> autoware_lint_common
[1.198s] ERROR:colcon.colcon_cmake.task.cmake.build:Could not find 'pwsh' executable
Failed   <<< autoware_lint_common [0.01s, exited with code 1]
Starting >>> scenario_simulator_exception
[1.206s] ERROR:colcon.colcon_cmake.task.cmake.build:Could not find 'pwsh' executable
Failed   <<< scenario_simulator_exception [0.01s, exited with code 1]
```

<img width="1457" height="790" alt="image" src="https://github.com/user-attachments/assets/8f8d6349-05e7-45b0-82dd-726a86ef2a8b" />


# Destructive Changes

None

# Known Limitations

Currently, I do not know why this error has occurred and why this patch solve this, but just  know this patch finally surpress the error.