### PR TITLE
Add vehicle tuning params to carla bridge

### DIFF
--- a/test_runner/scenario_test_runner/scenario_test_runner/carla_bridge.py
+++ b/test_runner/scenario_test_runner/scenario_test_runner/carla_bridge.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Minimal CARLA <-> Autoware bridge for the Odaiba use case.
-
 Spawns the ego at lanelet 1960 on startup, initializes Autoware's
 localization, publishes /vehicle/status/control_mode (= MANUAL) for the
 engage flow, and teleports the ego on /initialpose. CARLA must be
@@ -67,6 +66,29 @@ TICK_FAIL_LOG_PERIOD_S = 5.0  # throttle world.tick() failure spam
 SHUTDOWN_LOCK_TIMEOUT_S = 2.0  # never block shutdown waiting for a stuck tick
 
 
+# =============================================================================
+# Vehicle tuning defaults -- each key is also exposed as a ROS 2 parameter, so
+# any of these can be overridden at launch without editing this file.
+# =============================================================================
+TUNING = {
+    # --- Server-side input shaping (applied via the ported per-vehicle API) ---
+    # Steering rate limit on normalized steer [-1, 1]. Units: 1/s. <=0 disables.
+    "steer_rate_limit_1ps": 20,
+    # Steering first-order lag time constant. Units: s. <=0 disables.
+    "steer_first_order_lag_tau_s": 0.2,
+    # Acceleration jerk limits for constant-acceleration mode. Units: m/s^3. <=0 disables.
+    "accel_jerk_limit_pos_mps3": 4.0,
+    "accel_jerk_limit_neg_mps3": 6.0,
+    # Acceleration first-order lag time constant. Units: s. <=0 disables.
+    "accel_first_order_lag_tau_s": 0.2,
+
+    # --- Tyre friction multipliers (applied on top of the blueprint) ---
+    # Set to 1.0 to leave unchanged. Front/rear split is by wheel offset.x.
+    "front_friction_force_multiplier_mul": 1.0,
+    "rear_friction_force_multiplier_mul": 1.0,
+}
+
+
 # --- Coordinate helpers ----------------------------------------------------
 def normalize_angle(a):
     while a > math.pi:
@@ -107,6 +129,15 @@ def map_pose_to_carla_spawn(map_x, map_y, map_yaw_rad):
     )
 
 
+# --- Tyre tuning helper ----------------------------------------------------
+def _front_axle_indices(wheels):
+    """Front wheels = the half with the largest offset.x (forward)."""
+    xs = [(i, float(getattr(w.offset, "x", 0.0))) for i, w in enumerate(wheels)]
+    xs.sort(key=lambda t: t[1], reverse=True)
+    n_front = max(1, len(wheels) // 2)
+    return {i for i, _ in xs[:n_front]}
+
+
 # --- Bridge node -----------------------------------------------------------
 class CarlaBridge(Node):
     def __init__(self):
@@ -114,6 +145,13 @@ class CarlaBridge(Node):
         self.host = self.declare_parameter("host", "127.0.0.1").value
         self.port = self.declare_parameter("port", 2000).value
         self.hz_rate = self.declare_parameter("hz_rate", 30).value
+
+        # Vehicle tuning knobs: declare each TUNING default as a ROS 2 parameter
+        # so it can be overridden at launch, then snapshot the resolved values.
+        self.tuning = {
+            key: float(self.declare_parameter(key, float(default)).value)
+            for key, default in TUNING.items()
+        }
 
         self.client = carla.Client(self.host, self.port)
         self.client.set_timeout(60.0)
@@ -205,6 +243,75 @@ class CarlaBridge(Node):
             f"(dt={settings.fixed_delta_seconds:.3f}s)"
         )
 
+    # --- Vehicle tuning ----------------------------------------------------
+    def _apply_tuning(self, vehicle):
+        """Apply the tuning knobs to `vehicle`: tyre physics + input shaping.
+
+        Mirrors apply_tuning() in odaiba_vehicle_tuning.py. Called after every
+        spawn so tuning survives /initialpose respawns. Never raises -- a
+        missing API or physics failure is logged and swallowed so the bridge
+        keeps running.
+        """
+        t = self.tuning
+
+        # --- Tyre friction (lateral grip) ---
+        # friction_force_multiplier is applied through the per-wheel runtime API
+        # (set_wheel_friction_force_multiplier), which writes the live Chaos sim
+        # wheel WITHOUT rebuilding the physics state. So 1.0 is a true no-op and
+        # any other value has no side effect beyond the friction change itself.
+        # Front/rear split is by wheel offset.x. (cornering_stiffness is not tuned;
+        # the engine has no runtime setter for it, so it would require a physics
+        # rebuild via apply_physics_control, which perturbs the freshly spawned ego.)
+        try:
+            pc = vehicle.get_physics_control()   # read-only snapshot of base values
+            wheels = list(pc.wheels)
+            front_idx = _front_axle_indices(wheels)
+            for i, w in enumerate(wheels):
+                front = i in front_idx
+                ff_mul = t["front_friction_force_multiplier_mul"] if front else t["rear_friction_force_multiplier_mul"]
+                if ff_mul != 1.0 and hasattr(w, "friction_force_multiplier"):
+                    vehicle.set_wheel_friction_force_multiplier(
+                        i, float(w.friction_force_multiplier) * float(ff_mul))
+            w0 = vehicle.get_physics_control().wheels[0]
+            self.get_logger().info(
+                "tuning tyre: wheel[0] friction_force_multiplier=%.3f (after apply)"
+                % float(w0.friction_force_multiplier)
+            )
+        except AttributeError as ex:
+            self.get_logger().warn(
+                f"set_wheel_friction_force_multiplier not available ({ex!r}); the "
+                "'carla' package is likely not the one built from the odaiba-carla "
+                "repo. Tyre friction tuning was skipped."
+            )
+        except Exception as ex:  # noqa: BLE001 -- never let tuning crash the bridge
+            self.get_logger().warn(f"tyre friction tuning failed: {ex!r}")
+
+        # --- Server-side input shaping (steer + acceleration) ---
+        try:
+            vehicle.set_steer_rate_limit(float(t["steer_rate_limit_1ps"]))
+            vehicle.set_steer_first_order_lag_tau(float(t["steer_first_order_lag_tau_s"]))
+            vehicle.set_constant_acceleration_jerk_limit(
+                float(t["accel_jerk_limit_pos_mps3"]), float(t["accel_jerk_limit_neg_mps3"])
+            )
+            vehicle.set_constant_acceleration_first_order_lag_tau(
+                float(t["accel_first_order_lag_tau_s"])
+            )
+            self.get_logger().info(
+                "tuning input shaping: steer_rate=%.1f/s steer_tau=%.3fs "
+                "jerk=+%.1f/-%.1f m/s^3 accel_tau=%.3fs"
+                % (t["steer_rate_limit_1ps"], t["steer_first_order_lag_tau_s"],
+                   t["accel_jerk_limit_pos_mps3"], t["accel_jerk_limit_neg_mps3"],
+                   t["accel_first_order_lag_tau_s"])
+            )
+        except AttributeError as ex:
+            self.get_logger().warn(
+                f"input-shaping API not available ({ex!r}); the 'carla' package "
+                "is likely not the one built from the odaiba-carla repo. "
+                "Tuning of steer/accel was skipped."
+            )
+        except Exception as ex:  # noqa: BLE001
+            self.get_logger().warn(f"input-shaping tuning failed: {ex!r}")
+
     # --- Ego spawn / teleport ---------------------------------------------
     def _destroy_attached_actors(self):
         for actor in (self._imu_sensor, self._vehicle_status_sensor, self.ego):
@@ -260,6 +367,10 @@ class CarlaBridge(Node):
                 self.get_logger().error(f"{label} IMU sensor spawn failed")
             else:
                 self._imu_sensor.enable_for_ros()
+
+            # Apply the vehicle tuning to the freshly spawned ego so it
+            # survives /initialpose respawns.
+            self._apply_tuning(self.ego)
 
             self.world.tick()
 


### PR DESCRIPTION
Add seven vehicle tuning parameters to `carla_bridge.py`
- steer_rate_limit_1ps : Upper Limit on the Rate of Change of Normalized Steer Values
- steer_first_order_lag_tau_s : Steer's first-order lag time constant
- accel_jerk_limit_pos_mps3 : Acceleration-Side Jerk Limit
- accel_jerk_limit_neg_mps3 : Deceleration-Side Jerk Limit
- accel_first_order_lag_tau_s : First-order time constant of acceleration
- front_friction_force_multiplier_mul : Front-wheel friction multiplier
- rear_friction_force_multiplier_mul : Rear-wheel friction multiplier