### PR TITLE
Reduce storage consumption of pre-compiled header

### DIFF
--- a/openscenario/openscenario_interpreter/CMakeLists.txt
+++ b/openscenario/openscenario_interpreter/CMakeLists.txt
@@ -71,7 +71,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME} Boost::json glog pugixml)
 
 target_precompile_headers(${PROJECT_NAME}
-  PUBLIC
+  PRIVATE
     "<boost/json.hpp>"
     "<openscenario_interpreter/expression.hpp>"
     "<openscenario_interpreter/pointer.hpp>"


### PR DESCRIPTION
# Description


## Abstract

This PR change scope of `target_precompile_headers` of openscenario_interpreter shared library.
This will reduce storage consumption about 6GB (screenshot by [dust](https://github.com/bootandy/dust)). As others than openscenario_interpreter shared library are small C++ program, this does not affect compile time.

<img width="2555" height="1118" alt="Before" src="https://github.com/user-attachments/assets/61e3f130-ae7f-4553-acca-1504a592dd69" />
<img width="2555" height="1118" alt="image" src="https://github.com/user-attachments/assets/9c31b173-cbe6-4db0-85e4-42aab1fd3f8d" />
