### PR TITLE
fix(physx_vendor): disable Snippet/PVDRuntime builds for headless CI

### DIFF
--- a/external/physx_vendor/CMakeLists.txt
+++ b/external/physx_vendor/CMakeLists.txt
@@ -23,6 +23,13 @@ set(PHYSX_VENDOR_GIT_TAG "107.3-physx-5.6.1"
 # GPU preset (linux-gcc / linux-clang) only if GPU acceleration is required.
 set(PHYSX_VENDOR_PRESET "linux-gcc-cpu-only"
     CACHE STRING "PhysX generate_projects.sh preset (e.g. linux-gcc-cpu-only | linux-clang-cpu-only | linux-gcc)")
+# The upstream preset enables Snippet demo binaries (OpenGL at link time) and
+# OmniPVD runtime, but taiga_x only needs SDK static libraries and snippet
+# sources. Disable both by default so headless CI can build physx_vendor.
+set(PHYSX_VENDOR_BUILD_SNIPPETS OFF
+    CACHE BOOL "Build PhysX Snippet demo executables (requires OpenGL at link time)")
+set(PHYSX_VENDOR_BUILD_PVD_RUNTIME OFF
+    CACHE BOOL "Build PhysX OmniPVD runtime (not needed for taiga_x vehicle model)")
 
 # Build PhysX from source via its own generate_projects.sh. This downloads
 # packman dependencies (requires network access) and compiles the SDK.
@@ -41,7 +48,8 @@ externalproject_add(physx-ext
   TIMEOUT 18000
   BUILD_IN_SOURCE 0
   # PhysX generates per-config CMake build trees under physx/compiler/.
-  CONFIGURE_COMMAND bash -c "cd '${_physx_root}' && ./generate_projects.sh ${PHYSX_VENDOR_PRESET}"
+  # Re-run cmake after generate_projects.sh to turn off Snippets/PVDRuntime.
+  CONFIGURE_COMMAND bash -c "cd '${_physx_root}' && ./generate_projects.sh ${PHYSX_VENDOR_PRESET} && cmake '${_physx_build}' -DPX_BUILDSNIPPETS=${PHYSX_VENDOR_BUILD_SNIPPETS} -DPX_BUILDPVDRUNTIME=${PHYSX_VENDOR_BUILD_PVD_RUNTIME}"
   BUILD_COMMAND ${CMAKE_COMMAND} --build "${_physx_build}" --config release --parallel
   # The source/build tree persists; the install(DIRECTORY) rules below copy the
   # SDK subtree directly (no intermediate staging step).

--- a/external/physx_vendor/README.md
+++ b/external/physx_vendor/README.md
@@ -38,6 +38,8 @@ Relevant CMake cache variables (override with `--cmake-args -D...`):
 | `PHYSX_VENDOR_GIT_TAG` | `107.3-physx-5.6.1` | upstream commit/tag to build |
 | `PHYSX_VENDOR_PRESET` | `linux-gcc-cpu-only` | `generate_projects.sh` preset. CPU-only + gcc by default (no CUDA toolkit needed); the `taiga_x` vehicle solver runs on CPU. Use `linux-gcc` / `linux-clang` for the GPU build. |
 | `PHYSX_VENDOR_GIT_REPOSITORY` | NVIDIA-Omniverse/PhysX | source repository |
+| `PHYSX_VENDOR_BUILD_SNIPPETS` | `OFF` | Build Snippet demo executables (requires OpenGL; keep OFF for headless CI) |
+| `PHYSX_VENDOR_BUILD_PVD_RUNTIME` | `OFF` | Build OmniPVD runtime (not needed for `taiga_x`) |
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Disable `PX_BUILDSNIPPETS` and `PX_BUILDPVDRUNTIME` after PhysX `generate_projects.sh` so `physx_vendor` builds only SDK static libraries in headless CI
- Add `PHYSX_VENDOR_BUILD_SNIPPETS` / `PHYSX_VENDOR_BUILD_PVD_RUNTIME` CMake cache options (default OFF)
- Document the new options in README

## Background
`physx_vendor` failed in pilot-auto.x2 CI (v4.4-jazzy) when linking PhysX Snippet demo binaries against packman's `libGL.so`, because system OpenGL libraries (`libglapi.so.0`, `libxcb-dri2.so.0`) are not available in headless containers.

`taiga_x` only needs PhysX static libraries and snippet **source** files; Snippet demo executables are not used at runtime.

## Test plan
- [ ] `colcon build --packages-select physx_vendor` succeeds in headless CI
- [ ] `colcon build --packages-up-to simple_sensor_simulator` succeeds
- [ ] `taiga_x` vehicle model still links against required static libs