### PR TITLE
Use ros image for CI to avoid errors

### DIFF
--- a/.github/workflows/BuildAndRun.yaml
+++ b/.github/workflows/BuildAndRun.yaml
@@ -39,11 +39,6 @@ jobs:
         runs_on: [ubuntu-22.04, ubuntu-22.04-arm]
         cmake_build_type: [RelWithDebInfo, Release] # Debug build type is currently unavailable. @TODO Fix problem and add Debug build.
     steps:
-      - name: free disk
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false
-
       - name: Suppress warnings
         run: git config --global --add safe.directory '*'
 


### PR DESCRIPTION
# Description

## Abstract

This pull-request fixes the build CI errors by using ros image.
And I added some workflow optimizations.

## Background

After GitHub runner image update for `ubuntu22` (version: `20260112.2` ), the build CI started to fail.
https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20260112.2

https://github.com/tier4/scenario_simulator_v2/actions/workflows/BuildAndRun.yaml?query=branch%3Amaster


# Destructive Changes

None

# Known Limitations

The build CI for `RelWithDebInfo` is still failed due to lack of disk space
