### PR TITLE
fix steer report

### DIFF
--- a/external/concealer/include/concealer/autoware_universe.hpp
+++ b/external/concealer/include/concealer/autoware_universe.hpp
@@ -73,6 +73,7 @@ public:
   std::atomic<geometry_msgs::msg::Accel> current_acceleration;
   std::atomic<geometry_msgs::msg::Pose>  current_pose;
   std::atomic<geometry_msgs::msg::Twist> current_twist;
+  std::atomic<double>                    current_steering_tire_angle{0.0};
   // clang-format on
 
 private:

--- a/external/concealer/include/concealer/autoware_universe.hpp
+++ b/external/concealer/include/concealer/autoware_universe.hpp
@@ -73,7 +73,7 @@ public:
   std::atomic<geometry_msgs::msg::Accel> current_acceleration;
   std::atomic<geometry_msgs::msg::Pose>  current_pose;
   std::atomic<geometry_msgs::msg::Twist> current_twist;
-  std::atomic<double>                    current_steering_tire_angle{0.0};
+  std::atomic<float>                     current_steering_tire_angle{0.0f};
   // clang-format on
 
 private:

--- a/external/concealer/src/autoware_universe.cpp
+++ b/external/concealer/src/autoware_universe.cpp
@@ -128,7 +128,7 @@ AutowareUniverse::AutowareUniverse(bool simulate_localization) try
       setSteeringReport([this]() {
         SteeringReport message;
         message.stamp = get_clock()->now();
-        message.steering_tire_angle = getCommand().lateral.steering_tire_angle;
+        message.steering_tire_angle = current_steering_tire_angle.load();
         return message;
       }());
 

--- a/simulation/simple_sensor_simulator/src/vehicle_simulation/ego_entity_simulation.cpp
+++ b/simulation/simple_sensor_simulator/src/vehicle_simulation/ego_entity_simulation.cpp
@@ -181,6 +181,8 @@ auto EgoEntitySimulation::setAutowareStatus() -> void
   autoware->current_pose.store(status_.getMapPose());
 
   autoware->current_twist.store(getCurrentTwist());
+
+  autoware->current_steering_tire_angle.store(vehicle_model_ptr_->getSteer());
 }
 
 void EgoEntitySimulation::requestSpeedChange(double value)

--- a/simulation/simple_sensor_simulator/src/vehicle_simulation/ego_entity_simulation.cpp
+++ b/simulation/simple_sensor_simulator/src/vehicle_simulation/ego_entity_simulation.cpp
@@ -182,7 +182,7 @@ auto EgoEntitySimulation::setAutowareStatus() -> void
 
   autoware->current_twist.store(getCurrentTwist());
 
-  autoware->current_steering_tire_angle.store(vehicle_model_ptr_->getSteer());
+  autoware->current_steering_tire_angle.store(static_cast<float>(vehicle_model_ptr_->getSteer()));
 }
 
 void EgoEntitySimulation::requestSpeedChange(double value)


### PR DESCRIPTION
# Description

## Abstract

Fix `SteeringReport` to publish the actual simulated steering angle instead of the commanded target angle.

## Background

The `SteeringReport` message was populated from the lateral control command:

```cpp
message.steering_tire_angle = getCommand().lateral.steering_tire_angle;
```

This means the simulator was reporting the *desired* steering angle to Autoware rather than the *actual* one. For `DELAY_STEER_*` vehicle models, the simulated steering lags behind the command due to actuator dynamics. Feeding the command back as the report effectively hid this lag from the controller, causing it to receive false state feedback. 

## Details

A new `std::atomic<float> current_steering_tire_angle` field is added to `AutowareUniverse`, following the same pattern as `current_twist`, `current_pose`, and `current_acceleration`.

Each simulation step, `EgoEntitySimulation::setAutowareStatus()` stores the actual value from the vehicle dynamics model:

```cpp
autoware->current_steering_tire_angle.store(static_cast<float>(vehicle_model_ptr_->getSteer()));
```

The `SteeringReport` timer callback then reads this value:

```cpp
message.steering_tire_angle = current_steering_tire_angle.load();
```

This ensures Autoware receives physically accurate steering feedback, including any delay/lag modelled by the vehicle simulation.
