### PR TITLE
feat: add jazzy support for docker image

### DIFF
--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -43,6 +43,16 @@ jobs:
             platform: arm64
             dockerfile: Dockerfile
             image_tag: humble
+          - runs-on: ubuntu-24.04
+            rosdistro: jazzy
+            platform: amd64
+            dockerfile: Dockerfile
+            image_tag: jazzy
+          - runs-on: ubuntu-24.04-arm
+            rosdistro: jazzy
+            platform: arm64
+            dockerfile: Dockerfile
+            image_tag: jazzy
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -175,6 +185,14 @@ jobs:
             variant: development
             image_suffix: -devel
           - image_tag: humble
+            variant: runtime
+            image_suffix: -runtime
+          - image_tag: jazzy
+            variant: desktop
+          - image_tag: jazzy
+            variant: development
+            image_suffix: -devel
+          - image_tag: jazzy
             variant: runtime
             image_suffix: -runtime
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG ROS_DISTRO="humble"
 FROM docker.io/library/ros:${ROS_DISTRO} AS development
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NOWARNINGS=yes
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN --mount=type=cache,id=apt-cache-${TARGETARCH},target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib-${TARGETARCH},target=/var/lib/apt,sharing=locked \
@@ -32,7 +33,7 @@ RUN git clone --depth 1 https://github.com/autowarefoundation/autoware_launch.gi
     mv /tmp/autoware_launch/vehicle/sample_vehicle_launch/sample_vehicle_description /home/ubuntu/Desktop/scenario_simulator_ws/src/sample_vehicle_description && \
     rm -rf /tmp/autoware_launch && \
     mkdir -p external && \
-    vcs import external < dependency_${ROS_DISTRO}.repos
+    vcs import external < dependency_humble.repos
 
 RUN --mount=type=cache,id=apt-cache-${TARGETARCH},target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib-${TARGETARCH},target=/var/lib/apt,sharing=locked \
@@ -46,8 +47,9 @@ ENV CC="/usr/lib/ccache/gcc"
 ENV CXX="/usr/lib/ccache/g++"
 ENV CCACHE_DIR="/ccache"
 RUN --mount=type=cache,target=/ccache bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash && \
-    colcon build --cmake-args \ 
+    colcon build --cmake-args \
     -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF \
     -DBUILD_CPP_MOCK_SCENARIOS=ON \
     -DCMAKE_C_COMPILER_LAUNCHER=ccache \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
@@ -56,30 +58,30 @@ RUN --mount=type=cache,target=/ccache bash -c "source /opt/ros/${ROS_DISTRO}/set
 # Runtime Stage: Create a minimal final image
 # ===================================================================
 FROM docker.io/library/ros:${ROS_DISTRO}-ros-base AS runtime
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NOWARNINGS=yes
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+# Copy source first so rosdep can read package.xml files to resolve
+# only the runtime (exec) dependencies of every package in the workspace.
+COPY --from=development /home/ubuntu/Desktop/scenario_simulator_ws/src/ /home/ubuntu/Desktop/scenario_simulator_ws/src/
 
-# cspell: ignore libtbb libprotobuf
-# Install runtime dependencies in a single layer and clean up
+WORKDIR /home/ubuntu/Desktop/scenario_simulator_ws
+
 RUN --mount=type=cache,id=apt-cache-${TARGETARCH},target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib-${TARGETARCH},target=/var/lib/apt,sharing=locked \
     apt-get update && \
-    apt-get install -y --no-install-recommends \
-    software-properties-common python3-pip && \
-    add-apt-repository universe -y && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ros-humble-rmw-cyclonedds-cpp libgoogle-glog0v5 libprotobuf23 libzmq5 \
-    libpugixml1v5 libtbb12 libboost-filesystem1.74.0 ros-humble-lanelet2-matching \
-    ros-humble-lanelet2-io ros-humble-lanelet2-routing libgeographic19 \
-    ros-humble-behaviortree-cpp-v3 ros-humble-geographic-msgs && \
-    pip install xmlschema && \
-    apt-get remove --purge -y software-properties-common python3-pip && \
+    apt-get install -y --no-install-recommends python3-pip && \
+    rosdep update && \
+    rosdep install -iy --from-paths src --rosdistro ${ROS_DISTRO} --dependency-types=exec && \
+    apt-get install -y --no-install-recommends ros-${ROS_DISTRO}-rmw-cyclonedds-cpp && \
+    apt-get remove --purge -y python3-pip && \
     apt-get autoremove -y && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* /root/.ros/rosdep
 
 COPY --from=development /home/ubuntu/Desktop/scenario_simulator_ws/install/ /home/ubuntu/Desktop/scenario_simulator_ws/install/
 COPY --from=development /home/ubuntu/Desktop/scenario_simulator_ws/log/ /home/ubuntu/Desktop/scenario_simulator_ws/log/
-COPY --from=development /home/ubuntu/Desktop/scenario_simulator_ws/src/ /home/ubuntu/Desktop/scenario_simulator_ws/src/
 
 # Remove unnecessary development files from the copied artifacts
 RUN find /home/ubuntu/Desktop/scenario_simulator_ws/install -name cmake -type d -exec rm -rf {} + && \

--- a/simulation/traffic_simulator/CMakeLists.txt
+++ b/simulation/traffic_simulator/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 # silence Eigen NEON memcpy warning for ARM architecture
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" SYS_PROC_LOWER)
 if(SYS_PROC_LOWER STREQUAL "aarch64" OR SYS_PROC_LOWER STREQUAL "arm64")
-    add_compile_options(-Wno-class-memaccess)
+  add_compile_options(-Wno-class-memaccess -Wno-error=overloaded-virtual)
 endif()
 
 add_definitions("-DBOOST_ALLOW_DEPRECATED_HEADERS")


### PR DESCRIPTION
# Description

## Abstract

Add Jazzy (ROS 2 / Ubuntu 24.04) support to the Dockerfile and the `Docker.yaml` CI workflow, and silence an `overloaded-virtual` build error that surfaces only on ARM64 in `traffic_simulator`.

## Background

The Docker image was previously built only for Humble (Ubuntu 22.04, amd64/arm64). Jazzy is the next supported ROS 2 distribution for Autoware, and we need parity in the published images so downstream users can pull `jazzy-*` tags. 
## Details

### `Dockerfile`

- Added `ENV PIP_BREAK_SYSTEM_PACKAGES=1` to both stages so `pip install` works on Ubuntu 24.04's PEP 668-managed Python.
- Added `-DBUILD_TESTING=OFF` to the colcon invocation so the development image does not pull/build test-only dependencies.
- **Runtime stage refactor:** dropped the hand-maintained apt package list (which hard-coded `humble`-prefixed package names and Ubuntu 22.04 library) in favor of:
  - copying `src/` from the development stage early,
  - running `rosdep install --dependency-types=exec` against the workspace's `package.xml` files to resolve runtime deps for whichever `ROS_DISTRO` is being built,
  - explicitly installing `ros-${ROS_DISTRO}-rmw-cyclonedds-cpp` and setting `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` as the default RMW.
- Note: `vcs import` is intentionally pinned to `dependency_humble.repos` for now — the same external repo set is used for both distros until a Jazzy-specific repos file is needed.

### `.github/workflows/Docker.yaml`

- Added `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64) matrix entries with `rosdistro: jazzy` and `image_tag: jazzy`.
- Added matching `jazzy` entries (`desktop`, `-devel`, `-runtime`) to the `merge` job so the multi-arch manifests get pushed under the `jazzy-*` tags.

### `simulation/traffic_simulator/CMakeLists.txt`

- Extended the existing ARM64-only compile-options block with `-Wno-error=overloaded-virtual` so the warning no longer fails the build on `aarch64` / `arm64`. The warning itself is left enabled; only its promotion to an error is suppressed.

# Destructive Changes

None.

# Known Limitations

- `vcs import` still reads `dependency_humble.repos` even when building Jazzy. If a dependency in that file is incompatible with Jazzy, the development stage will fail to build. A follow-up should introduce `dependency_jazzy.repos` (or confirm the file is distro-agnostic and rename it).
- The `-Wno-error=overloaded-virtual` suppression is a workaround. The underlying overload(s) hidden by a base-class virtual should be audited and either renamed, marked `using Base::foo;`, or explicitly overridden so the flag can be removed. An issue should be opened to track this.
- The runtime image's footprint now depends on whatever `rosdep` resolves for `--dependency-types=exec`; if a package's `package.xml` understates its runtime deps, the resulting image may be missing libraries that the previous hand-curated list happened to include.
