### PR TITLE
Fix `simulation_api_schema::TrafficSignal` operator of `TrafficLight`

### DIFF
--- a/simulation/traffic_simulator/include/traffic_simulator/traffic_lights/traffic_light.hpp
+++ b/simulation/traffic_simulator/include/traffic_simulator/traffic_lights/traffic_light.hpp
@@ -534,6 +534,9 @@ struct TrafficLight
     simulation_api_schema::TrafficSignal traffic_signal_proto;
 
     traffic_signal_proto.set_id(way_id);
+    for (const auto & relation_id : regulatory_elements_ids) {
+      traffic_signal_proto.add_relation_ids(relation_id);
+    }
     for (const auto & bulb : bulbs) {
       auto traffic_light_bulb_proto = static_cast<simulation_api_schema::TrafficLight>(bulb);
       traffic_light_bulb_proto.set_confidence(confidence);

--- a/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
+++ b/simulation/traffic_simulator/src/traffic_lights/traffic_lights_base.cpp
@@ -114,11 +114,8 @@ auto TrafficLightsBase::generateUpdateTrafficLightsRequest() const
 {
   simulation_api_schema::UpdateTrafficLightsRequest update_traffic_lights_request;
   for (auto && [lanelet_id, traffic_light] : traffic_lights_map_) {
-    auto traffic_signal = static_cast<simulation_api_schema::TrafficSignal>(traffic_light);
-    for (const auto & relation_id : traffic_light.regulatory_elements_ids) {
-      traffic_signal.add_relation_ids(relation_id);
-    }
-    *update_traffic_lights_request.add_states() = traffic_signal;
+    *update_traffic_lights_request.add_states() =
+      static_cast<simulation_api_schema::TrafficSignal>(traffic_light);
   }
   return update_traffic_lights_request;
 }


### PR DESCRIPTION
# Description

## Abstract

Previously, `simulation_api_schema::TrafficSignal` opperator of `TrafficLight` class does not fill `relation_ids` field and this pull-reuest fixes this.

## Background

A bug was reported where traffic light topics were incomplete when using the detected channel.
After investigation, I found that when configuring only the detected channel without configuring ground-truth channel, the `relation_ids` field was not set, resulting in missing content.
This pull request fundamentally resolves this issue by adding the `relation_ids` field using a conversion operator rather than adding it each time.

## References

[Regression Test](https://github.com/tier4/sim_evaluation_tools/issues/621): OK

# Destructive Changes

None

# Known Limitations

None