### PR TITLE
Open simulation interface

### DIFF
--- a/simulation/simulation_interface/CMakeLists.txt
+++ b/simulation/simulation_interface/CMakeLists.txt
@@ -20,8 +20,22 @@ find_package(ament_cmake_auto REQUIRED)
 find_package(Boost REQUIRED thread)
 find_package(cppzmq QUIET)
 find_package(rclcpp REQUIRED)
+include(FetchContent)
 include(FindProtobuf REQUIRED)
 ament_auto_find_build_dependencies()
+
+FetchContent_Declare(open_simulation_interface
+  GIT_REPOSITORY https://github.com/OpenSimulationInterface/open-simulation-interface.git
+  GIT_TAG        v3.7.0)
+
+FetchContent_MakeAvailable(open_simulation_interface)
+
+FetchContent_GetProperties(open_simulation_interface)
+
+if(NOT open_simulation_interface_POPULATED)
+  FetchContent_Populate(open_simulation_interface)
+  add_subdirectory(${open_simulation_interface_SOURCE_DIR} ${open_simulation_interface_BINARY_DIR})
+endif()
 
 set(PROTO_FILES
   "proto/autoware_control_msgs.proto"
@@ -62,6 +76,7 @@ ament_auto_add_library(simulation_interface SHARED
 )
 target_link_libraries(simulation_interface
   ${PROTOBUF_LIBRARY}
+  open_simulation_interface
   pthread
   sodium
   zmq
@@ -77,6 +92,7 @@ install(TARGETS simulation_interface
 
 install(
   DIRECTORY ${CMAKE_BINARY_DIR}/proto/
+            ${open_simulation_interface_BINARY_DIR}/
   DESTINATION include/
 )
 

--- a/simulation/simulation_interface/CMakeLists.txt
+++ b/simulation/simulation_interface/CMakeLists.txt
@@ -27,17 +27,13 @@ ament_auto_find_build_dependencies()
 # cSpell:ignore wonkycase
 # lint_cmake: -readability/wonkycase
 
-FetchContent_Declare(open_simulation_interface
-  GIT_REPOSITORY https://github.com/OpenSimulationInterface/open-simulation-interface.git
-  GIT_TAG        v3.8.0)
+FetchContent_Declare(osi-cpp GIT_REPOSITORY https://github.com/OpenSimulationInterface/osi-cpp.git GIT_TAG v3.8.0)
+FetchContent_MakeAvailable(osi-cpp)
+FetchContent_GetProperties(osi-cpp)
 
-FetchContent_MakeAvailable(open_simulation_interface)
-
-FetchContent_GetProperties(open_simulation_interface)
-
-if(NOT open_simulation_interface_POPULATED)
-  FetchContent_Populate(open_simulation_interface)
-  add_subdirectory(${open_simulation_interface_SOURCE_DIR} ${open_simulation_interface_BINARY_DIR})
+if(NOT osi-cpp_POPULATED)
+  FetchContent_Populate(osi-cpp)
+  add_subdirectory(${osi-cpp_SOURCE_DIR} ${osi-cpp_BINARY_DIR})
 endif()
 
 set(PROTO_FILES
@@ -98,11 +94,6 @@ install(
             ${open_simulation_interface_BINARY_DIR}/include/osi3/
   DESTINATION include/
 )
-
-install(
-  DIRECTORY ${open_simulation_interface_BINARY_DIR}/
-  DESTINATION lib
-  FILES_MATCHING REGEX ".*\\.so.*")
 
 install(
   DIRECTORY launch

--- a/simulation/simulation_interface/CMakeLists.txt
+++ b/simulation/simulation_interface/CMakeLists.txt
@@ -29,7 +29,7 @@ ament_auto_find_build_dependencies()
 
 FetchContent_Declare(open_simulation_interface
   GIT_REPOSITORY https://github.com/OpenSimulationInterface/open-simulation-interface.git
-  GIT_TAG        v3.7.0)
+  GIT_TAG        v3.8.0)
 
 FetchContent_MakeAvailable(open_simulation_interface)
 
@@ -95,15 +95,14 @@ install(TARGETS simulation_interface
 
 install(
   DIRECTORY ${CMAKE_BINARY_DIR}/proto/
-  DIRECTORY ${open_simulation_interface_BINARY_DIR}/include/osi3/
+            ${open_simulation_interface_BINARY_DIR}/include/osi3/
   DESTINATION include/
 )
 
 install(
   DIRECTORY ${open_simulation_interface_BINARY_DIR}/
   DESTINATION lib
-  FILES_MATCHING REGEX ".*\\.so.*"
-  )
+  FILES_MATCHING REGEX ".*\\.so.*")
 
 install(
   DIRECTORY launch

--- a/simulation/simulation_interface/CMakeLists.txt
+++ b/simulation/simulation_interface/CMakeLists.txt
@@ -24,6 +24,8 @@ include(FetchContent)
 include(FindProtobuf REQUIRED)
 ament_auto_find_build_dependencies()
 
+# lint_cmake: -readability/wonkycase
+
 FetchContent_Declare(open_simulation_interface
   GIT_REPOSITORY https://github.com/OpenSimulationInterface/open-simulation-interface.git
   GIT_TAG        v3.7.0)

--- a/simulation/simulation_interface/CMakeLists.txt
+++ b/simulation/simulation_interface/CMakeLists.txt
@@ -24,6 +24,7 @@ include(FetchContent)
 include(FindProtobuf REQUIRED)
 ament_auto_find_build_dependencies()
 
+# cSpell:ignore wonkycase
 # lint_cmake: -readability/wonkycase
 
 FetchContent_Declare(open_simulation_interface

--- a/simulation/simulation_interface/CMakeLists.txt
+++ b/simulation/simulation_interface/CMakeLists.txt
@@ -95,9 +95,15 @@ install(TARGETS simulation_interface
 
 install(
   DIRECTORY ${CMAKE_BINARY_DIR}/proto/
-            ${open_simulation_interface_BINARY_DIR}/
+  DIRECTORY ${open_simulation_interface_BINARY_DIR}/include/osi3/
   DESTINATION include/
 )
+
+install(
+  DIRECTORY ${open_simulation_interface_BINARY_DIR}/
+  DESTINATION lib
+  FILES_MATCHING REGEX ".*\\.so.*"
+  )
 
 install(
   DIRECTORY launch

--- a/simulation/simulation_interface/include/simulation_interface/conversions.hpp
+++ b/simulation/simulation_interface/include/simulation_interface/conversions.hpp
@@ -34,6 +34,7 @@
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <iostream>
+#include <osi_common.pb.h>
 #include <rosgraph_msgs/msg/clock.hpp>
 #include <simulation_interface/constants.hpp>
 #include <std_msgs/msg/header.hpp>
@@ -280,6 +281,12 @@ auto toProtobufMessage(const traffic_simulator_msgs::msg::PolylineTrajectory &)
 
 auto toROS2Message(const traffic_simulator_msgs::PolylineTrajectory &)
   -> traffic_simulator_msgs::msg::PolylineTrajectory;
+
+template <typename T, typename... Ts>
+auto to(Ts&&...) -> T;
+
+template <>
+auto to<osi3::Timestamp>(const builtin_interfaces::msg::Time &) -> osi3::Timestamp;
 }  // namespace simulation_interface
 
 #endif  // SIMULATION_INTERFACE__CONVERSIONS_HPP_

--- a/simulation/simulation_interface/include/simulation_interface/conversions.hpp
+++ b/simulation/simulation_interface/include/simulation_interface/conversions.hpp
@@ -15,6 +15,7 @@
 #ifndef SIMULATION_INTERFACE__CONVERSIONS_HPP_
 #define SIMULATION_INTERFACE__CONVERSIONS_HPP_
 
+#include <osi_common.pb.h>
 #include <simulation_interface/builtin_interfaces.pb.h>
 #include <simulation_interface/geometry_msgs.pb.h>
 #include <simulation_interface/rosgraph_msgs.pb.h>
@@ -34,7 +35,6 @@
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <iostream>
-#include <osi_common.pb.h>
 #include <rosgraph_msgs/msg/clock.hpp>
 #include <simulation_interface/constants.hpp>
 #include <std_msgs/msg/header.hpp>
@@ -283,7 +283,7 @@ auto toROS2Message(const traffic_simulator_msgs::PolylineTrajectory &)
   -> traffic_simulator_msgs::msg::PolylineTrajectory;
 
 template <typename T, typename... Ts>
-auto to(Ts&&...) -> T;
+auto to(Ts &&...) -> T;
 
 template <>
 auto to<osi3::Timestamp>(const builtin_interfaces::msg::Time &) -> osi3::Timestamp;

--- a/simulation/simulation_interface/include/simulation_interface/conversions.hpp
+++ b/simulation/simulation_interface/include/simulation_interface/conversions.hpp
@@ -283,7 +283,7 @@ auto toROS2Message(const traffic_simulator_msgs::PolylineTrajectory &)
   -> traffic_simulator_msgs::msg::PolylineTrajectory;
 
 template <typename T, typename... Ts>
-auto to(Ts &&...) -> T;
+auto to(Ts &&...) -> T = delete;
 
 template <>
 auto to<osi3::Timestamp>(const builtin_interfaces::msg::Time &) -> osi3::Timestamp;

--- a/simulation/simulation_interface/src/conversions.cpp
+++ b/simulation/simulation_interface/src/conversions.cpp
@@ -659,4 +659,13 @@ auto toROS2Message(const traffic_simulator_msgs::PolylineTrajectory & proto)
   message.shape = toROS2Message(proto.shape());
   return message;
 }
+
+template <>
+auto to<osi3::Timestamp>(const builtin_interfaces::msg::Time & time) -> osi3::Timestamp
+{
+  auto timestamp = osi3::Timestamp();
+  timestamp.set_seconds(time.sec);
+  timestamp.set_nanos(time.nanosec);
+  return timestamp;
+}
 }  // namespace simulation_interface


### PR DESCRIPTION
# Description

## Abstract

Added a dependency on `OpenSimulationInterface/osi-cpp` to package `simulation_interface`.

## Background

As preparation for replacing `simulation_interface` with the ASAM Open Simulation Interface (OSI).

## Details

CMake FetchContent clones the necessary dependency repositories during the build process.

## References

- [OpenSimulationInterface/osi-cpp](https://github.com/OpenSimulationInterface/osi-cpp)

# Destructive Changes

None.

# Known Limitations

None.
