### PR TITLE
fix(traffic_simulator): ignore unused-local-typedefs warning

### DIFF
--- a/simulation/traffic_simulator/CMakeLists.txt
+++ b/simulation/traffic_simulator/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(traffic_simulator)
 
-add_compile_options(-Wno-error=class-memaccess)
+add_compile_options(-Wno-error=class-memaccess -Wno-error=unused-local-typedefs)
 
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
# Description

## Abstract

Suppress `-Werror=unused-local-typedefs` for `traffic_simulator` so the package
builds cleanly on ROS 2 Jazzy.

## Background

GCC 13 (shipped with Jazzy) tightened `-Wunused-local-typedefs` so it now fires inside function templates when a particular instantiation does not use the typedef. This trips on `lanelet2_core`'s `signedDistanceImpl` in `/opt/ros/jazzy/include/lanelet2_core/geometry/impl/LineString.h:130`, which declares `using BasicPoint = PointT;` without referencing it in some instantiations. Combined with this package's `-Werror`, building `test_lanelet_wrapper_traffic_lights` fails:

```
/opt/ros/jazzy/include/lanelet2_core/geometry/impl/LineString.h:130:9: error: typedef 'using BasicPoint = PointT' locally defined but not used [-Werror=unused-local-typedefs]
```
The same code compiled fine on Humble (GCC 11), which did not flag the typedef.

## Details
Append `-Wno-error=unused-local-typedefs` to the existing `add_compile_options` line in `simulation/traffic_simulator/CMakeLists.txt`, mirroring the pattern already used for `-Wno-error=class-memaccess` (Eigen NEON memcpy on ARM). The warning still surfaces in build logs, but is no longer fatal.

The root cause is in an upstream system header, so demoting the warning to a non-fatal one on our side is the appropriate scope for this package.

## References

https://github.com/autowarefoundation/autoware/pull/7092#issuecomment-4368896055

# Destructive Changes

none

# Known Limitations

We might unintentionally ignore other unused-local-typedefs warnings for this package in the future. 
