### PR TITLE
feat(ego_entity): use alternative

### DIFF
--- a/simulation/traffic_simulator/src/entity/ego_entity.cpp
+++ b/simulation/traffic_simulator/src/entity/ego_entity.cpp
@@ -21,12 +21,14 @@
 #include <string>
 #include <system_error>
 #include <thread>
+#include <traffic_simulator/data_type/lane_change.hpp>
 #include <traffic_simulator/entity/ego_entity.hpp>
 #include <traffic_simulator/utils/pose.hpp>
 #include <traffic_simulator/utils/route.hpp>
 #include <traffic_simulator_msgs/msg/waypoints_array.hpp>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -258,13 +260,12 @@ void EgoEntity::requestAssignRoute(
     assert(not route.empty());
 
     auto goal = static_cast<geometry_msgs::msg::Pose>(route.back());
+    using autoware_adapi_v1_msgs::msg::RoutePrimitive;
     using autoware_adapi_v1_msgs::msg::RouteSegment;
     auto make_segment = [](const int64_t id) {
       RouteSegment segment;
       segment.preferred.id = id;
       segment.preferred.type = "lane";
-      // NOTE: If traffic_simulator supports to the overlap of lanelet pose,
-      //       the second and subsequent lanelet pose are packed into segment.alternatives.
       return segment;
     };
 
@@ -295,6 +296,66 @@ void EgoEntity::requestAssignRoute(
           return a.preferred.id == b.preferred.id;
         }),
       route_segments.end());
+
+    // Pack source-lane neighbors into alternatives only after a lane-change transition.
+    // Policy:
+    //   - before LC: preferred only (single lane)
+    //   - after LC: keep the previous lane as alternatives until the boundary is no longer
+    //     changeable (e.g. solid), so LC / cancel still have enough route length.
+    // Each lanelet ID may appear only once across all segments (isRouteLooped rejects duplicates).
+    std::unordered_set<int64_t> used_lanelet_ids;
+    used_lanelet_ids.reserve(route_segments.size());
+    for (const auto & segment : route_segments) {
+      used_lanelet_ids.insert(segment.preferred.id);
+    }
+
+    const auto routing_graph_type = routing_configuration.routing_graph_type;
+    const auto is_lateral_neighbor =
+      [this, routing_graph_type](
+        const int64_t from_id, const int64_t to_id,
+        traffic_simulator::lane_change::Direction direction) {
+        const auto neighbor_id =
+          hdmap_utils_ptr_->getLaneChangeableLaneletId(from_id, direction, routing_graph_type);
+        return neighbor_id && *neighbor_id == to_id;
+      };
+
+    auto append_alternative_if_unused =
+      [&used_lanelet_ids](RouteSegment & segment, const int64_t id) {
+        if (!used_lanelet_ids.insert(id).second) {
+          return false;
+        }
+        RoutePrimitive alternative;
+        alternative.id = id;
+        alternative.type = "lane";
+        segment.alternatives.push_back(alternative);
+        return true;
+      };
+
+    for (std::size_t i = 0; i + 1 < route_segments.size(); ++i) {
+      const auto from_id = route_segments[i].preferred.id;
+      const auto to_id = route_segments[i + 1].preferred.id;
+
+      std::optional<traffic_simulator::lane_change::Direction> source_side;
+      if (is_lateral_neighbor(from_id, to_id, traffic_simulator::lane_change::Direction::LEFT)) {
+        // Preferred jumped to the left lane; keep the previous (right) lane as alternatives.
+        source_side = traffic_simulator::lane_change::Direction::RIGHT;
+      } else if (is_lateral_neighbor(
+                   from_id, to_id, traffic_simulator::lane_change::Direction::RIGHT)) {
+        source_side = traffic_simulator::lane_change::Direction::LEFT;
+      }
+      if (!source_side) {
+        continue;
+      }
+
+      for (std::size_t j = i + 1; j < route_segments.size(); ++j) {
+        const auto neighbor_id = hdmap_utils_ptr_->getLaneChangeableLaneletId(
+          route_segments[j].preferred.id, *source_side, routing_graph_type);
+        if (!neighbor_id) {
+          break;  // no more changeable neighbor on the source side
+        }
+        append_alternative_if_unused(route_segments[j], *neighbor_id);
+      }
+    }
 
     requestClearRoute();
 


### PR DESCRIPTION
# Description

<!-- Please check examples and comment out this sentence. Minimal example is [here](pull_request_samples/example_simple.md) and detailed example is [here](pull_request_samples/example_detail.md) -->

## Abstract

Fixed bag:
- Fixed an issue where lane changes were not possible when `RoutingAction__use_lane_ids_for_routing` was set to True

## Details

This PR packs source-lane neighbors into `alternatives` after a preferred lateral jump, so Autoware keeps enough current-lane length for lane change.

| Before fix | After fix |
| --- | --- |
| `RouteSegment` has **preferred only** (`alternatives` empty). When preferred jumps to the adjacent lane, the source lane ahead is not in the route, so current lanes are truncated at the LC point and the LC path cannot be generated (insufficient LC distance → stop). | After each preferred lateral jump, add source-side neighbors to **alternatives** (unique IDs; stop when not lane-changeable). Before LC: preferred only. After LC: preferred on the target lane + alternatives on the source lane → enough length for LC / cancel. |
| <img width="1280" height="720" alt="pr_lc_before" src="https://github.com/user-attachments/assets/ec04d250-aba8-4b96-9576-932cd0945d16" /> |  <img width="1280" height="720" alt="pr_lc_after" src="https://github.com/user-attachments/assets/1b9a7656-50a5-497d-ae78-949054979fcb" /> |
