### PR TITLE
Make StatusMonitor threshold configurable

### DIFF
--- a/common/status_monitor/include/status_monitor/status_monitor.hpp
+++ b/common/status_monitor/include/status_monitor/status_monitor.hpp
@@ -142,6 +142,8 @@ public:
     return thunk();
   }
 
+  auto updateThreshold(const std::chrono::seconds & t) -> void;
+
   auto write() const -> void;
 } static status_monitor;
 }  // namespace common

--- a/common/status_monitor/src/status_monitor.cpp
+++ b/common/status_monitor/src/status_monitor.cpp
@@ -78,6 +78,12 @@ StatusMonitor::~StatusMonitor()
   }
 }
 
+auto StatusMonitor::updateThreshold(const std::chrono::seconds & t) -> void
+{
+  auto lock = std::scoped_lock<std::mutex>(mutex);
+  threshold = t;
+}
+
 auto StatusMonitor::write() const -> void
 {
   auto lock = std::scoped_lock<std::mutex>(mutex);

--- a/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
+++ b/openscenario/openscenario_interpreter/src/openscenario_interpreter.cpp
@@ -127,6 +127,9 @@ auto Interpreter::on_configure(const rclcpp_lifecycle::State &) -> Result
 
       script = std::make_shared<OpenScenario>(osc_path);
 
+      common::status_monitor.updateThreshold(
+        std::chrono::seconds(common::getParameter<std::int64_t>("status_monitor_threshold", 10)));
+
       // CanonicalizedLaneletPose is also used on the OpenScenarioInterpreter side as NativeLanePose.
       // so canonicalization takes place here - it uses the value of the consider_pose_by_road_slope parameter
       traffic_simulator::lanelet_pose::CanonicalizedLaneletPose::setConsiderPoseByRoadSlope(

--- a/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
+++ b/test_runner/scenario_test_runner/launch/scenario_test_runner.launch.py
@@ -101,6 +101,7 @@ def launch_setup(context, *args, **kwargs):
     sigterm_timeout                             = LaunchConfiguration("sigterm_timeout",                             default=8)
     simulate_localization                       = LaunchConfiguration("simulate_localization",                       default=True)
     speed_condition                             = LaunchConfiguration("speed_condition",                             default="legacy")
+    status_monitor_threshold                    = LaunchConfiguration("status_monitor_threshold",                    default=10)
     trajectory_based_detection_offset           = LaunchConfiguration("trajectory_based_detection_offset",           default=0.0)
     use_custom_centerline                       = LaunchConfiguration("use_custom_centerline",                       default=True)
     use_sim_time                                = LaunchConfiguration("use_sim_time",                                default=False)
@@ -138,6 +139,7 @@ def launch_setup(context, *args, **kwargs):
     print(f"sigterm_timeout                             := {sigterm_timeout.perform(context)}")
     print(f"simulate_localization                       := {simulate_localization.perform(context)}")
     print(f"speed_condition                             := {speed_condition.perform(context)}")
+    print(f"status_monitor_threshold                    := {status_monitor_threshold.perform(context)}")
     print(f"trajectory_based_detection_offset           := {trajectory_based_detection_offset.perform(context)}")
     print(f"use_custom_centerline                       := {use_custom_centerline.perform(context)}")
     print(f"use_sim_time                                := {use_sim_time.perform(context)}")
@@ -172,6 +174,7 @@ def launch_setup(context, *args, **kwargs):
             {"sigterm_timeout": sigterm_timeout},
             {"simulate_localization": simulate_localization},
             {"speed_condition": speed_condition},
+            {"status_monitor_threshold": status_monitor_threshold},
             {"trajectory_based_detection_offset": trajectory_based_detection_offset},
             {"use_custom_centerline": use_custom_centerline},
             {"use_sim_time": use_sim_time},
@@ -229,7 +232,7 @@ def launch_setup(context, *args, **kwargs):
         DeclareLaunchArgument("enable_perf",                                 default_value=enable_perf                                ),
         DeclareLaunchArgument("global_frame_rate",                           default_value=global_frame_rate                          ),
         DeclareLaunchArgument("global_real_time_factor",                     default_value=global_real_time_factor                    ),
-        DeclareLaunchArgument("global_timeout",                              default_value=global_timeout                             ),        
+        DeclareLaunchArgument("global_timeout",                              default_value=global_timeout                             ),
         DeclareLaunchArgument("initialize_localization",                     default_value=initialize_localization                    ),
         DeclareLaunchArgument("launch_autoware",                             default_value=launch_autoware                            ),
         DeclareLaunchArgument("launch_rviz",                                 default_value=launch_rviz                                ),
@@ -244,6 +247,7 @@ def launch_setup(context, *args, **kwargs):
         DeclareLaunchArgument("sigterm_timeout",                             default_value=sigterm_timeout                            ),
         DeclareLaunchArgument("simulate_localization",                       default_value=simulate_localization                      ),
         DeclareLaunchArgument("speed_condition",                             default_value=speed_condition                            ),
+        DeclareLaunchArgument("status_monitor_threshold",                    default_value=status_monitor_threshold                   ),
         DeclareLaunchArgument("trajectory_based_detection_offset",           default_value=trajectory_based_detection_offset          ),
         DeclareLaunchArgument("use_custom_centerline",                       default_value=use_custom_centerline                      ),
         DeclareLaunchArgument("use_sim_time",                                default_value=use_sim_time                               ),


### PR DESCRIPTION
# Description

## Abstract

This PR makes the StatusMonitor threshold configurable as a simulator parameter.

## Background

The default execution constraints are too restrictive for scenarios involving extensive map data, leading to unintended interruptions during evaluation. I have made these constraints configurable to allow for more flexibility during heavy processing tasks.

## Reference

[Regression Test](https://evaluation.tier4.jp/evaluation/reports/99cce362-631c-5889-b2d4-3fb25566c7cf?project_id=prd_jt): 1 Failure. It passed multiple times in my local environment, so I suspect this is a flaky test.

# Destructive Changes

None

# Known Limitations

None
